### PR TITLE
Refactor: eliminate PHP 8.1+ deprecation warnings in Paper::isImported()

### DIFF
--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -4515,25 +4515,127 @@ class Episciences_Paper
     }
 
     /**
-     * @return bool
+     * Safely parse a date string to DateTime object
+     *
+     * @param string|null $date Date string in 'Y-m-d H:i:s' format
+     * @return DateTime|null DateTime object or null if parsing fails or input is null
+     */
+    private function parseDateSafely(?string $date): ?DateTime
+    {
+        if ($date === null || $date === '') {
+            return null;
+        }
+
+        try {
+            $dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $date);
+            if ($dateTime === false) {
+                // Try alternative format without time
+                $dateTime = DateTime::createFromFormat('Y-m-d', $date);
+            }
+            return $dateTime !== false ? $dateTime : null;
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Check if paper is explicitly marked as imported via flag
+     *
+     * @return bool True if flag is 'imported'
+     */
+    private function isExplicitlyImported(): bool
+    {
+        return $this->getFlag() === 'imported';
+    }
+
+    /**
+     * Check if publication date is before or equal to submission date (data inconsistency)
+     *
+     * @return bool True if publication_date <= submission_date
+     */
+    private function isPublicationBeforeSubmission(): bool
+    {
+        $publicationDate = $this->parseDateSafely($this->getPublication_date());
+        $submissionDate = $this->parseDateSafely($this->getSubmission_date());
+
+        if ($publicationDate === null || $submissionDate === null) {
+            return false;
+        }
+
+        return $publicationDate <= $submissionDate;
+    }
+
+    /**
+     * Check if submission or publication year is before 2013 (legacy data)
+     *
+     * @return bool True if either date is before 2013
+     */
+    private function isBeforeYear2013(): bool
+    {
+        $publicationDate = $this->parseDateSafely($this->getPublication_date());
+        $submissionDate = $this->parseDateSafely($this->getSubmission_date());
+
+        if ($submissionDate !== null && (int)$submissionDate->format('Y') < 2013) {
+            return true;
+        }
+
+        if ($publicationDate !== null && (int)$publicationDate->format('Y') < 2013) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check for date inconsistencies with the paper creation date (WHEN) for published papers
+     *
+     * @return bool True if published paper has date inconsistencies
+     */
+    private function hasDateInconsistencies(): bool
+    {
+        if ($this->getStatus() !== self::STATUS_PUBLISHED) {
+            return false;
+        }
+
+        $whenDate = $this->parseDateSafely($this->getWhen());
+        if ($whenDate === null) {
+            return false;
+        }
+
+        $submissionDate = $this->parseDateSafely($this->getSubmission_date());
+        $publicationDate = $this->parseDateSafely($this->getPublication_date());
+
+        // Submission date after creation date (inconsistent)
+        if ($submissionDate !== null && $submissionDate > $whenDate) {
+            return true;
+        }
+
+        // Publication date before creation date (inconsistent)
+        if ($publicationDate !== null && $publicationDate < $whenDate) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determine if this paper was imported from another system
+     *
+     * A paper is considered imported if:
+     * 1. It has the 'imported' flag explicitly set, OR
+     * 2. It exhibits data inconsistencies characteristic of imported legacy data:
+     *    - Publication date is before or equal to submission date
+     *    - Either date is from before 2013 (legacy data era)
+     *    - For published papers: dates are inconsistent with the paper creation date
+     *
+     * @return bool True if paper is imported
      */
     public function isImported(): bool
     {
-
-        return ($this->getFlag() === 'imported' ||
-
-            (
-                date('Y-m-d', strtotime($this->getPublication_date())) <= date('Y-m-d', strtotime($this->getSubmission_date()))
-                || (int)date('Y', strtotime($this->getSubmission_date())) < 2013
-                || (int)date('Y-m-d', strtotime($this->getPublication_date())) < 2013
-                || (
-                    (
-                        date('Y-m-d', strtotime($this->getSubmission_date())) > date('Y-m-d', strtotime($this->getWhen()))
-                        || date('Y-m-d', strtotime($this->getPublication_date())) < date('Y-m-d', strtotime($this->getWhen()))
-                    )
-                    and $this->getStatus() === self::STATUS_PUBLISHED
-                )
-            ));
+        return $this->isExplicitlyImported()
+            || $this->isPublicationBeforeSubmission()
+            || $this->isBeforeYear2013()
+            || $this->hasDateInconsistencies();
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_IsImportedTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_IsImportedTest.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace unit\library\Episciences\paper;
+
+use Episciences_Paper;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Test suite for Episciences_Paper::isImported() method and its private helpers
+ */
+final class Episciences_Paper_IsImportedTest extends TestCase
+{
+    /**
+     * Test isImported returns true when flag is explicitly 'imported'
+     */
+    public function testIsImportedWithExplicitFlag(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('imported');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-10 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_PUBLISHED);
+
+        self::assertTrue($paper->isImported(), 'Paper with imported flag should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when publication date is before submission date
+     */
+    public function testIsImportedWithPublicationBeforeSubmission(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-05-01 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-06-15 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        self::assertTrue($paper->isImported(), 'Paper with publication before submission should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when publication date equals submission date
+     */
+    public function testIsImportedWithPublicationEqualsSubmission(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-05-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-15 10:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        self::assertTrue($paper->isImported(), 'Paper with publication equal to submission should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when submission year is before 2013
+     */
+    public function testIsImportedWithSubmissionBefore2013(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2012-12-31 09:00:00');
+        $paper->method('getWhen')->willReturn('2012-12-31 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        self::assertTrue($paper->isImported(), 'Paper with submission date before 2013 should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when publication year is before 2013
+     */
+    public function testIsImportedWithPublicationBefore2013(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2012-05-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-10 09:00:00');
+        $paper->method('getWhen')->willReturn('2012-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        self::assertTrue($paper->isImported(), 'Paper with publication date before 2013 should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when published paper has submission after WHEN
+     */
+    public function testIsImportedWithSubmissionAfterWhenForPublished(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-20 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_PUBLISHED);
+
+        self::assertTrue($paper->isImported(), 'Published paper with submission after WHEN should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns true when published paper has publication before WHEN
+     */
+    public function testIsImportedWithPublicationBeforeWhenForPublished(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-05-01 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-05 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_PUBLISHED);
+
+        self::assertTrue($paper->isImported(), 'Published paper with publication before WHEN should be detected as imported');
+    }
+
+    /**
+     * Test isImported returns false with valid dates and no import criteria
+     */
+    public function testIsImportedWithValidDatesNotImported(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-10 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00'); // WHEN same day as submission
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED); // Not published to avoid date inconsistency check
+
+        self::assertFalse($paper->isImported(), 'Paper with valid consistent dates should not be detected as imported');
+    }
+
+    /**
+     * Test isImported handles null publication date gracefully
+     */
+    public function testIsImportedWithNullPublicationDate(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn(null);
+        $paper->method('getSubmission_date')->willReturn('2023-05-10 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-09 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        // Should not throw error and should return false (no criteria met)
+        self::assertFalse($paper->isImported(), 'Paper with null publication date should not cause error');
+    }
+
+    /**
+     * Test isImported handles null submission date gracefully
+     */
+    public function testIsImportedWithNullSubmissionDate(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn(null);
+        $paper->method('getWhen')->willReturn('2023-05-09 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        // Should not throw error and should return false (no criteria met)
+        self::assertFalse($paper->isImported(), 'Paper with null submission date should not cause error');
+    }
+
+    /**
+     * Test isImported handles null WHEN date gracefully
+     */
+    public function testIsImportedWithNullWhenDate(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-06-15 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-10 09:00:00');
+        $paper->method('getWhen')->willReturn(null);
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_PUBLISHED);
+
+        // Should not throw error and should return false (no criteria met)
+        self::assertFalse($paper->isImported(), 'Paper with null WHEN date should not cause error');
+    }
+
+    /**
+     * Test isImported with all null dates
+     */
+    public function testIsImportedWithAllNullDates(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn(null);
+        $paper->method('getSubmission_date')->willReturn(null);
+        $paper->method('getWhen')->willReturn(null);
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        // Should not throw error and should return false (no criteria met)
+        self::assertFalse($paper->isImported(), 'Paper with all null dates should not cause error');
+    }
+
+    /**
+     * Test parseDateSafely with valid date
+     */
+    public function testParseDateSafelyWithValidDate(): void
+    {
+        $paper = new Episciences_Paper();
+        $method = $this->getPrivateMethod('parseDateSafely');
+
+        $result = $method->invoke($paper, '2023-05-15 10:30:45');
+
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEquals('2023-05-15 10:30:45', $result->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * Test parseDateSafely with null value
+     */
+    public function testParseDateSafelyWithNull(): void
+    {
+        $paper = new Episciences_Paper();
+        $method = $this->getPrivateMethod('parseDateSafely');
+
+        $result = $method->invoke($paper, null);
+
+        self::assertNull($result, 'parseDateSafely should return null for null input');
+    }
+
+    /**
+     * Test parseDateSafely with empty string
+     */
+    public function testParseDateSafelyWithEmptyString(): void
+    {
+        $paper = new Episciences_Paper();
+        $method = $this->getPrivateMethod('parseDateSafely');
+
+        $result = $method->invoke($paper, '');
+
+        self::assertNull($result, 'parseDateSafely should return null for empty string');
+    }
+
+    /**
+     * Test parseDateSafely with invalid date format
+     */
+    public function testParseDateSafelyWithInvalidFormat(): void
+    {
+        $paper = new Episciences_Paper();
+        $method = $this->getPrivateMethod('parseDateSafely');
+
+        $result = $method->invoke($paper, 'not-a-date');
+
+        self::assertNull($result, 'parseDateSafely should return null for invalid date format');
+    }
+
+    /**
+     * Test isImported does not detect date inconsistencies for non-published papers
+     */
+    public function testIsImportedIgnoresDateInconsistenciesForNonPublished(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, [
+            'getFlag',
+            'getPublication_date',
+            'getSubmission_date',
+            'getWhen',
+            'getStatus'
+        ]);
+
+        $paper->method('getFlag')->willReturn('submitted');
+        $paper->method('getPublication_date')->willReturn('2023-05-01 10:00:00');
+        $paper->method('getSubmission_date')->willReturn('2023-05-20 09:00:00');
+        $paper->method('getWhen')->willReturn('2023-05-10 08:00:00');
+        $paper->method('getStatus')->willReturn(Episciences_Paper::STATUS_SUBMITTED);
+
+        // Date inconsistencies should only apply to published papers
+        // In this case, publication is before submission which should trigger import
+        self::assertTrue($paper->isImported(), 'Paper with publication before submission should be imported regardless of status');
+    }
+
+    /**
+     * Helper method to access private methods for testing
+     *
+     * @param string $methodName
+     * @return ReflectionMethod
+     */
+    private function getPrivateMethod(string $methodName): ReflectionMethod
+    {
+        $reflection = new \ReflectionClass(Episciences_Paper::class);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method;
+    }
+}


### PR DESCRIPTION
Replace unsafe strtotime() calls with DateTime parsing to prevent deprecation warnings when null values are passed Extract import detection logic into testable private helper methods for improved maintainability and add comprehensive unit tests