### PR TITLE
- Switch to paperIds as Episciences public PIDs for export formats and OAI-PMH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## Unreleased
+### Fixed
+- Fixed issue: [64](https://github.com/CCSDForge/episciences/issues/64): Layout of mails with reviewers' comments
+ 
 ### Changed
+- Improvements for displaying when a document has been imported. E.g. for journals coming to the platform with previous content 
 - Switch to paperIds as Episciences public PIDs for export formats and OAI-PMH. The switch from the docIds to paperIds was incomplete. One unique paperId is assigned to each version of a document. Each version of a document has a different unique docid.
 
 ## 1.0.15.1 - 2021-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## Unreleased
+### Changed
+- Switch to paperIds as Episciences public PIDs for export formats and OAI-PMH. The switch from the docIds to paperIds was incomplete. One unique paperId is assigned to each version of a document. Each version of a document has a different unique docid.
+
 ## 1.0.15.1 - 2021-08-31
 ### Fixed
 - Fixed issue: [62](https://github.com/CCSDForge/episciences/issues/62): String not localized

--- a/application/modules/journal/views/scripts/export/datacite.phtml
+++ b/application/modules/journal/views/scripts/export/datacite.phtml
@@ -46,7 +46,7 @@ $schemInfo = ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http
     <?php if($this->doi != ''): ?>
         <identifier identifierType="DOI"><?php echo htmlentities($this->doi, ENT_XML1); ?></identifier>
     <?php else: ?>
-        <identifier identifierType="URL"><?php echo $journalUrl . '/' . $paper->getDocid(); ?></identifier>
+        <identifier identifierType="URL"><?php echo $journalUrl . '/' . $paper->getPaperid(); ?></identifier>
     <?php endif;?>
 
 
@@ -132,7 +132,7 @@ $schemInfo = ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http
 
     <?php if($this->doi != ''): ?>
     <alternateIdentifiers>
-        <alternateIdentifier alternateIdentifierType="URL"><?php echo $journalUrl . '/' . $paper->getDocid(); ?></alternateIdentifier>
+        <alternateIdentifier alternateIdentifierType="URL"><?php echo $journalUrl . '/' . $paper->getPaperid(); ?></alternateIdentifier>
     </alternateIdentifiers>
     <?php endif; ?>
 

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1801,7 +1801,7 @@ class Episciences_Paper
     public function getOaiHeader(): string
     {
         $cache = new FilesystemAdapter(self::CACHE_CLASS_NAMESPACE, 0, CACHE_PATH_METADATA);
-        $cacheName = $this->getDocid() . '-' . __FUNCTION__;
+        $cacheName = $this->getPaperid() . '-' . __FUNCTION__;
         $oaiHeaderItem = $cache->getItem($cacheName);
         $oaiHeaderItem->expiresAfter(self::CACHE_EXPIRE_OAI_HEADER);
 
@@ -1836,7 +1836,7 @@ class Episciences_Paper
      */
     public function getOaiIdentifier(): string
     {
-        return 'oai:' . DOMAIN . ':' . Episciences_Review::getData($this->getRvid())['CODE'] . ':' . $this->getDocid();
+        return 'oai:' . DOMAIN . ':' . Episciences_Review::getData($this->getRvid())['CODE'] . ':' . $this->getPaperid();
     }
 
     /**
@@ -1855,7 +1855,7 @@ class Episciences_Paper
         }
 
         $cache = new FilesystemAdapter(self::CACHE_CLASS_NAMESPACE, 0, CACHE_PATH_METADATA);
-        $cacheName = $this->getDocid() . '-' . $method;
+        $cacheName = $this->getPaperid() . '-' . $method;
         $metadataCache = $cache->getItem($cacheName);
 
         if ($this->isPublished()) {
@@ -3530,7 +3530,7 @@ class Episciences_Paper
             }
         }
 
-        $citation = $review->getCode() . ':' . $this->getDocid() . ' - ' . $review->getName() . ', ';
+        $citation = $review->getCode() . ':' . $this->getPaperid() . ' - ' . $review->getName() . ', ';
         $citation .= date('Y-m-d', strtotime($this->getPublication_date()));
         if ($this->getVid()) {
             $volume = Episciences_VolumesManager::find($this->getVid());

--- a/library/Episciences/Paper/Tei.php
+++ b/library/Episciences/Paper/Tei.php
@@ -341,7 +341,7 @@ class Episciences_Paper_Tei
         $ref = $xml->createElement('ref');
         $ref->setAttribute('type', 'file');
 
-        $ref->setAttribute('target', $this->getReview()->getUrl() . '/' . $this->getPaper()->getDocid() . '/pdf');
+        $ref->setAttribute('target', $this->getReview()->getUrl() . '/' . $this->getPaper()->getPaperid() . '/pdf');
         $edition->appendChild($ref);
         $es->appendChild($edition);
 
@@ -370,11 +370,11 @@ class Episciences_Paper_Tei
         $ps = $xml->createElement('publicationStmt');
         $ps->appendChild($xml->createElement('distributor', 'CCSD'));
 
-        $id = $xml->createElement('idno', $this->getReview()->getCode() . ':' . $this->getPaper()->getDocid());
+        $id = $xml->createElement('idno', $this->getReview()->getCode() . ':' . $this->getPaper()->getPaperid());
         $id->setAttribute('type', 'id');
         $ps->appendChild($id);
 
-        $id = $xml->createElement('idno', $this->getReview()->getUrl() . '/' . $this->getPaper()->getDocid());
+        $id = $xml->createElement('idno', $this->getReview()->getUrl() . '/' . $this->getPaper()->getPaperid());
         $id->setAttribute('type', 'url');
         $ps->appendChild($id);
 


### PR DESCRIPTION
Switch to paperIds as Episciences public PIDs for export formats and OAI-PMH. The switch from the docIds to paperIds was incomplete. One unique paperId is assigned to each version of a document. Each version of a document has a different unique docid.
