### PR TITLE
Fix bug: "obsolete invitations" on the paper management page are not …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Fixed issue: [77](https://github.com/CCSDForge/episciences/issues/77): It is not possible for the reviewer to intervene in the copy editing process if this one has already been started
+- Fixed bug: "obsolete invitations" on the paper management page are not labeled (when a paper is obsolete, reviewers are disabled) 
 ### Added
 - Add new document metadata: acceptance date
 

--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -1648,6 +1648,7 @@ return [
     "rapports de relecture supplémentaires" => "additional ratings reports",
     "rapport de relecture supplémentaire" => "additional rating report",
     "Vous êtes sur le point de supprimer un rapport de relecture." => "You are about to delete a rating report.",
+    "Lorsqu'un article est obsolète, les relecteurs sont désactivés" => 'When a paper is obsolete, reviewers are disabled',
 
     "Relire les articles" => 'Rate articles',
     "Vous n'avez rien à relire pour le moment." => "You haven't any article to review yet.",

--- a/application/modules/journal/views/scripts/partials/paper_reviewers.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_reviewers.phtml
@@ -60,7 +60,7 @@ $ratings = $paper->getRatings();
                         continue;
                     } ?>
                     <div class="panel panel-warning">
-                        <div class="panel-heading" data-target="#<?php echo $status; ?>-invitations"
+                        <div class="panel-heading" data-target="#<?= $status ?>-invitations"
                              data-toggle="collapse" data-parent="#invitations">
                             <h4 class="panel-title">
                                 <?php
@@ -84,9 +84,17 @@ $ratings = $paper->getRatings();
                                     case Episciences_Reviewer::STATUS_UNINVITED:
                                         $title .= (count($invitations) > 1) ? $this->translate('rapports de relecture supplémentaires') : $this->translate('rapport de relecture supplémentaire');
                                         break;
+                                    case Episciences_Reviewer::STATUS_INACTIVE: // when a paper is obsolete, reviewers are disabled
+                                        $title .= (count($invitations) > 1) ? $this->translate('invitations obsolètes') : $this->translate('invitation obsolète');
+                                        $title .= '&nbsp';
+                                        $title .= '<i data-toggle="tooltip" title="';
+                                        $title.= $this->translate("Lorsqu'un article est obsolète, les relecteurs sont désactivés") .'" class="fas fa-info-circle pull-right"></i>';
+                                        break;
+                                    default:
+                                        $title .= 'Undefined invitation status';
                                 }
                                 ?>
-                                <?php echo $title; ?>
+                                <?= $title ?>
                             </h4>
                         </div>
                         <div id="<?php echo $status ?>-invitations"

--- a/library/Episciences/Reviewer.php
+++ b/library/Episciences/Reviewer.php
@@ -5,12 +5,13 @@
  */
 class Episciences_Reviewer extends Episciences_User
 {
-    const STATUS_PENDING = 'pending';
-    const STATUS_ACTIVE = 'active';
-    const STATUS_DECLINED = 'declined';
-    const STATUS_CANCELLED = 'cancelled';
-    const STATUS_EXPIRED = 'expired';
-    const STATUS_UNINVITED = 'uninvited';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_DECLINED = 'declined';
+    public const STATUS_CANCELLED = 'cancelled';
+    public const STATUS_EXPIRED = 'expired';
+    public const STATUS_UNINVITED = 'uninvited';
+    public const STATUS_INACTIVE = 'inactive';
 
     protected $_when;
     protected $_status;


### PR DESCRIPTION
…labeled (when a paper is obsolete, reviewers are disabled)