### PR TITLE
Fixed: "Cancel" and "Submit" buttons when selecting the details of an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Security
 -->
+## Unreleased
+Fixed: "Cancel" and "Submit" buttons when selecting the details of an item in an article's history: [106](https://github.com/CCSDForge/episciences/issues/106): replaced by a single "Close" button
 
 ## 1.0.21 - 2021-11-03
 ### Added

--- a/application/modules/journal/views/scripts/partials/modal.phtml
+++ b/application/modules/journal/views/scripts/partials/modal.phtml
@@ -36,7 +36,7 @@
             <div class="modal-footer">
                 <?php if ($this->buttons !== false) : ?>
                     <button type="button" class="btn btn-default"
-                            data-dismiss="modal"><?php echo $this->translate('Annuler'); ?></button>
+                            data-dismiss="modal"><?php echo $this->translate('Fermer'); ?></button>
                     <?php if (!$this->hideSubmit) : ?>
                         <button type="button" class="btn btn-primary"
                                 id="submit-modal"><?php echo $this->translate('Valider'); ?></button>

--- a/application/modules/journal/views/scripts/partials/paper_history_logs.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_history_logs.phtml
@@ -30,10 +30,8 @@ $logs_with_details = [
 <?php foreach ($this->logs as $log) : ?>
 
     <?php if (in_array($log['ACTION'], $logs_with_details, false)) : ?>
-        <a    class="modal-opener"
-        href="/administratepaper/log?id=<?php echo $log['LOGID'] ?>"
-        data-width="50%"
-        title="<?php echo $this->translate($log['ACTION']) ?>">
+    <?php $logHref = '/administratepaper/log?id=' . $log['LOGID']; ?>
+        <a class="modal-opener" href="<?= $logHref ?>" data-width="50%" data-hidesubmit="true" title="<?= $this->translate($log['ACTION']) ?>">
     <?php endif; ?>
 
     <div

--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -522,8 +522,8 @@ function openModal(url, title, params, source) {
 
     // set css params
     if (params) {
-        for (var key in params) {
-            if ($('body').css(key) != 'undefined') {
+        for (let key in params) {
+            if ($('body').css(key) !== 'undefined') {
                 $modal_box.find('.modal-dialog').css(key, params[key]);
             }
         }
@@ -533,6 +533,8 @@ function openModal(url, title, params, source) {
     if (!modalStructureExists()) {
         return false;
     }
+
+    params.hidesubmit ? $modal_button.hide() : $modal_button.show();
 
     // run callback method (if there is one)
     if (params['callback']) {
@@ -603,8 +605,6 @@ function openModal(url, title, params, source) {
     $('#myModal').on('hidden.bs.modal', function () {
         // do something…
     })
-
-    return;
 }
 
 function resizeModal(width, height) {


### PR DESCRIPTION
… item in an article's history [#106]: replaced by a single "Close" button