### PR TITLE
Fix #46 Paper order within a volume is broken

### DIFF
--- a/library/Ccsd/Search/Solr/Indexer/Episciences.php
+++ b/library/Ccsd/Search/Solr/Indexer/Episciences.php
@@ -38,45 +38,10 @@ class Ccsd_Search_Solr_Indexer_Episciences extends Ccsd_Search_Solr_Indexer
      * @param int $docId
      * @param Document $ndx
      * @return bool|mixed
-     * @throws Zend_Date_Exception
      * @throws Zend_Db_Statement_Exception
      */
     protected function addMetadataToDoc(int $docId, Document $ndx)
     {
-
-        /*
-        'submitter'			=>	array(
-                'uid' 		=>	$submitter->getUid(),
-                'firstname'	=>	$submitter->getFirstname(),
-                'lastname'	=>	$submitter->getLastname(),
-                'mail'		=>	$submitter->getEmail()),
-                'version'			=>	$this->getVersion(),
-                'submission_date'	=>	$this->getSubmission_date(),
-                'publication_date'	=>	$this->getPublication_date(),
-                'title'				=>	$this->getTitle(),
-                'description'		=>	$this->getMetadata('description'),
-                'authors'			=>	$this->getMetadata('authors'),
-                'subjects'			=>	$this->getMetadata('subjects'),
-                'pdf_url'			=>	APPLICATION_URL.'/'.$this->getDocid().'/pdf',
-                'doc_url'			=>	APPLICATION_URL.'/'.$this->getDocid(),
-                'citation'			=>	$this->getCitation(),
-                'review_issn'		=>	$review->getSetting('ISSN'),
-                'review_title'		=>	$review->getName(),
-                'volume_name'		=>	$volume_name,
-                'section_name'		=>	$section_name,
-        */
-
-        // TODO : Ajouter dans le schéma :
-
-        // submitter_uid_i
-        // submitter_firstname_s
-        // submitter_lastname_s
-        // submitter_email_s
-        // keywords
-        // citation
-        // es_doc_url_s
-        // es_doc_url_t
-        // revue_issn_s
 
         // Suffixes (conventions)
         // _t : text (correspondance approximative : insensible à la casse, aux accents)
@@ -150,6 +115,7 @@ class Ccsd_Search_Solr_Indexer_Episciences extends Ccsd_Search_Solr_Indexer
 
         $dataToIndex = [
             'docid' => $docId,
+            'paperid' => $paperData['PAPERID'],
             'language_s' => Ccsd_Tools::xpath($paperData['RECORD'], '//dc:language'),
             'identifier_s' => $paperData['IDENTIFIER'],
             'version_td' => $paperData['VERSION'],

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -319,6 +319,8 @@ class Episciences_Volume
 
         $result = Episciences_Tools::solrCurl($query, 'episciences', 'select', true);
         $result = unserialize($result, ['allowed_classes' => false]);
+
+
         if ($result && array_key_exists('response', $result)) {
 
             $positions = $this->getPaperPositions();
@@ -330,8 +332,8 @@ class Episciences_Volume
             if (is_array($positions) && !empty($positions)) {
                 $positions = array_flip($positions);
                 foreach ($papers as $paper) {
-                    if (array_key_exists($paper['docid'], $positions)) {
-                        $sorted_papers[$positions[$paper['docid']]] = $paper;
+                    if (array_key_exists($paper['paperid'], $positions)) {
+                        $sorted_papers[$positions[$paper['paperid']]] = $paper;
                     } else {
                         $unsorted_papers[] = $paper;
                     }

--- a/src/solr/schema.xml
+++ b/src/solr/schema.xml
@@ -325,6 +325,9 @@
 		<field name="docid" type="int" indexed="true" stored="true" multiValued="false" required="true"/>
 		<!-- Identifiant unique de chaque document ======================================================= -->
 
+		<!-- Permanent id across all document versions ; links to multiple docids -->
+		<field name="paperid" type="int" indexed="true" stored="true" multiValued="false" />
+
 		<!-- Identifiant du document au sein de l'archive dont il est issu ======================================================= -->
 		<field name="identifier_s" type="string" indexed="true" stored="true" multiValued="false" required="true"/>
 		<!-- Identifiant du document au sein de l'archive dont il est issu ======================================================= -->


### PR DESCRIPTION
Some time ago we started using paperids to sort papers positions because it is consistent across all document versions, previously we were using docids which are different for each version of a document.
But we forgot to update the way papers are sorted for public displays of volumes and were still using a docid.

Fix: Added indexing of paperid ; new solr schema field paperid
The new fields allows to sort papers correctly with public display of volumes, i.e. according to the paperid
