### PR TITLE
Potential fix for code scanning alert no. 41: Variable not declared before use

### DIFF
--- a/public/js/datepicker/datepicker.js
+++ b/public/js/datepicker/datepicker.js
@@ -23,6 +23,7 @@ $(function() {
 function datepicker (selector)
 {
     var dateFormat = 'yy-mm-dd'; // Format ISO 8601
+    var lang; // Declare lang at function start
 
     $(selector).each(function(index) {
         var params = {'dateFormat': dateFormat, constrainInput: true};
@@ -74,8 +75,8 @@ function datepicker (selector)
         if ($(this).attr('attr-maxdate')) params.maxDate = $(this).attr('attr-maxdate');
 
         //traduction du datepicker
-        if (undefined == lang) {
-            var lang = 'fr';
+        if (typeof lang === "undefined" || lang === undefined) {
+            lang = 'fr';
         }
         
         $(this).datepicker($.datepicker.regional[lang]);


### PR DESCRIPTION
Potential fix for [https://github.com/CCSDForge/episciences/security/code-scanning/41](https://github.com/CCSDForge/episciences/security/code-scanning/41)

The best fix is to move the declaration of `var lang` to the beginning of the `datepicker` function, so that it is clearly declared before any usage. If the initial value should depend on a later check, it can be set to `undefined` at the top and assigned a value as needed later. This does not alter existing logic but makes variable scope and usage explicit and clear. The only required change is to lift `var lang` to the top of the function `datepicker`, in file `public/js/datepicker/datepicker.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
