### PR TITLE
Potential fix for code scanning alert no. 40: Useless assignment to local variable

### DIFF
--- a/public/js/forms/form.js
+++ b/public/js/forms/form.js
@@ -41,14 +41,14 @@ form.validate = function() {
 	    	// Element TinyMCE
 	    	if ($(element).is("textarea") && tinyMCE.editors[name]) {
 	    		if (tinyMCE.editors[name].getContent()) {
-	    			validated = true;
 	    			continue;
+					
 	    		}
 	    	} 
 	    	// Autres types d'élément
 	    	else if ( $(element).val() ){
-	    		validated = true;
     			continue;
+					
 	    	}
 	    	
 	    	// En cas d'erreur


### PR DESCRIPTION
Potential fix for [https://github.com/CCSDForge/episciences/security/code-scanning/40](https://github.com/CCSDForge/episciences/security/code-scanning/40)

The best way to fix the problem is to remove the unnecessary assignments to `validated` within the loop. Specifically, both instances of `validated = true` (lines 44 and 50) are immediately followed by `continue`, so the value assigned is never checked or used after assignment. Remove these two assignments, preserving the `continue` statements so that the loop flow remains unchanged. No new imports or definitions are needed, and no other changes to logic are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
