### PR TITLE
Fix bug: TinyMCE is removing elements like <script>:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Security
 -->
-
+## Unreleased
+Fix bug: TinyMCE is removing elements like <script>:
+- Enable TinyMCE 'FullPage' plugin (Fullpage exposes <head>, <body> and various meta tags in source code view)
 
 ## 1.0.14 - 2021-07-28
 ### Fixed

--- a/application/modules/common/views/scripts/page/render.phtml
+++ b/application/modules/common/views/scripts/page/render.phtml
@@ -24,7 +24,7 @@ if ($this->mode === 'edit') {
         __initMCE('textarea:last', undefined, {
             convert_urls: false,
             theme: "modern",
-            plugins: "textcolor link image code fullscreen table visualblocks paste",
+            plugins: "textcolor link image code fullscreen table visualblocks paste fullpage",
             toolbar1: "bold italic underline strikethrough | forecolor backcolor | alignleft aligncenter alignright alignjustify | bullist numlist | link image | table | styleselect | removeformat visualblocks | code",
             menubar: false,
             <?php if ($locale === 'fr') : ?>


### PR DESCRIPTION
- Enable TinyMCE 'FullPage' plugin:
  Fullpage exposes <head>, <body> and various meta tags in source code view.