### PR TITLE
Fixed: altered secondary volume rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New option to allow Editors to receive 'Comments for editors' before declaring a conflict of interest (disabled by default)
 
 ### Fixed
+- altered secondary volume rendering
 - [#776](https://github.com/CCSDForge/episciences/issues/776) Action Required: Fix Renovate Configuration
 - [#657](https://github.com/CCSDForge/episciences/issues/657) Conditionally remove the `<hr>` separator in the public and admin views of article metadata
 - [#786](https://github.com/CCSDForge/episciences/issues/786) English translation of 'Télécharger le fichier'

--- a/application/modules/journal/views/scripts/partials/paper_other_volumes.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_other_volumes.phtml
@@ -1,28 +1,53 @@
 <?php // Liste des volumes secondaires **********************************************
 /** @var Episciences_Paper $article */
+
+use Psr\Log\LogLevel;
+
 $article = $this->article;
+$clonedArticle = clone($article);
 /** @var Episciences_Volume[] $volumes */
 $volumes = $this->volumes;
 /** @var Episciences_Volume_Paper[] $othersVolumes */
 $othersVolumes = $article->getOtherVolumes();
 ?>
 
+
 <?php if (!empty($othersVolumes)) : ?>
-    <?php
-    $i = 0;
-    foreach ($othersVolumes as $paper_volume) {
-        $i++;
-        if ($paper_volume->getVid() == $article->getVid()) {
-            continue;
-        }
-        /** @var Episciences_Volume $volume */
-        $volume = $volumes[$paper_volume->getVid()];
-        echo Episciences_Tools::convertMarkdownToHtml($volume->getNameKey());
-        if ($i < count($othersVolumes)) {
-            echo ', ';
-        }
-    }
-    ?>
+    <ul style="list-style-type:none">
+
+        <?php
+        /** @var Episciences_Volume $secondaryVolume */
+        foreach ($othersVolumes as $secondaryVolume) :
+
+            if ($secondaryVolume->getVid() === $article->getVid()) {
+                continue;
+            }
+
+            $volume = $volumes[$secondaryVolume->getVid()];
+            $currentVid = $volume->getVid();
+            $clonedArticle->setVid($currentVid);
+
+            ?>
+
+            <li style="margin-bottom: 5px;">
+                <span class="sv-<?= $volume->getVid() ?>">
+                      <?= $volume->getNameKey() ?>
+                      <?= $this->partial('partials/paper_volume_position.phtml', [
+                          'docId' => $article->getDocid(),
+                          'vid' => $currentVid,
+                          'position' => $volume->getPositionByPaperId($clonedArticle->getPaperid(), $currentVid),
+                          'from' => Zend_Controller_Front::getInstance()->getRequest()->getActionName()
+                      ])
+                      ?>
+                </span>
+
+            </li>
+        <?php endforeach; ?>
+        <?php unset($clonedArticle); ?>
+    </ul>
+
 <?php else : ?>
-    <?php echo $this->translate('aucun'); ?>
-<?php endif; ?>
+    <?= $this->translate('aucun') ?>
+
+<?php endif ?>
+

--- a/application/modules/journal/views/scripts/partials/paper_volume_position.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_volume_position.phtml
@@ -1,9 +1,9 @@
-<?php if (null !== $this->position) : ?> <?php // first position in view => position 0 in VOLUME_PAPER_POSITION table?>
-    <span id="position_ <?= $this->docId; ?>"> , # <?= $this->position + 1; ?> &nbsp;
-        <?php if(Episciences_Auth::isSecretary()) : ?>
-            <a href="/volume/edit?id=<?= $this->vid; ?>&from=<?= $this->from !== 'view' ? $this->from : $this->from . '&docid=' . $this->docId; ?>" class="btn btn-default btn-xs" title="<?= $this->translate("Modifier"); ?>">
+<?php // first position in view => position 0 in VOLUME_PAPER_POSITION table?>
+<span id="position_ <?= $this->docId ?>"><?= sprintf(', #%s', ($this->position + 1)) ?> &nbsp;
+        <?php if (Episciences_Auth::isSecretary()) : ?>
+            <a href="/volume/edit?id=<?= $this->vid ?>&from=<?= $this->from !== 'view' ? $this->from : $this->from . '&docid=' . $this->docId ?>"
+               class="btn btn-default btn-xs" title="<?= $this->translate("Modifier") ?>">
                 <span class="glyphicon glyphicon-pencil"></span>
             </a>
         <?php endif; ?>
     </span>
-<?php endif; ?>

--- a/application/modules/journal/views/scripts/volume/form.phtml
+++ b/application/modules/journal/views/scripts/volume/form.phtml
@@ -105,7 +105,7 @@
             }
             ?>
             <div id="papers-element" class="form-group row">
-                <label class="col-md-3 control-label optional"><?= $this->translate('Articles') ?></label>
+                <label class="col-md-3 control-label optional"><?= count($this->element->getView()->paperList) . ' ' . $this->translate('articles') ?></label>
                 <div class="col-md-9" style="padding-top: 7px">
                     <div id="papers">
                         <?php foreach ($this->element->getView()->paperList as $paperOrder => $paper) : ?>

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -150,9 +150,14 @@ class Episciences_Volume
      */
     public static function findGapsInPaperOrders(array $sorted_papers): array
     {
-        $arrayOfMyDreams = range(0, count($sorted_papers) - 1);
+        $gaps = [];
         $actualArray = array_keys($sorted_papers);
-        return array_diff($arrayOfMyDreams, $actualArray);
+        for ($i = 0; $i < max($actualArray); $i++) {
+            if (!in_array($i, $actualArray, true)) {
+                $gaps[] = $i;
+            }
+        }
+        return $gaps;
     }
 
     /**
@@ -921,7 +926,7 @@ class Episciences_Volume
             }
 
             $position++;
-            
+
             try {
                 $decodedValues = $this->decodeAndValidateMetadata($value);
             } catch (JsonException $e) {
@@ -931,13 +936,13 @@ class Episciences_Volume
 
             // Sanitize user input to prevent XSS
             $sanitizedValues = $this->sanitizeMetadataValues($decodedValues);
-            
+
             // Add required fields
             $sanitizedValues['vid'] = $this->getVid();
             $sanitizedValues['position'] = $position;
 
             $metadata = new Episciences_Volume_Metadata($sanitizedValues);
-            
+
             if (!$metadata->save()) {
                 $errors[] = "Failed to save metadata at position {$position}";
                 continue;
@@ -967,7 +972,7 @@ class Episciences_Volume
     private function decodeAndValidateMetadata(string $value): array
     {
         $decodedValues = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
-        
+
         if (!is_array($decodedValues)) {
             throw new JsonException('Decoded metadata must be an array');
         }
@@ -1004,7 +1009,7 @@ class Episciences_Volume
             }
         }
 
-        // Sanitize content array - HTML escape each language version  
+        // Sanitize content array - HTML escape each language version
         if (isset($values['content']) && is_array($values['content'])) {
             $sanitized['content'] = [];
             foreach ($values['content'] as $lang => $content) {
@@ -1202,6 +1207,7 @@ class Episciences_Volume
             foreach ($papers as $p) {
                 $docId = $p->getDocid();
                 $titles = $p->getAllTitles();
+                $vid = $p->getVid(); // primary volume
 
                 if (array_key_exists($locale, $titles)) {
                     $pTitle = $titles[$locale];
@@ -1213,6 +1219,7 @@ class Episciences_Volume
 
                 $paperList[$docId]['title'] = $pTitle;
                 $paperList[$docId]['docid'] = $docId;
+                $paperList[$docId]['vid'] = $vid;
                 // RT#129760
                 $paperList[$docId]['paperid'] = $p->getPaperid();
                 $paperList[$docId]['status'] = $p->getStatus();
@@ -1333,7 +1340,7 @@ class Episciences_Volume
 
     public function setVol_year($volYear): \Episciences_Volume
     {
-        $this->_vol_year =  (int)$volYear ?: null;
+        $this->_vol_year = (int)$volYear ?: null;
         return $this;
     }
 
@@ -1527,6 +1534,38 @@ class Episciences_Volume
             ->where('VID = ?', $this->getVid())
             ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED);
         return $db->fetchOne($select);
+    }
+
+    /**
+     *
+     * @param int $paperId
+     * @param int|null $vid [ default ($vid = null]) : returns position in primary volume
+     * @return int|null
+     */
+
+    public function getPositionByPaperId(int $paperId, int $vid = null): ?int
+    {
+
+        try {
+            $sortedPapers = $this->getSortedPapersFromVolume('object');
+        } catch (Zend_Db_Select_Exception|Zend_Exception $e) {
+            $sortedPapers = [];
+        }
+
+
+        /**
+         * @var int $position
+         * @var  Episciences_Paper $paper
+         */
+
+        foreach ( $sortedPapers as $position => $paper) {
+
+            if ($paper->getPaperid() === $paperId && $paper->getVid() === $vid) {
+                return $position;
+            }
+        }
+
+        return $position + 1;
     }
 
 

--- a/library/Episciences/Volume/Paper.php
+++ b/library/Episciences/Volume/Paper.php
@@ -36,10 +36,10 @@ class Episciences_Volume_Paper
 
     public function setVid($vid)
     {
-        $this->_vid = $vid;
+        $this->_vid = (int)$vid;
     }
 
-    public function getVid()
+    public function getVid() : int
     {
         return $this->_vid;
     }


### PR DESCRIPTION
Updated function Volume::findGapsInPaperOrders() : do not see all the gaps in certain situations (ex. sorted_papers = [1,2,37])