### PR TITLE
#693_corriger the bug for adding the formatted version

### DIFF
--- a/application/modules/journal/controllers/PaperController.php
+++ b/application/modules/journal/controllers/PaperController.php
@@ -775,6 +775,7 @@ class PaperController extends PaperDefaultController
         /** @var Zend_Controller_Request_Http $request */
         $request = $this->getRequest();
         $attachments = $request->getPost(Episciences_Mail_Send::ATTACHMENTS); // see js/library/es.fileupload.js
+        $attachments = is_array($attachments) ? $attachments : [];
 
         $templateAuthorType = '';
         $templateEditorType = '';


### PR DESCRIPTION
le problème survient lorsque l’auteur écrit uniquement un commentaire sans joindre de fichier. Dans ce cas, le système s’attend à recevoir une liste de fichiers joints (un array), mais reçoit null, ce qui provoque une erreur.