### PR TITLE
#702_Supprime le suffixe de version des identifiants arXiv

### DIFF
--- a/public/js/submit/index.js
+++ b/public/js/submit/index.js
@@ -97,6 +97,7 @@ $(document).ready(function () {
       } else {
         identifier = urlSearch.replace("?persistentId=", "");
       }
+
       return removeVersionFromIdentifier(identifier);
     } catch (error) {
       return input;


### PR DESCRIPTION
Problème : Duplication de version dans les identifiants arXiv lors de la soumission de documents.
Solution: Modifier /js/submit/index.js