### PR TITLE
- Fixed Paper Metrics based on wrong DocId, it gave null metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#646](https://github.com/CCSDForge/episciences/issues/646) Rediriger sur la page de l'article qui vient d'être soumis au lieu de la page qui liste toutes les soumissions
 - [#780](https://github.com/CCSDForge/episciences/issues/780) Option to lock volume name when an article in it is published
 - [#147](https://github.com/CCSDForge/episciences/issues/147) Add new pages Acknowledgements (page code journal-acknowledgements)  in menu 'About'
+- Fixed Paper Metrics based on wrong DocId, it gave null metrics
+
+### Changed
+- Paper metrics Refactored; 1 query instead of 2 ; Episciences_Paper_Visits::count is deprecated
+
 ## v1.0.52 - 2025-08-28
 
 ### Fixed

--- a/application/modules/journal/controllers/PaperController.php
+++ b/application/modules/journal/controllers/PaperController.php
@@ -190,9 +190,10 @@ class PaperController extends PaperDefaultController
         }
 
         // paper *************************************************************
+        $paperMetrics = Episciences_Paper_Visits::getPaperMetricsByPaperId($paper->getPaperid());
         $this->view->paper = $paper;
-        $this->view->page_count = Episciences_Paper_Visits::count($docId);
-        $this->view->file_count = Episciences_Paper_Visits::count($docId, 'file');
+        $this->view->page_count = $paperMetrics[Episciences_Paper_Visits::PAGE_COUNT_METRICS_NAME];
+        $this->view->file_count = $paperMetrics[Episciences_Paper_Visits::FILE_COUNT_METRICS_NAME];
 
         // other versions block
         $versions = [];

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1412,11 +1412,7 @@ class Episciences_Paper
                     'cited_by' => $citedBy,
                     'classifications' => $classifications,
                     'graphical_abstract_file' => $graphical_abstract_file,
-
-                    'metrics' => [
-                        'page_count' => !$this->isPublished() ? null : Episciences_Paper_Visits::count($this->getDocid()),
-                        'file_count' => !$this->isPublished() ? null : Episciences_Paper_Visits::count($this->getDocid(), 'file')
-                    ],
+                    'metrics' => Episciences_Paper_Visits::getPaperMetricsByPaperId($this->getPaperid()),
 
                 ],
                 'latest_version_item_number' => (int)$this->getLatestVersionId(),

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -4074,5 +4074,24 @@ class Episciences_PapersManager
         return $affectedRows;
     }
 
+    /**
+     * Get All the DocIds associated to a PaperId
+     */
+    public static function getDocIdsFromPaperId(int $paperId): array
+    {
+        $result = [];
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $select = $db
+            ->select()
+            ->from(T_PAPERS, ['DOCID'])
+            ->where('PAPERID = ?', $paperId);
+        try {
+            $query = $select->query();
+            $result = $query->fetchAll();
+        } catch (Exception $e) {
+            trigger_error($e->getMessage(), E_USER_WARNING);
+        }
+        return $result;
 
+    }
 }


### PR DESCRIPTION
- Fixed Paper Metrics based on wrong DocId, it gave null metrics
- Paper metrics Refactored: 1 query instead of 2 ; Episciences_Paper_Visits::count is deprecated
