### PR TITLE
Refactor AuthorsManager into 6 single-responsibility classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Episciences_Paper_Authors_EnrichmentService` — DB/TEI author data merging
   - `Episciences_Paper_Authors_AffiliationHelper` — Affiliation/ROR/acronym utilities
   - `Episciences_Paper_Authors_ViewFormatter` — HTML display formatting
+- Refactored `Episciences_Paper_Authors_ViewFormatter` to separate data fetching from formatting logic, improving testability
 - `AuthorsManager` kept as orchestrator with backward-compatible `@deprecated` proxies
 - Moved `normalizeOrcid()` implementation from `AuthorsManager` to `HalTeiParser` to break circular dependency; `AuthorsManager::normalizeOrcid()` is now a deprecated proxy
 - `AuthorsManager::ONE_MONTH` now references `TeiCacheManager::ONE_MONTH` (deduplicated constant)
@@ -34,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Applied `normalizeOrcid()` in Zenodo and ARCHE hooks where raw ORCID values were stored without normalization
 - `findAffiliationsOneAuthorByPaperId()`: fixed potential undefined variable when author rows are empty
 - `hasAcronym()`: fixed iteration over nested `id` array (was comparing top-level keys instead of inspecting each identifier sub-array, consistent with `hasRor()`)
+- `HalTeiParser::getAuthorsFromHalTei()`: fixed logic to prevent enriching the wrong author when `persName` is missing in TEI XML
 - `ViewFormatter`: fixed XSS via unquoted HTML attributes (`href`, `data-original-title`); values are now properly quoted and escaped with `htmlspecialchars()`
+- `ViewFormatter::buildAffiliationListHtml()`: fixed Stored XSS by escaping the affiliation acronym
 - `ViewFormatter`: fixed `html_entity_decode(htmlspecialchars())` no-op; plain-text author list now uses raw name, HTML template uses escaped name
 - `EnrichmentService::mergeExistingAffiliations()`: fixed `key()` always returning 0 instead of the actual matching DB affiliation key; now uses `array_search()`
 - `AffiliationHelper::isAcronymDuplicate()`: fixed hardcoded `[0]` index; now iterates all identifiers (consistent with `hasRor()`/`hasAcronym()`)
@@ -44,10 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Repository`: `JSON_DECODE_FLAGS` no longer includes encode-only flags (`JSON_UNESCAPED_SLASHES`, `JSON_UNESCAPED_UNICODE`)
 
 ### Security
-- Fixed XSS vulnerability in `ViewFormatter::buildAuthorHtml()` and `buildAffiliationListHtml()` where user-controlled values were interpolated into unquoted HTML attributes
+- Fixed XSS vulnerability in `ViewFormatter::buildAuthorHtml()` and `buildAffiliationListHtml()` where user-controlled values were interpolated into unquoted or improperly escaped HTML attributes (ORCID URL, data-title, and affiliation acronym)
 - Fixed potential Solr query injection in `TeiCacheManager::buildApiUrl()`
 
 ### Added
+- Comprehensive unit tests for `Episciences_Paper_Authors_ViewFormatter` covering HTML display logic and XSS prevention
 - [#883](https://github.com/CCSDForge/episciences/issues/883) Allow json files as attachments
 - It is now possible to report status changes to an external entry point (can be configured by review)
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Episciences_Paper_Authors_AffiliationHelper` — Affiliation/ROR/acronym utilities
   - `Episciences_Paper_Authors_ViewFormatter` — HTML display formatting
 - `AuthorsManager` kept as orchestrator with backward-compatible `@deprecated` proxies
+- Moved `normalizeOrcid()` implementation from `AuthorsManager` to `HalTeiParser` to break circular dependency; `AuthorsManager::normalizeOrcid()` is now a deprecated proxy
+- `AuthorsManager::ONE_MONTH` now references `TeiCacheManager::ONE_MONTH` (deduplicated constant)
+- Added `TeiCacheManager::fetchAndGet()` to combine fetch-if-needed + read in a single call; callers updated (`EnrichmentService`, `LicenceManager`, `AuthorsManager`)
 
 ### Fixed
 - ORCID normalization: `cleanLowerCaseOrcid()` did not strip `https://orcid.org/` URL prefix; new `normalizeOrcid()` method handles URL stripping, trimming, and lowercase `x` → `X` fix
 - Applied `normalizeOrcid()` in Zenodo and ARCHE hooks where raw ORCID values were stored without normalization
 - `findAffiliationsOneAuthorByPaperId()`: fixed potential undefined variable when author rows are empty
 - `hasAcronym()`: fixed iteration over nested `id` array (was comparing top-level keys instead of inspecting each identifier sub-array, consistent with `hasRor()`)
+- `ViewFormatter`: fixed XSS via unquoted HTML attributes (`href`, `data-original-title`); values are now properly quoted and escaped with `htmlspecialchars()`
+- `ViewFormatter`: fixed `html_entity_decode(htmlspecialchars())` no-op; plain-text author list now uses raw name, HTML template uses escaped name
+- `EnrichmentService::mergeExistingAffiliations()`: fixed `key()` always returning 0 instead of the actual matching DB affiliation key; now uses `array_search()`
+- `AffiliationHelper::isAcronymDuplicate()`: fixed hardcoded `[0]` index; now iterates all identifiers (consistent with `hasRor()`/`hasAcronym()`)
+- `AffiliationHelper::setOrUpdateRorAcronym()`: returns first match deterministically instead of last
+- `TeiCacheManager::buildApiUrl()`: applied `urlencode()` on identifier to prevent Solr query injection
+- `TeiCacheManager::getFromCache()`: removed dead `expiresAfter()` call on the read path
+- `Repository`: `JSON_DECODE_FLAGS` no longer includes encode-only flags (`JSON_UNESCAPED_SLASHES`, `JSON_UNESCAPED_UNICODE`)
+
+### Security
+- Fixed XSS vulnerability in `ViewFormatter::buildAuthorHtml()` and `buildAffiliationListHtml()` where user-controlled values were interpolated into unquoted HTML attributes
+- Fixed potential Solr query injection in `TeiCacheManager::buildApiUrl()`
 
 ### Added
 - [#883](https://github.com/CCSDForge/episciences/issues/883) Allow json files as attachments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 ## Unreleased
+### Changed
+- Refactored `Episciences_Paper_AuthorsManager` (879-line God Class) into 6 single-responsibility classes:
+  - `Episciences_Hal_TeiCacheManager` — HAL TEI cache and HTTP
+  - `Episciences_Paper_Authors_HalTeiParser` — TEI XML parsing
+  - `Episciences_Paper_Authors_Repository` — Database CRUD
+  - `Episciences_Paper_Authors_EnrichmentService` — DB/TEI author data merging
+  - `Episciences_Paper_Authors_AffiliationHelper` — Affiliation/ROR/acronym utilities
+  - `Episciences_Paper_Authors_ViewFormatter` — HTML display formatting
+- `AuthorsManager` kept as orchestrator with backward-compatible `@deprecated` proxies
+
+### Fixed
+- ORCID normalization: `cleanLowerCaseOrcid()` did not strip `https://orcid.org/` URL prefix; new `normalizeOrcid()` method handles URL stripping, trimming, and lowercase `x` → `X` fix
+- Applied `normalizeOrcid()` in Zenodo and ARCHE hooks where raw ORCID values were stored without normalization
+- `findAffiliationsOneAuthorByPaperId()`: fixed potential undefined variable when author rows are empty
+- `hasAcronym()`: fixed iteration over nested `id` array (was comparing top-level keys instead of inspecting each identifier sub-array, consistent with `hasRor()`)
+
 ### Added
 - [#883](https://github.com/CCSDForge/episciences/issues/883) Allow json files as attachments
 - It is now possible to report status changes to an external entry point (can be configured by review)

--- a/library/Episciences/Hal/TeiCacheManager.php
+++ b/library/Episciences/Hal/TeiCacheManager.php
@@ -1,0 +1,119 @@
+<?php
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+class Episciences_Hal_TeiCacheManager
+{
+    public const ONE_MONTH = 3600 * 24 * 31;
+
+    private const CACHE_NAMESPACE = 'halTei';
+    private const CACHE_KEY_PREFIX = 'hal-tei-';
+    private const CACHE_KEY_EXTENSION = '.xml';
+    private const HAL_API_BASE_URL = 'https://api.archives-ouvertes.fr/search/';
+    private const HAL_USER_AGENT = 'CCSD Episciences support@episciences.org';
+    private const TIMEOUT_WEB = 3;
+    private const TIMEOUT_CLI = 40;
+
+    /**
+     * Fetch TEI from HAL API and store it in cache
+     *
+     * @param string $identifier HAL document identifier
+     * @param int $version HAL document version (0 = latest)
+     * @return bool true if fetched from API, false if already cached
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public static function fetchAndCache(string $identifier, int $version = 0): bool
+    {
+        $cacheKey = self::buildCacheKey($identifier, $version);
+        $cache = self::createCacheAdapter();
+        $cacheItem = $cache->getItem($cacheKey);
+        $cacheItem->expiresAfter(self::ONE_MONTH);
+
+        if (!$cacheItem->isHit()) {
+            $teiXml = self::fetchFromApi($identifier, $version);
+            $cacheItem->set($teiXml);
+            $cache->save($cacheItem);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieve cached TEI XML string
+     *
+     * @param string $identifier HAL document identifier
+     * @param int $version HAL document version (0 = latest)
+     * @return string TEI XML content, or empty string if not cached
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public static function getFromCache(string $identifier, int $version = 0): string
+    {
+        $cacheKey = self::buildCacheKey($identifier, $version);
+        $cache = self::createCacheAdapter();
+        $cacheItem = $cache->getItem($cacheKey);
+        $cacheItem->expiresAfter(self::ONE_MONTH);
+
+        if (!$cacheItem->isHit()) {
+            return '';
+        }
+
+        return $cacheItem->get();
+    }
+
+    private static function createCacheAdapter(): FilesystemAdapter
+    {
+        return new FilesystemAdapter(self::CACHE_NAMESPACE, self::ONE_MONTH, dirname(APPLICATION_PATH) . '/cache/');
+    }
+
+    private static function buildCacheKey(string $identifier, int $version): string
+    {
+        $key = self::CACHE_KEY_PREFIX . $identifier;
+
+        if ($version !== 0) {
+            $key .= '-' . $version;
+        }
+
+        return $key . self::CACHE_KEY_EXTENSION;
+    }
+
+    /**
+     * @param string $identifier HAL document identifier
+     * @param int $version HAL document version (0 = latest)
+     * @return string raw TEI XML response
+     */
+    private static function fetchFromApi(string $identifier, int $version): string
+    {
+        $client = new GuzzleClient();
+        $url = self::buildApiUrl($identifier, $version);
+        $timeout = (PHP_SAPI === 'cli') ? self::TIMEOUT_CLI : self::TIMEOUT_WEB;
+
+        try {
+            return $client->get($url, [
+                'headers' => [
+                    'User-Agent' => self::HAL_USER_AGENT,
+                    'Content-Type' => 'application/json',
+                    'Accept' => 'application/json'
+                ],
+                'timeout' => $timeout
+            ])->getBody()->getContents();
+        } catch (GuzzleException $e) {
+            trigger_error($e->getMessage());
+        }
+
+        return '';
+    }
+
+    private static function buildApiUrl(string $identifier, int $version): string
+    {
+        $halIdQuery = '(halId_s:' . $identifier . ' OR halIdSameAs_s:' . $identifier . ')';
+
+        if ($version === 0) {
+            return self::HAL_API_BASE_URL . '?q=(' . $halIdQuery . ')&wt=xml-tei';
+        }
+
+        return self::HAL_API_BASE_URL . '?q=(' . $halIdQuery . ' AND version_i:' . $version . ')&wt=xml-tei';
+    }
+}

--- a/library/Episciences/Paper/Authors/AffiliationHelper.php
+++ b/library/Episciences/Paper/Authors/AffiliationHelper.php
@@ -1,0 +1,237 @@
+<?php
+
+class Episciences_Paper_Authors_AffiliationHelper
+{
+    public const ID_TYPE_ROR = 'ROR';
+    private const KEY_NAME = 'name';
+    private const KEY_ID = 'id';
+    private const KEY_ID_TYPE = 'id-type';
+    private const KEY_ACRONYM = 'acronym';
+    private const ACRONYM_SEPARATOR = '||';
+
+    /**
+     * Build a structured affiliation array with ROR identifier
+     *
+     * @param array{name: string, ROR: string, acronym?: string} $affiliationData
+     * @return array structured affiliation for DB storage
+     */
+    public static function buildWithRor(array $affiliationData): array
+    {
+        $structured = [
+            self::KEY_NAME => $affiliationData[self::KEY_NAME],
+            self::KEY_ID => [
+                [
+                    self::KEY_ID => $affiliationData[self::ID_TYPE_ROR],
+                    self::KEY_ID_TYPE => self::ID_TYPE_ROR
+                ]
+            ]
+        ];
+
+        if (array_key_exists(self::KEY_ACRONYM, $affiliationData)) {
+            $structured[self::KEY_ID][0][self::KEY_ACRONYM] = $affiliationData[self::KEY_ACRONYM];
+        }
+
+        return $structured;
+    }
+
+    /**
+     * Build a structured affiliation array with only a name (no ROR)
+     *
+     * @param string $name affiliation name
+     * @return array{name: string}
+     */
+    public static function buildNameOnly(string $name): array
+    {
+        return [self::KEY_NAME => $name];
+    }
+
+    /**
+     * Build an identifier-only array (ROR + optional acronym) for attaching to an existing affiliation
+     *
+     * @param string $rorUrl full ROR URL
+     * @param string|null $acronym optional acronym
+     * @return array[] single-element array with ROR identifier
+     */
+    public static function buildRorOnly(string $rorUrl, ?string $acronym): array
+    {
+        $identifier = [
+            self::KEY_ID => $rorUrl,
+            self::KEY_ID_TYPE => self::ID_TYPE_ROR
+        ];
+
+        if ($acronym !== null && $acronym !== '') {
+            $identifier[self::KEY_ACRONYM] = $acronym;
+        }
+
+        return [$identifier];
+    }
+
+    /**
+     * Check whether an affiliation already has a ROR identifier
+     *
+     * @param array $authorAffiliation single affiliation entry from the DB
+     * @return bool
+     */
+    public static function hasRor(array $authorAffiliation): bool
+    {
+        if (!isset($authorAffiliation[self::KEY_ID])) {
+            return false;
+        }
+
+        foreach ($authorAffiliation[self::KEY_ID] as $identifier) {
+            if ($identifier[self::KEY_ID_TYPE] === self::ID_TYPE_ROR) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether an affiliation has an acronym attached
+     *
+     * @param array $authorAffiliation single affiliation entry from the DB
+     * @return bool
+     */
+    public static function hasAcronym(array $authorAffiliation): bool
+    {
+        if (!isset($authorAffiliation[self::KEY_ID])) {
+            return false;
+        }
+
+        foreach ($authorAffiliation[self::KEY_ID] as $identifier) {
+            if (array_key_exists(self::KEY_ACRONYM, $identifier)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if a given acronym already exists in an affiliation identifier
+     *
+     * @param array $affiliationIdentifiers identifier array (e.g. from $affiliation['id'])
+     * @param string $acronym acronym to check
+     * @return bool
+     */
+    public static function isAcronymDuplicate(array $affiliationIdentifiers, string $acronym): bool
+    {
+        return isset($affiliationIdentifiers[0][self::KEY_ACRONYM])
+            && $affiliationIdentifiers[0][self::KEY_ACRONYM] === $acronym;
+    }
+
+    /**
+     * Collect all unique acronyms from an author's affiliations, formatted as "[ACRONYM]"
+     *
+     * @param array $affiliationsFromDb all affiliations for one author
+     * @return string formatted acronym list separated by "||", or empty string
+     */
+    public static function getExistingAcronyms(array $affiliationsFromDb): string
+    {
+        $uniqueAcronyms = [];
+
+        foreach ($affiliationsFromDb as $affiliation) {
+            if (!isset($affiliation[self::KEY_ID])) {
+                continue;
+            }
+
+            foreach ($affiliation[self::KEY_ID] as $identifier) {
+                if (array_key_exists(self::KEY_ACRONYM, $identifier)) {
+                    $uniqueAcronyms[] = $identifier[self::KEY_ACRONYM];
+                }
+            }
+        }
+
+        if (empty($uniqueAcronyms)) {
+            return '';
+        }
+
+        $uniqueAcronyms = array_unique($uniqueAcronyms);
+        $bracketedAcronyms = array_map(static fn(string $acronym): string => '[' . $acronym . ']', $uniqueAcronyms);
+
+        return self::formatAcronymList($bracketedAcronyms);
+    }
+
+    /**
+     * Join acronym entries with the "||" separator
+     *
+     * @param array $acronymList list of formatted acronym strings
+     * @return string
+     */
+    public static function formatAcronymList(array $acronymList): string
+    {
+        return implode(self::ACRONYM_SEPARATOR, $acronymList);
+    }
+
+    /**
+     * Find the matching acronym from a list that appears in the given haystack string
+     *
+     * @param array $acronyms list of acronyms to search for
+     * @param string $haystack string to search within
+     * @return string matched acronym, or empty string if none found
+     */
+    public static function setOrUpdateRorAcronym(array $acronyms, string $haystack): string
+    {
+        $matchedAcronym = '';
+
+        foreach ($acronyms as $acronym) {
+            if ($acronym !== '' && str_contains($haystack, $acronym)) {
+                $matchedAcronym = $acronym;
+            }
+        }
+
+        return $matchedAcronym;
+    }
+
+    /**
+     * Remove an acronym substring from an affiliation name (used for export)
+     *
+     * @param string $affiliationName full affiliation name
+     * @param string $acronym acronym to remove
+     * @return string cleaned name
+     */
+    public static function eraseAcronymInName(string $affiliationName, string $acronym): string
+    {
+        return rtrim(str_replace($acronym, '', $affiliationName));
+    }
+
+    /**
+     * Strip surrounding brackets from an acronym string, e.g. "[CNRS]" → "CNRS"
+     *
+     * @param string $bracketedAcronym acronym with brackets
+     * @return string acronym without brackets
+     */
+    public static function cleanAcronym(string $bracketedAcronym): string
+    {
+        return substr(trim($bracketedAcronym), 1, -1);
+    }
+
+    /**
+     * Format affiliations for the ROR input widget in the paper view
+     *
+     * @param array $affiliations list of affiliation entries
+     * @return array<int, string> formatted affiliation strings
+     */
+    public static function formatAffiliationForInputRor(array $affiliations): array
+    {
+        $formatted = [];
+
+        foreach ($affiliations as $affiliation) {
+            $rorSuffix = '';
+            $acronymSuffix = '';
+
+            if (array_key_exists(self::KEY_ID, $affiliation)) {
+                $rorSuffix = ' #' . $affiliation[self::KEY_ID][0][self::KEY_ID];
+
+                if (array_key_exists(self::KEY_ACRONYM, $affiliation[self::KEY_ID][0])) {
+                    $acronymSuffix = ' [' . $affiliation[self::KEY_ID][0][self::KEY_ACRONYM] . ']';
+                }
+            }
+
+            $formatted[] = $affiliation[self::KEY_NAME] . $acronymSuffix . $rorSuffix;
+        }
+
+        return $formatted;
+    }
+}

--- a/library/Episciences/Paper/Authors/AffiliationHelper.php
+++ b/library/Episciences/Paper/Authors/AffiliationHelper.php
@@ -117,8 +117,13 @@ class Episciences_Paper_Authors_AffiliationHelper
      */
     public static function isAcronymDuplicate(array $affiliationIdentifiers, string $acronym): bool
     {
-        return isset($affiliationIdentifiers[0][self::KEY_ACRONYM])
-            && $affiliationIdentifiers[0][self::KEY_ACRONYM] === $acronym;
+        foreach ($affiliationIdentifiers as $identifier) {
+            if (isset($identifier[self::KEY_ACRONYM]) && $identifier[self::KEY_ACRONYM] === $acronym) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -178,6 +183,7 @@ class Episciences_Paper_Authors_AffiliationHelper
         foreach ($acronyms as $acronym) {
             if ($acronym !== '' && str_contains($haystack, $acronym)) {
                 $matchedAcronym = $acronym;
+                break;
             }
         }
 

--- a/library/Episciences/Paper/Authors/EnrichmentService.php
+++ b/library/Episciences/Paper/Authors/EnrichmentService.php
@@ -38,8 +38,7 @@ class Episciences_Paper_Authors_EnrichmentService
 
         $decodedAuthors = Episciences_Paper_Authors_Repository::getDecodedAuthors($paperId);
 
-        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
-        $cachedTeiXml = Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
+        $cachedTeiXml = Episciences_Hal_TeiCacheManager::fetchAndGet($identifier, $version);
 
         if ($cachedTeiXml === '') {
             return 0;
@@ -168,15 +167,15 @@ class Episciences_Paper_Authors_EnrichmentService
                 continue;
             }
 
-            $currentAffiliationKey = key($dbAuthors[$authorIndex][self::KEY_AFFILIATION]);
+            $matchingKey = array_search($affiliationName, $existingNames, true);
             $hasRor = array_key_exists(self::KEY_ROR, $teiAffiliation);
             $dbAffiliationHasRor = Episciences_Paper_Authors_AffiliationHelper::hasRor(
-                $dbAuthor[self::KEY_AFFILIATION][$currentAffiliationKey]
+                $dbAuthor[self::KEY_AFFILIATION][$matchingKey]
             );
 
             if ($hasRor && !$dbAffiliationHasRor) {
                 $acronym = $teiAffiliation[self::KEY_ACRONYM] ?? '';
-                $dbAuthors[$authorIndex][self::KEY_AFFILIATION][$currentAffiliationKey]['id'] =
+                $dbAuthors[$authorIndex][self::KEY_AFFILIATION][$matchingKey]['id'] =
                     Episciences_Paper_Authors_AffiliationHelper::buildRorOnly($teiAffiliation[self::KEY_ROR], $acronym);
 
                 if (PHP_SAPI === 'cli') {

--- a/library/Episciences/Paper/Authors/EnrichmentService.php
+++ b/library/Episciences/Paper/Authors/EnrichmentService.php
@@ -1,0 +1,255 @@
+<?php
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+class Episciences_Paper_Authors_EnrichmentService
+{
+    private const KEY_ORCID = 'orcid';
+    private const KEY_FULLNAME = 'fullname';
+    private const KEY_AFFILIATION = 'affiliation';
+    private const KEY_AFFILIATIONS = 'affiliations';
+    private const KEY_ROR = 'ROR';
+    private const KEY_ACRONYM = 'acronym';
+    private const KEY_NAME = 'name';
+
+    private const JSON_ENCODE_FLAGS = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT;
+    private const LOGGER_CHANNEL = 'AuthorsManager';
+    private const LOG_FILE_PREFIX = 'getcreatordata_';
+
+    private static ?Logger $logger = null;
+
+    /**
+     * Enrich author ORCID and affiliation data from HAL TEI into the database
+     *
+     * @param int $repoId repository identifier
+     * @param int $paperId paper identifier
+     * @param string $identifier HAL document identifier
+     * @param int $version HAL document version (0 = latest)
+     * @return int number of affected rows
+     * @throws JsonException
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public static function enrichAffiOrcidFromTeiHalInDB(int $repoId, int $paperId, string $identifier, int $version): int
+    {
+        if ($repoId !== (int)Episciences_Repositories::HAL_REPO_ID) {
+            return 0;
+        }
+
+        $decodedAuthors = Episciences_Paper_Authors_Repository::getDecodedAuthors($paperId);
+
+        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
+        $cachedTeiXml = Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
+
+        if ($cachedTeiXml === '') {
+            return 0;
+        }
+
+        $teiDocument = simplexml_load_string($cachedTeiXml);
+
+        if (!is_object($teiDocument) || $teiDocument->count() <= 0) {
+            return 0;
+        }
+
+        $teiAuthors = Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei($teiDocument);
+        $teiAffiliations = Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei($teiDocument);
+        $teiAuthors = Episciences_Paper_Authors_HalTeiParser::mergeAuthorInfoAndAffiTei($teiAuthors, $teiAffiliations);
+
+        $enrichedAuthors = self::mergeInfoDbAndInfoTei($decodedAuthors, $teiAuthors);
+
+        $authorEntity = new Episciences_Paper_Authors();
+        $authorEntity->setAuthors(json_encode($enrichedAuthors, self::JSON_ENCODE_FLAGS));
+        $authorEntity->setPaperId($paperId);
+
+        return Episciences_Paper_Authors_Repository::update($authorEntity);
+    }
+
+    /**
+     * Merge database author records with TEI-parsed author data (ORCID + affiliations)
+     *
+     * @param array $dbAuthors authors from the database
+     * @param array $teiAuthors authors parsed from TEI
+     * @return array enriched authors array
+     */
+    public static function mergeInfoDbAndInfoTei(array $dbAuthors, array $teiAuthors): array
+    {
+        foreach ($dbAuthors as $authorIndex => $dbAuthor) {
+            foreach ($teiAuthors as $teiAuthor) {
+                if (!self::matchAuthorByName($dbAuthor, $teiAuthor)) {
+                    continue;
+                }
+
+                self::enrichAuthorOrcid($dbAuthors, $authorIndex, $dbAuthor, $teiAuthor);
+                self::enrichAuthorAffiliations($dbAuthors, $authorIndex, $dbAuthor, $teiAuthor);
+            }
+        }
+
+        return $dbAuthors;
+    }
+
+    /**
+     * Check whether a DB author and a TEI author represent the same person (by name)
+     *
+     * @param array $dbAuthor single author from database
+     * @param array $teiAuthor single author from TEI
+     * @return bool true if names match (exact or accent-insensitive)
+     */
+    private static function matchAuthorByName(array $dbAuthor, array $teiAuthor): bool
+    {
+        $dbFullname = $dbAuthor[self::KEY_FULLNAME];
+        $teiFullname = $teiAuthor[self::KEY_FULLNAME];
+
+        return ($dbFullname === $teiFullname)
+            || (Episciences_Tools::replaceAccents($teiFullname) === Episciences_Tools::replaceAccents($dbFullname));
+    }
+
+    /**
+     * Add ORCID from TEI to a DB author that lacks one
+     *
+     * @param array &$dbAuthors full authors array (modified by reference)
+     * @param int|string $authorIndex index of the author being enriched
+     * @param array $dbAuthor current author data from DB
+     * @param array $teiAuthor matching author data from TEI
+     */
+    private static function enrichAuthorOrcid(array &$dbAuthors, int|string $authorIndex, array $dbAuthor, array $teiAuthor): void
+    {
+        if (!array_key_exists(self::KEY_ORCID, $teiAuthor) || array_key_exists(self::KEY_ORCID, $dbAuthor)) {
+            return;
+        }
+
+        $dbAuthors[$authorIndex][self::KEY_ORCID] = $teiAuthor[self::KEY_ORCID];
+
+        if (PHP_SAPI === 'cli') {
+            self::logInfoMessage('Orcid Added for ' . $dbAuthors[$authorIndex][self::KEY_FULLNAME]);
+        }
+    }
+
+    /**
+     * Add or merge affiliations from TEI into a DB author record
+     *
+     * @param array &$dbAuthors full authors array (modified by reference)
+     * @param int|string $authorIndex index of the author being enriched
+     * @param array $dbAuthor current author data from DB
+     * @param array $teiAuthor matching author data from TEI
+     */
+    private static function enrichAuthorAffiliations(array &$dbAuthors, int|string $authorIndex, array $dbAuthor, array $teiAuthor): void
+    {
+        if (!array_key_exists(self::KEY_AFFILIATIONS, $teiAuthor)) {
+            return;
+        }
+
+        if (array_key_exists(self::KEY_AFFILIATION, $dbAuthor)) {
+            self::mergeExistingAffiliations($dbAuthors, $authorIndex, $dbAuthor, $teiAuthor);
+        } else {
+            self::addNewAffiliations($dbAuthors, $authorIndex, $teiAuthor);
+        }
+    }
+
+    /**
+     * Merge TEI affiliations into an author that already has affiliations in DB
+     *
+     * @param array &$dbAuthors full authors array (modified by reference)
+     * @param int|string $authorIndex index of the author being enriched
+     * @param array $dbAuthor current author data from DB
+     * @param array $teiAuthor matching author data from TEI
+     */
+    private static function mergeExistingAffiliations(array &$dbAuthors, int|string $authorIndex, array $dbAuthor, array $teiAuthor): void
+    {
+        foreach ($teiAuthor[self::KEY_AFFILIATIONS] as $teiAffiliation) {
+            $existingNames = array_column($dbAuthor[self::KEY_AFFILIATION], self::KEY_NAME);
+            $affiliationName = $teiAffiliation[self::KEY_NAME];
+
+            if (!in_array($affiliationName, $existingNames, true)) {
+                self::appendAffiliation($dbAuthors, $authorIndex, $teiAffiliation);
+
+                if (PHP_SAPI === 'cli') {
+                    self::logInfoMessage('Affiliation Added with ROR for ' . $dbAuthors[$authorIndex][self::KEY_FULLNAME]);
+                }
+                continue;
+            }
+
+            $currentAffiliationKey = key($dbAuthors[$authorIndex][self::KEY_AFFILIATION]);
+            $hasRor = array_key_exists(self::KEY_ROR, $teiAffiliation);
+            $dbAffiliationHasRor = Episciences_Paper_Authors_AffiliationHelper::hasRor(
+                $dbAuthor[self::KEY_AFFILIATION][$currentAffiliationKey]
+            );
+
+            if ($hasRor && !$dbAffiliationHasRor) {
+                $acronym = $teiAffiliation[self::KEY_ACRONYM] ?? '';
+                $dbAuthors[$authorIndex][self::KEY_AFFILIATION][$currentAffiliationKey]['id'] =
+                    Episciences_Paper_Authors_AffiliationHelper::buildRorOnly($teiAffiliation[self::KEY_ROR], $acronym);
+
+                if (PHP_SAPI === 'cli') {
+                    self::logInfoMessage('ROR to Affiliation Added for ' . $dbAuthors[$authorIndex][self::KEY_FULLNAME] . ' - ' . $affiliationName);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add all TEI affiliations to an author that has no affiliations in DB
+     *
+     * @param array &$dbAuthors full authors array (modified by reference)
+     * @param int|string $authorIndex index of the author being enriched
+     * @param array $teiAuthor matching author data from TEI
+     */
+    private static function addNewAffiliations(array &$dbAuthors, int|string $authorIndex, array $teiAuthor): void
+    {
+        foreach ($teiAuthor[self::KEY_AFFILIATIONS] as $teiAffiliation) {
+            $hasRor = array_key_exists(self::KEY_ROR, $teiAffiliation);
+            self::appendAffiliation($dbAuthors, $authorIndex, $teiAffiliation);
+
+            if (PHP_SAPI === 'cli') {
+                $rorLabel = $hasRor ? 'with ROR' : 'without ROR found,';
+                self::logInfoMessage(
+                    'New Affiliation ' . $rorLabel . ' Added for '
+                    . $dbAuthors[$authorIndex][self::KEY_FULLNAME] . ' - ' . $teiAffiliation[self::KEY_NAME]
+                );
+            }
+        }
+    }
+
+    /**
+     * Append a single affiliation (with or without ROR) to an author
+     *
+     * @param array &$dbAuthors full authors array (modified by reference)
+     * @param int|string $authorIndex index of the author
+     * @param array $teiAffiliation affiliation data from TEI
+     */
+    private static function appendAffiliation(array &$dbAuthors, int|string $authorIndex, array $teiAffiliation): void
+    {
+        if (array_key_exists(self::KEY_ROR, $teiAffiliation)) {
+            $dbAuthors[$authorIndex][self::KEY_AFFILIATION][] =
+                Episciences_Paper_Authors_AffiliationHelper::buildWithRor($teiAffiliation);
+        } else {
+            $dbAuthors[$authorIndex][self::KEY_AFFILIATION][] =
+                Episciences_Paper_Authors_AffiliationHelper::buildNameOnly($teiAffiliation[self::KEY_NAME]);
+        }
+    }
+
+    /**
+     * Log an informational message to the enrichment log file
+     *
+     * @param string $message log message
+     * @throws Exception
+     */
+    public static function logInfoMessage(string $message): void
+    {
+        self::getLogger()->info($message);
+    }
+
+    /**
+     * @return Logger
+     * @throws Exception
+     */
+    private static function getLogger(): Logger
+    {
+        if (self::$logger === null) {
+            $logFile = EPISCIENCES_LOG_PATH . self::LOG_FILE_PREFIX . date('Y-m-d') . '.log';
+            self::$logger = new Logger(self::LOGGER_CHANNEL);
+            self::$logger->pushHandler(new StreamHandler($logFile, Logger::INFO));
+        }
+
+        return self::$logger;
+    }
+}

--- a/library/Episciences/Paper/Authors/HalTeiParser.php
+++ b/library/Episciences/Paper/Authors/HalTeiParser.php
@@ -92,11 +92,28 @@ class Episciences_Paper_Authors_HalTeiParser
 
         foreach ($authorNode->idno as $idnoNode) {
             if ((string)$idnoNode->attributes()->type === self::IDNO_TYPE_ORCID) {
-                $parsedAuthors[$lastAuthorIndex][self::KEY_ORCID] = Episciences_Paper_AuthorsManager::normalizeOrcid((string)$idnoNode);
+                $parsedAuthors[$lastAuthorIndex][self::KEY_ORCID] = self::normalizeOrcid((string)$idnoNode);
             }
         }
 
         return $parsedAuthors;
+    }
+
+    /**
+     * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
+     *
+     * @param string $orcid
+     * @return string
+     */
+    public static function normalizeOrcid(string $orcid): string
+    {
+        $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
+
+        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', $orcid)) {
+            $orcid = substr($orcid, 0, -1) . 'X';
+        }
+
+        return $orcid;
     }
 
     /**

--- a/library/Episciences/Paper/Authors/HalTeiParser.php
+++ b/library/Episciences/Paper/Authors/HalTeiParser.php
@@ -1,0 +1,199 @@
+<?php
+
+class Episciences_Paper_Authors_HalTeiParser
+{
+    private const IDNO_TYPE_ORCID = 'ORCID';
+    private const IDNO_TYPE_ROR = 'ROR';
+    private const KEY_AFFILIATIONS = 'affiliations';
+    private const KEY_ORCID = 'orcid';
+    private const KEY_NAME = 'name';
+    private const KEY_ACRONYM = 'acronym';
+    private const ROR_URL_PREFIX = 'https://ror.org/';
+
+    /**
+     * Extract all authors with their affiliations and ORCIDs from a TEI XML document
+     *
+     * @param SimpleXMLElement $teiDocument full TEI XML document
+     * @return array<int, array{given_name: string, family: string, fullname: string, affiliations?: array, orcid?: string}>
+     */
+    public static function getAuthorsFromHalTei(SimpleXMLElement $teiDocument): array
+    {
+        if (!isset($teiDocument->text->body->listBibl->biblFull->titleStmt->author)) {
+            return [];
+        }
+
+        $authorNodes = $teiDocument->text->body->listBibl->biblFull->titleStmt->author;
+        $parsedAuthors = [];
+
+        foreach ($authorNodes as $authorNode) {
+            foreach ($authorNode->persName as $personName) {
+                $parsedAuthors = self::getAuthorInfoFromXmlTei($personName, $parsedAuthors);
+            }
+
+            if (isset($authorNode->affiliation)) {
+                $parsedAuthors = self::getAuthorStructureFromXmlTei($authorNode, $parsedAuthors);
+            }
+
+            if (isset($authorNode->idno)) {
+                $parsedAuthors = self::getOrcidAuthorFromXmlTei($authorNode, $parsedAuthors);
+            }
+        }
+
+        return $parsedAuthors;
+    }
+
+    /**
+     * Extract author name information from a TEI persName element
+     *
+     * @param SimpleXMLElement|null $personName TEI persName element
+     * @param array $parsedAuthors accumulated authors array
+     * @return array updated authors array with new entry appended
+     */
+    public static function getAuthorInfoFromXmlTei(?SimpleXMLElement $personName, array $parsedAuthors): array
+    {
+        $parsedAuthors[] = [
+            'given_name' => (string)$personName->forename,
+            'family' => (string)$personName->surname,
+            'fullname' => rtrim($personName->forename . ' ' . $personName->surname),
+        ];
+
+        return $parsedAuthors;
+    }
+
+    /**
+     * Extract affiliation structure references from a TEI author element
+     *
+     * @param SimpleXMLElement|null $authorNode TEI author element
+     * @param array $parsedAuthors accumulated authors array
+     * @return array updated authors array with affiliations added to last entry
+     */
+    public static function getAuthorStructureFromXmlTei(?SimpleXMLElement $authorNode, array $parsedAuthors): array
+    {
+        $lastAuthorIndex = array_key_last($parsedAuthors);
+
+        foreach ($authorNode->affiliation as $affiliationNode) {
+            $structRef = (string)str_replace('#', '', $affiliationNode->attributes()->ref);
+            $parsedAuthors[$lastAuthorIndex][self::KEY_AFFILIATIONS][] = $structRef;
+        }
+
+        return $parsedAuthors;
+    }
+
+    /**
+     * Extract ORCID identifier from a TEI author element
+     *
+     * @param SimpleXMLElement|null $authorNode TEI author element
+     * @param array $parsedAuthors accumulated authors array
+     * @return array updated authors array with ORCID added to last entry
+     */
+    public static function getOrcidAuthorFromXmlTei(?SimpleXMLElement $authorNode, array $parsedAuthors): array
+    {
+        $lastAuthorIndex = array_key_last($parsedAuthors);
+
+        foreach ($authorNode->idno as $idnoNode) {
+            if ((string)$idnoNode->attributes()->type === self::IDNO_TYPE_ORCID) {
+                $parsedAuthors[$lastAuthorIndex][self::KEY_ORCID] = Episciences_Paper_AuthorsManager::normalizeOrcid((string)$idnoNode);
+            }
+        }
+
+        return $parsedAuthors;
+    }
+
+    /**
+     * Extract affiliation details (name, ROR, acronym) from the TEI back/listOrg section
+     *
+     * @param SimpleXMLElement $teiDocument full TEI XML document
+     * @return array<string, array{name: string, ROR?: string, acronym?: string}> keyed by structure ID
+     */
+    public static function getAffiFromHalTei(SimpleXMLElement $teiDocument): array
+    {
+        $backSection = $teiDocument->text->back;
+        $organizationsByStructId = [];
+
+        if (!isset($backSection->listOrg)) {
+            return $organizationsByStructId;
+        }
+
+        foreach ($backSection->listOrg->org as $orgNode) {
+            $structId = (string)$orgNode->attributes('xml', true)[0];
+            $organizationsByStructId[$structId][self::KEY_NAME] = trim((string)$orgNode->orgName);
+            $hasRor = self::extractRorFromOrg($orgNode, $organizationsByStructId, $structId);
+
+            if ($hasRor) {
+                self::extractAcronymFromOrg($orgNode, $organizationsByStructId, $structId);
+            }
+        }
+
+        return $organizationsByStructId;
+    }
+
+    /**
+     * @param SimpleXMLElement $orgNode
+     * @param array &$organizationsByStructId
+     * @param string $structId
+     * @return bool true if ROR was found
+     */
+    private static function extractRorFromOrg(SimpleXMLElement $orgNode, array &$organizationsByStructId, string $structId): bool
+    {
+        if (!$orgNode->idno) {
+            return false;
+        }
+
+        foreach ($orgNode->idno as $idnoNode) {
+            if ((string)$idnoNode->attributes()->type === self::IDNO_TYPE_ROR) {
+                $rorId = str_replace(self::ROR_URL_PREFIX, '', (string)$idnoNode);
+                $organizationsByStructId[$structId][self::IDNO_TYPE_ROR] = trim(self::ROR_URL_PREFIX . $rorId);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param SimpleXMLElement $orgNode
+     * @param array &$organizationsByStructId
+     * @param string $structId
+     */
+    private static function extractAcronymFromOrg(SimpleXMLElement $orgNode, array &$organizationsByStructId, string $structId): void
+    {
+        foreach ($orgNode->orgName as $orgNameNode) {
+            if ((string)$orgNameNode->attributes()->type === self::KEY_ACRONYM) {
+                $organizationsByStructId[$structId][self::KEY_ACRONYM] = trim((string)$orgNameNode);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Replace affiliation structure references (e.g. "struct-1234") with their resolved details
+     *
+     * @param array $authorsWithStructRefs authors with raw structure references
+     * @param array $affiliationsByStructId affiliation details keyed by structure ID
+     * @return array authors with resolved affiliation details
+     */
+    public static function mergeAuthorInfoAndAffiTei(array $authorsWithStructRefs, array $affiliationsByStructId): array
+    {
+        foreach ($authorsWithStructRefs as $authorIndex => $author) {
+            if (!isset($author[self::KEY_AFFILIATIONS])) {
+                continue;
+            }
+
+            foreach ($author[self::KEY_AFFILIATIONS] as $affiIndex => $structRef) {
+                $resolvedAffiliation = [self::KEY_NAME => $affiliationsByStructId[$structRef][self::KEY_NAME]];
+
+                if (array_key_exists(self::IDNO_TYPE_ROR, $affiliationsByStructId[$structRef])) {
+                    $resolvedAffiliation[self::IDNO_TYPE_ROR] = $affiliationsByStructId[$structRef][self::IDNO_TYPE_ROR];
+                }
+
+                if (array_key_exists(self::KEY_ACRONYM, $affiliationsByStructId[$structRef])) {
+                    $resolvedAffiliation[self::KEY_ACRONYM] = $affiliationsByStructId[$structRef][self::KEY_ACRONYM];
+                }
+
+                $authorsWithStructRefs[$authorIndex][self::KEY_AFFILIATIONS][$affiIndex] = $resolvedAffiliation;
+            }
+        }
+
+        return $authorsWithStructRefs;
+    }
+}

--- a/library/Episciences/Paper/Authors/HalTeiParser.php
+++ b/library/Episciences/Paper/Authors/HalTeiParser.php
@@ -26,8 +26,14 @@ class Episciences_Paper_Authors_HalTeiParser
         $parsedAuthors = [];
 
         foreach ($authorNodes as $authorNode) {
+            $initialCount = count($parsedAuthors);
+
             foreach ($authorNode->persName as $personName) {
                 $parsedAuthors = self::getAuthorInfoFromXmlTei($personName, $parsedAuthors);
+            }
+
+            if (count($parsedAuthors) === $initialCount) {
+                continue;
             }
 
             if (isset($authorNode->affiliation)) {

--- a/library/Episciences/Paper/Authors/Repository.php
+++ b/library/Episciences/Paper/Authors/Repository.php
@@ -2,7 +2,7 @@
 
 class Episciences_Paper_Authors_Repository
 {
-    private const JSON_DECODE_FLAGS = JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE;
+    private const JSON_DECODE_FLAGS = JSON_THROW_ON_ERROR;
     private const JSON_ENCODE_FLAGS = JSON_FORCE_OBJECT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
     private const JSON_MAX_DEPTH = 512;
 
@@ -28,6 +28,7 @@ class Episciences_Paper_Authors_Repository
     {
         $decodedAuthors = [];
 
+        // One row per paper expected; loop processes the single row
         foreach (self::getAuthorByPaperId($paperId) as $row) {
             $decodedAuthors = json_decode($row['authors'], true, self::JSON_MAX_DEPTH, self::JSON_DECODE_FLAGS);
         }
@@ -52,6 +53,7 @@ class Episciences_Paper_Authors_Repository
         }
 
         $decodedAuthors = [];
+        // One row per paper expected; loop processes the single row
         foreach ($authorRows as $row) {
             $decodedAuthors = json_decode($row['authors'], true, self::JSON_MAX_DEPTH, self::JSON_DECODE_FLAGS);
         }

--- a/library/Episciences/Paper/Authors/Repository.php
+++ b/library/Episciences/Paper/Authors/Repository.php
@@ -1,0 +1,200 @@
+<?php
+
+class Episciences_Paper_Authors_Repository
+{
+    private const JSON_DECODE_FLAGS = JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE;
+    private const JSON_ENCODE_FLAGS = JSON_FORCE_OBJECT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+    private const JSON_MAX_DEPTH = 512;
+
+    /**
+     * @param int|string $paperId
+     * @return array raw rows from the paper_authors table
+     */
+    public static function getAuthorByPaperId($paperId): array
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $select = $db->select()->from(T_PAPER_AUTHORS)->where('PAPERID = ?', $paperId);
+        return $db->fetchAssoc($select);
+    }
+
+    /**
+     * Decode the authors JSON for a given paper
+     *
+     * @param int $paperId
+     * @return array decoded authors data
+     * @throws JsonException
+     */
+    public static function getDecodedAuthors(int $paperId): array
+    {
+        $decodedAuthors = [];
+
+        foreach (self::getAuthorByPaperId($paperId) as $row) {
+            $decodedAuthors = json_decode($row['authors'], true, self::JSON_MAX_DEPTH, self::JSON_DECODE_FLAGS);
+        }
+
+        return $decodedAuthors;
+    }
+
+    /**
+     * Find the affiliations of a specific author within a paper
+     *
+     * @param int $paperId
+     * @param int $authorIndex 0-based index of the author in the JSON array
+     * @return array|string affiliations array, or empty string if not found
+     * @throws JsonException
+     */
+    public static function findAffiliationsOneAuthorByPaperId(int $paperId, int $authorIndex): array|string
+    {
+        $authorRows = self::getAuthorByPaperId($paperId);
+
+        if (empty($authorRows)) {
+            return '';
+        }
+
+        $decodedAuthors = [];
+        foreach ($authorRows as $row) {
+            $decodedAuthors = json_decode($row['authors'], true, self::JSON_MAX_DEPTH, self::JSON_DECODE_FLAGS);
+        }
+
+        if (isset($decodedAuthors[$authorIndex]['affiliation'])) {
+            return $decodedAuthors[$authorIndex]['affiliation'];
+        }
+
+        return '';
+    }
+
+    /**
+     * Insert one or more author records
+     *
+     * @param array $authors array of Episciences_Paper_Authors instances or associative arrays
+     * @return int number of affected rows
+     */
+    public static function insert(array $authors): int
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $quotedValues = [];
+        $affectedRows = 0;
+
+        foreach ($authors as $authorData) {
+            if (!($authorData instanceof Episciences_Paper_Authors)) {
+                $authorData = new Episciences_Paper_Authors($authorData);
+            }
+            $quotedValues[] = '(' . $db->quote($authorData->getAuthors()) . ',' . $db->quote($authorData->getPaperId()) . ')';
+        }
+
+        $sql = 'INSERT INTO ' . $db->quoteIdentifier(T_PAPER_AUTHORS) . ' (`authors`,`paperId`) VALUES ';
+
+        if (!empty($quotedValues)) {
+            try {
+                /** @var Zend_Db_Statement_Interface $result */
+                $result = $db->query($sql . implode(', ', $quotedValues));
+                $affectedRows = $result->rowCount();
+            } catch (Exception $e) {
+                trigger_error($e->getMessage(), E_USER_ERROR);
+            }
+        }
+
+        return $affectedRows;
+    }
+
+    /**
+     * Update an existing author record
+     *
+     * @param Episciences_Paper_Authors $authorEntity
+     * @return int number of affected rows
+     */
+    public static function update(Episciences_Paper_Authors $authorEntity): int
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $where = [];
+
+        $authorId = $authorEntity->getAuthorId();
+        if ($authorId !== null) {
+            $where['idauthors = ?'] = $authorId;
+        }
+        $where['paperid = ?'] = $authorEntity->getPaperId();
+
+        $values = [
+            'authors' => $authorEntity->getAuthors()
+        ];
+
+        try {
+            $affectedRows = $db->update(T_PAPER_AUTHORS, $values, $where);
+        } catch (Zend_Db_Adapter_Exception $exception) {
+            $affectedRows = 0;
+            trigger_error($exception->getMessage(), E_USER_ERROR);
+        }
+
+        return $affectedRows;
+    }
+
+    /**
+     * Delete all author records for a given paper
+     *
+     * @param int $paperId
+     * @return bool true if at least one row was deleted
+     */
+    public static function deleteAuthorsByPaperId(int $paperId): bool
+    {
+        if ($paperId < 1) {
+            return false;
+        }
+
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        return ($db->delete(T_PAPER_AUTHORS, ['paperid = ?' => $paperId]) > 0);
+    }
+
+    /**
+     * Copy authors from paper metadata into the authors table
+     *
+     * @param Episciences_Paper $paper
+     * @return int number of inserted rows
+     */
+    public static function insertFromPaper(Episciences_Paper $paper): int
+    {
+        $paperId = $paper->getPaperid();
+
+        if (!empty(self::getAuthorByPaperId($paperId))) {
+            return 0;
+        }
+
+        $metadataAuthors = $paper->getMetadata('authors');
+        $formattedAuthors = [];
+
+        foreach ($metadataAuthors as $rawAuthor) {
+            $fullname = Episciences_Tools::reformatOaiDcAuthor($rawAuthor);
+            $nameParts = explode(', ', $rawAuthor);
+
+            $formattedAuthors[] = [
+                'fullname' => $fullname,
+                'given' => $nameParts[1] ?? null,
+                'family' => $nameParts[0] ?? null
+            ];
+        }
+
+        return self::insert([
+            [
+                'authors' => json_encode($formattedAuthors, self::JSON_ENCODE_FLAGS),
+                'paperId' => $paperId
+            ]
+        ]);
+    }
+
+    /**
+     * Ensure an author record exists for a paper; insert from metadata if missing
+     *
+     * @param int $docId
+     * @param int $paperId
+     * @return void
+     * @throws Zend_Db_Statement_Exception
+     */
+    public static function verifyExistOrInsert(int $docId, int $paperId): void
+    {
+        if (!empty(self::getAuthorByPaperId($paperId))) {
+            return;
+        }
+
+        $paper = Episciences_PapersManager::get($docId, false);
+        self::insertFromPaper($paper);
+    }
+}

--- a/library/Episciences/Paper/Authors/ViewFormatter.php
+++ b/library/Episciences/Paper/Authors/ViewFormatter.php
@@ -39,6 +39,17 @@ class Episciences_Paper_Authors_ViewFormatter
             $decodedAuthors = json_decode($row['authors'], true);
         }
 
+        return self::formatAuthors($decodedAuthors);
+    }
+
+    /**
+     * Format decoded authors array into HTML view components
+     *
+     * @param array $decodedAuthors
+     * @return array{template: string, orcid: string, listAffi: string, authorsList: string}
+     */
+    public static function formatAuthors(array $decodedAuthors): array
+    {
         $templateHtml = '';
         $orcidText = '';
         $authorsList = '';
@@ -208,7 +219,7 @@ class Episciences_Paper_Authors_ViewFormatter
                     . '<a href="' . $affiliationUrl . '" target="_blank">' . $affiliationName;
 
                 if (isset($affiliation[self::KEY_ACRONYM])) {
-                    $html .= ' [' . $affiliation[self::KEY_ACRONYM] . ']';
+                    $html .= ' [' . htmlspecialchars($affiliation[self::KEY_ACRONYM], ENT_QUOTES, 'UTF-8') . ']';
                 }
 
                 $html .= '</a></li>';

--- a/library/Episciences/Paper/Authors/ViewFormatter.php
+++ b/library/Episciences/Paper/Authors/ViewFormatter.php
@@ -1,0 +1,297 @@
+<?php
+
+class Episciences_Paper_Authors_ViewFormatter
+{
+    private const KEY_AFFILIATION = 'affiliation';
+    private const KEY_ORCID = 'orcid';
+    private const KEY_FULLNAME = 'fullname';
+    private const KEY_NAME = 'name';
+    private const KEY_ID = 'id';
+    private const KEY_ID_TYPE = 'id-type';
+    private const KEY_ACRONYM = 'acronym';
+    private const KEY_URL = 'url';
+    private const KEY_TYPE = 'type';
+
+    private const ORCID_BASE_URL = 'https://orcid.org/';
+    private const ORCID_PLACEHOLDER = 'NULL';
+    private const AUTHOR_SEPARATOR = '; ';
+    private const AUTHOR_LIST_SEPARATOR = ';';
+    private const ORCID_SEPARATOR = '##';
+
+    private const RESULT_KEY_TEMPLATE = 'template';
+    private const RESULT_KEY_ORCID = 'orcid';
+    private const RESULT_KEY_LIST_AFFI = 'listAffi';
+    private const RESULT_KEY_AUTHORS_LIST = 'authorsList';
+    private const RESULT_KEY_AFFILIATION_NUMERIC = 'affiliationNumeric';
+    private const RESULT_KEY_AUTHORS = 'authors';
+
+    /**
+     * Build HTML template for author enrichment display (ORCID icons, affiliation superscripts, affiliation list)
+     *
+     * @param int|string $paperId
+     * @return array{template: string, orcid: string, listAffi: string, authorsList: string}
+     */
+    public static function formatAuthorEnrichmentForViewByPaper(int|string $paperId): array
+    {
+        $decodedAuthors = [];
+        foreach (Episciences_Paper_Authors_Repository::getAuthorByPaperId($paperId) as $row) {
+            $decodedAuthors = json_decode($row['authors'], true);
+        }
+
+        $templateHtml = '';
+        $orcidText = '';
+        $authorsList = '';
+        $affiliationListHtml = '';
+
+        if (empty($decodedAuthors)) {
+            return self::buildResult($templateHtml, $orcidText, $affiliationListHtml, $authorsList);
+        }
+
+        $uniqueAffiliations = self::collectUniqueAffiliations($decodedAuthors);
+        $authorCount = count($decodedAuthors);
+
+        foreach ($decodedAuthors as $authorIndex => $author) {
+            $fullname = html_entity_decode(htmlspecialchars($author[self::KEY_FULLNAME]));
+            $authorsList .= $fullname;
+
+            $templateHtml .= self::buildAuthorHtml($author, $fullname);
+            $orcidText .= self::buildOrcidText($author);
+
+            if (array_key_exists(self::KEY_AFFILIATION, $author)) {
+                $templateHtml .= self::buildAffiliationSuperscripts($author[self::KEY_AFFILIATION], $uniqueAffiliations);
+            }
+
+            if ($authorIndex !== $authorCount - 1) {
+                $authorsList .= self::AUTHOR_LIST_SEPARATOR;
+                $templateHtml .= self::AUTHOR_SEPARATOR;
+                $orcidText .= self::ORCID_SEPARATOR;
+            }
+        }
+
+        $affiliationListHtml = self::buildAffiliationListHtml($uniqueAffiliations);
+
+        return self::buildResult($templateHtml, $orcidText, $affiliationListHtml, $authorsList);
+    }
+
+    /**
+     * Collect all unique affiliations from all authors (deduplicated)
+     *
+     * @param array $decodedAuthors all authors with their affiliations
+     * @return array<int, array{affiliation: string, url?: string, acronym?: string}> reindexed unique affiliations
+     */
+    private static function collectUniqueAffiliations(array $decodedAuthors): array
+    {
+        $allAffiliations = [];
+
+        foreach ($decodedAuthors as $author) {
+            if (!array_key_exists(self::KEY_AFFILIATION, $author)) {
+                continue;
+            }
+
+            foreach ($author[self::KEY_AFFILIATION] as $affiliation) {
+                $affiliationEntry = [self::KEY_AFFILIATION => $affiliation[self::KEY_NAME]];
+
+                if (array_key_exists(self::KEY_ID, $affiliation)) {
+                    $affiliationEntry[self::KEY_URL] = $affiliation[self::KEY_ID][0][self::KEY_ID];
+                    if (array_key_exists(self::KEY_ACRONYM, $affiliation[self::KEY_ID][0])) {
+                        $affiliationEntry[self::KEY_ACRONYM] = $affiliation[self::KEY_ID][0][self::KEY_ACRONYM];
+                    }
+                }
+
+                $allAffiliations[] = $affiliationEntry;
+            }
+        }
+
+        $serialized = array_map('serialize', $allAffiliations);
+        $uniqueSerialized = array_unique($serialized);
+
+        return array_values(array_map('unserialize', $uniqueSerialized));
+    }
+
+    /**
+     * Build the HTML for a single author (name + optional ORCID icon)
+     *
+     * @param array $author single author data
+     * @param string $fullname sanitized full name
+     * @return string HTML string
+     */
+    private static function buildAuthorHtml(array $author, string $fullname): string
+    {
+        if (!array_key_exists(self::KEY_ORCID, $author)) {
+            return ' ' . $fullname . ' ';
+        }
+
+        $orcid = htmlspecialchars($author[self::KEY_ORCID]);
+        $orcidUrl = self::ORCID_BASE_URL . $orcid;
+
+        return $fullname
+            . ' <a rel="noopener" href=' . $orcidUrl
+            . ' data-toggle="tooltip" data-placement="bottom" data-original-title=' . $orcid
+            . ' target="_blank">'
+            . '<img srcset="/img/orcid_id.svg" src="/img/ORCID-iD.png" height="16px" alt="ORCID"/></a>';
+    }
+
+    /**
+     * Build the ORCID text token for a single author
+     *
+     * @param array $author single author data
+     * @return string ORCID value or "NULL" placeholder
+     */
+    private static function buildOrcidText(array $author): string
+    {
+        if (array_key_exists(self::KEY_ORCID, $author)) {
+            return htmlspecialchars($author[self::KEY_ORCID]);
+        }
+
+        return self::ORCID_PLACEHOLDER;
+    }
+
+    /**
+     * Build superscript HTML for an author's affiliations (e.g. "<sup>1,</sup><sup>2</sup>")
+     *
+     * @param array $authorAffiliations affiliations of the current author
+     * @param array $uniqueAffiliations global unique affiliation list
+     * @return string HTML superscript string
+     */
+    private static function buildAffiliationSuperscripts(array $authorAffiliations, array $uniqueAffiliations): string
+    {
+        $html = '';
+        $totalAffiliations = count($authorAffiliations);
+        $displayedCount = 0;
+
+        foreach ($authorAffiliations as $authorAffiliation) {
+            foreach ($uniqueAffiliations as $globalIndex => $globalAffiliation) {
+                if (!in_array($globalAffiliation[self::KEY_AFFILIATION], $authorAffiliation, true)) {
+                    continue;
+                }
+
+                $isMatchingUrl = isset($globalAffiliation[self::KEY_URL], $authorAffiliation[self::KEY_ID])
+                    && $globalAffiliation[self::KEY_URL] === $authorAffiliation[self::KEY_ID][0][self::KEY_ID];
+
+                $isMatchingNameOnly = !isset($authorAffiliation[self::KEY_ID]) && !isset($globalAffiliation[self::KEY_URL]);
+
+                if ($isMatchingUrl || $isMatchingNameOnly) {
+                    $superscriptNumber = $globalIndex + 1;
+                    $separator = ($displayedCount === $totalAffiliations - 1) ? '' : ',';
+                    $html .= '<sup>' . $superscriptNumber . $separator . '</sup>';
+                    $displayedCount++;
+                }
+            }
+        }
+
+        return $html;
+    }
+
+    /**
+     * Build the HTML unordered list of all unique affiliations
+     *
+     * @param array $uniqueAffiliations deduplicated affiliation list
+     * @return string HTML <ul> string
+     */
+    private static function buildAffiliationListHtml(array $uniqueAffiliations): string
+    {
+        if (empty($uniqueAffiliations)) {
+            return '';
+        }
+
+        $html = '<ul class="list-unstyled">';
+
+        foreach ($uniqueAffiliations as $index => $affiliation) {
+            $displayNumber = $index + 1;
+            $affiliationName = htmlspecialchars($affiliation[self::KEY_AFFILIATION]);
+
+            if (isset($affiliation[self::KEY_URL])) {
+                $html .= '<li class="affiliation"><span class="label label-default">' . $displayNumber . '</span> '
+                    . '<a href=' . $affiliation[self::KEY_URL] . ' target="_blank">' . $affiliationName;
+
+                if (isset($affiliation[self::KEY_ACRONYM])) {
+                    $html .= ' [' . $affiliation[self::KEY_ACRONYM] . ']';
+                }
+
+                $html .= '</a></li>';
+            } else {
+                $html .= '<li class="affiliation"><span class="label label-default">' . $displayNumber . '</span> '
+                    . $affiliationName . '</li>';
+            }
+        }
+
+        $html .= '</ul>';
+
+        return $html;
+    }
+
+    /**
+     * Build the standard result array
+     *
+     * @param string $templateHtml author template with ORCID and superscripts
+     * @param string $orcidText concatenated ORCID identifiers
+     * @param string $affiliationListHtml HTML list of affiliations
+     * @param string $authorsList plain text author names
+     * @return array{template: string, orcid: string, listAffi: string, authorsList: string}
+     */
+    private static function buildResult(string $templateHtml, string $orcidText, string $affiliationListHtml, string $authorsList): array
+    {
+        return [
+            self::RESULT_KEY_TEMPLATE => $templateHtml,
+            self::RESULT_KEY_ORCID => $orcidText,
+            self::RESULT_KEY_LIST_AFFI => $affiliationListHtml,
+            self::RESULT_KEY_AUTHORS_LIST => $authorsList,
+        ];
+    }
+
+    /**
+     * Build a numbered affiliation index for all authors, using MD5 keys for deduplication
+     *
+     * @param int $paperId
+     * @return array{affiliationNumeric: array, authors: array}
+     * @throws JsonException
+     */
+    public static function filterAuthorsAndAffiNumeric(int $paperId): array
+    {
+        $allAuthors = Episciences_Paper_Authors_Repository::getDecodedAuthors($paperId);
+        $affiliationIndex = [];
+
+        foreach ($allAuthors as $authorKey => $author) {
+            if (!isset($author[self::KEY_AFFILIATION])) {
+                continue;
+            }
+
+            foreach ($author[self::KEY_AFFILIATION] as $affiliation) {
+                $hashSource = $affiliation[self::KEY_NAME];
+
+                if (isset($affiliation[self::KEY_ID])) {
+                    $hashSource .= $affiliation[self::KEY_ID][0][self::KEY_ID] . $affiliation[self::KEY_ID][0][self::KEY_ID_TYPE];
+                }
+
+                $affiliationHash = md5($hashSource);
+
+                if (array_key_exists($affiliationHash, $affiliationIndex)) {
+                    $allAuthors[$authorKey]['idAffi'][$affiliationHash] = $affiliationIndex[$affiliationHash];
+                } else {
+                    $affiliationEntry = [self::KEY_NAME => $affiliation[self::KEY_NAME]];
+
+                    if (isset($affiliation[self::KEY_ID])) {
+                        $affiliationEntry[self::KEY_URL] = $affiliation[self::KEY_ID][0][self::KEY_ID];
+                        $affiliationEntry[self::KEY_TYPE] = $affiliation[self::KEY_ID][0][self::KEY_ID_TYPE];
+
+                        if (array_key_exists(self::KEY_ACRONYM, $affiliation[self::KEY_ID][0])) {
+                            $affiliationEntry[self::KEY_ACRONYM] = $affiliation[self::KEY_ID][0][self::KEY_ACRONYM];
+                        }
+                    }
+
+                    $affiliationIndex[$affiliationHash] = $affiliationEntry;
+                    $allAuthors[$authorKey]['idAffi'][$affiliationHash] = $affiliationEntry;
+                }
+
+                ksort($allAuthors[$authorKey]['idAffi']);
+            }
+        }
+
+        ksort($affiliationIndex);
+
+        return [
+            self::RESULT_KEY_AFFILIATION_NUMERIC => $affiliationIndex,
+            self::RESULT_KEY_AUTHORS => $allAuthors,
+        ];
+    }
+}

--- a/library/Episciences/Paper/Authors/ViewFormatter.php
+++ b/library/Episciences/Paper/Authors/ViewFormatter.php
@@ -34,6 +34,7 @@ class Episciences_Paper_Authors_ViewFormatter
     public static function formatAuthorEnrichmentForViewByPaper(int|string $paperId): array
     {
         $decodedAuthors = [];
+        // One row per paper expected; loop processes the single row
         foreach (Episciences_Paper_Authors_Repository::getAuthorByPaperId($paperId) as $row) {
             $decodedAuthors = json_decode($row['authors'], true);
         }
@@ -51,10 +52,11 @@ class Episciences_Paper_Authors_ViewFormatter
         $authorCount = count($decodedAuthors);
 
         foreach ($decodedAuthors as $authorIndex => $author) {
-            $fullname = html_entity_decode(htmlspecialchars($author[self::KEY_FULLNAME]));
-            $authorsList .= $fullname;
+            $rawFullname = $author[self::KEY_FULLNAME];
+            $escapedFullname = htmlspecialchars($rawFullname, ENT_QUOTES, 'UTF-8');
+            $authorsList .= $rawFullname;
 
-            $templateHtml .= self::buildAuthorHtml($author, $fullname);
+            $templateHtml .= self::buildAuthorHtml($author, $escapedFullname);
             $orcidText .= self::buildOrcidText($author);
 
             if (array_key_exists(self::KEY_AFFILIATION, $author)) {
@@ -121,13 +123,13 @@ class Episciences_Paper_Authors_ViewFormatter
             return ' ' . $fullname . ' ';
         }
 
-        $orcid = htmlspecialchars($author[self::KEY_ORCID]);
-        $orcidUrl = self::ORCID_BASE_URL . $orcid;
+        $orcid = htmlspecialchars($author[self::KEY_ORCID], ENT_QUOTES, 'UTF-8');
+        $orcidUrl = htmlspecialchars(self::ORCID_BASE_URL . $author[self::KEY_ORCID], ENT_QUOTES, 'UTF-8');
 
         return $fullname
-            . ' <a rel="noopener" href=' . $orcidUrl
-            . ' data-toggle="tooltip" data-placement="bottom" data-original-title=' . $orcid
-            . ' target="_blank">'
+            . ' <a rel="noopener" href="' . $orcidUrl
+            . '" data-toggle="tooltip" data-placement="bottom" data-original-title="' . $orcid
+            . '" target="_blank">'
             . '<img srcset="/img/orcid_id.svg" src="/img/ORCID-iD.png" height="16px" alt="ORCID"/></a>';
     }
 
@@ -201,8 +203,9 @@ class Episciences_Paper_Authors_ViewFormatter
             $affiliationName = htmlspecialchars($affiliation[self::KEY_AFFILIATION]);
 
             if (isset($affiliation[self::KEY_URL])) {
+                $affiliationUrl = htmlspecialchars($affiliation[self::KEY_URL], ENT_QUOTES, 'UTF-8');
                 $html .= '<li class="affiliation"><span class="label label-default">' . $displayNumber . '</span> '
-                    . '<a href=' . $affiliation[self::KEY_URL] . ' target="_blank">' . $affiliationName;
+                    . '<a href="' . $affiliationUrl . '" target="_blank">' . $affiliationName;
 
                 if (isset($affiliation[self::KEY_ACRONYM])) {
                     $html .= ' [' . $affiliation[self::KEY_ACRONYM] . ']';

--- a/library/Episciences/Paper/AuthorsManager.php
+++ b/library/Episciences/Paper/AuthorsManager.php
@@ -2,7 +2,8 @@
 
 class Episciences_Paper_AuthorsManager
 {
-    public const ONE_MONTH = 3600 * 24 * 31;
+    /** @deprecated Use Episciences_Hal_TeiCacheManager::ONE_MONTH */
+    public const ONE_MONTH = Episciences_Hal_TeiCacheManager::ONE_MONTH;
 
     // ────────────────────────────────────────────
     // ORCID normalization (stays here, used cross-module)
@@ -10,18 +11,14 @@ class Episciences_Paper_AuthorsManager
 
     /**
      * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
+     *
      * @param string $orcid
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::normalizeOrcid()
      */
     public static function normalizeOrcid(string $orcid): string
     {
-        // Strip URL prefix (https://orcid.org/, http://orcid.org/)
-        $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
-        // Fix lowercase 'x' checksum digit
-        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', $orcid)) {
-            $orcid = substr($orcid, 0, -1) . 'X';
-        }
-        return $orcid;
+        return Episciences_Paper_Authors_HalTeiParser::normalizeOrcid($orcid);
     }
 
     /**
@@ -83,8 +80,7 @@ class Episciences_Paper_AuthorsManager
      */
     public static function getTeiHalByIdentifier(string $identifier, int $version = 0): string
     {
-        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
-        return Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
+        return Episciences_Hal_TeiCacheManager::fetchAndGet($identifier, $version);
     }
 
     /**

--- a/library/Episciences/Paper/AuthorsManager.php
+++ b/library/Episciences/Paper/AuthorsManager.php
@@ -1,182 +1,42 @@
 <?php
 
-use GuzzleHttp\Client as guzzleClient;
-use GuzzleHttp\Exception\GuzzleException;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-
 class Episciences_Paper_AuthorsManager
 {
     public const ONE_MONTH = 3600 * 24 * 31;
 
-    public static function formatAuthorEnrichmentForViewByPaper($paperId): array
+    // ────────────────────────────────────────────
+    // ORCID normalization (stays here, used cross-module)
+    // ────────────────────────────────────────────
+
+    /**
+     * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
+     * @param string $orcid
+     * @return string
+     */
+    public static function normalizeOrcid(string $orcid): string
     {
-        $decodedauthor = [];
-        foreach (self::getAuthorByPaperId($paperId) as $value) {
-            $decodedauthor = json_decode($value['authors'], true);
+        // Strip URL prefix (https://orcid.org/, http://orcid.org/)
+        $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
+        // Fix lowercase 'x' checksum digit
+        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', $orcid)) {
+            $orcid = substr($orcid, 0, -1) . 'X';
         }
-        $templateString = "";
-        $sizeArr = count($decodedauthor);
-        //create TMP text to save orcid for view popup Jquery
-        $orcidText = "";
-        // for display
-        $tmpArrayAffiliation = [];
-        $tmpArrayAfUrl = [];
-        //pre clean affi to avoid duplicate
-        $unUniqueAffi = [];
-        $stringListAffi = '';
-        //authorList we needed it for the select affiliation but can be in case we need all author for other things
-        $authorsList = '';
-        $uniqueAffi = [];
-        if (!empty($decodedauthor)) {
-            foreach ($decodedauthor as $value) {
-                if (array_key_exists('affiliation', $value)) {
-                    $tmpArrayAffiliation[] = $value['affiliation'];
-                }
-            }
-            foreach ($tmpArrayAffiliation as $affiliationInfo) {
-                foreach ($affiliationInfo as $affiliation) {
-                    if (array_key_exists('id', $affiliation)) {
-                        $tmpInfoAffi = ['affiliation' => $affiliation['name'], 'url' => $affiliation['id'][0]['id']];
-                        if (array_key_exists('acronym',$affiliation['id'][0])){
-                            $tmpInfoAffi['acronym'] = $affiliation['id'][0]['acronym'];
-                        }
-                    } else {
-                        $tmpInfoAffi = ['affiliation' => $affiliation['name']];
-                    }
-                    $tmpArrayAfUrl[] = $tmpInfoAffi;
-                }
-            }
-            // make unique array of url and affiliation and reindex it
-            $tmpArrayAfUrl = array_map("unserialize", array_unique(array_map("serialize", $tmpArrayAfUrl)));
-            $i = 0;
-            foreach ($tmpArrayAfUrl as $key => $value) {
-                $uniqueAffi[$i] = $value;
-                $i++;
-            }
-            foreach ($decodedauthor as $key => $value) {
-                $fullname = html_entity_decode(htmlspecialchars($value['fullname']));
-                $authorsList .= $fullname;
-                //search orcid to display logo and url in paper page
-                if (array_key_exists('orcid', $value)) {
-                    $orcid = htmlspecialchars($value['orcid']);
-                    $orcidUrl = "https://orcid.org/" . $orcid;
-                    $templateString .= $fullname . ' <a rel="noopener" href=' . $orcidUrl . ' data-toggle="tooltip" data-placement="bottom" data-original-title=' . $orcid . ' target="_blank">'
-                        . '<img srcset="/img/orcid_id.svg" src="/img/ORCID-iD.png" height="16px" alt="ORCID"/></a>';
-                    $orcidText .= $orcid;
-                } else {
-                    $templateString .= ' ' . $fullname . ' ';
-                    $orcidText .= "NULL";
-                }
-                //search affiliation in author looping
-                if (array_key_exists('affiliation', $value)) {
-                    // count affiliation to display ',' correctly
-                    $counterAffiAuthor = count($value['affiliation']);
-                    $counterDisplayedAffiAuthor = 0;
-                    foreach ($value['affiliation'] as $affiliationAuthor) {
-                        foreach ($uniqueAffi as $keyAffi => $affi) {
-                            // check if affiliation looped exist for the author and url corresponding to the right ROR looped in order to avoid some duplications
-                            // at this point the json in DB is monodimensional so we can point exactly with no other loop
-                            if (in_array($affi['affiliation'], $affiliationAuthor, true)) {
-                                if (array_key_exists('url', $affi) && array_key_exists('id', $affiliationAuthor)) {
-                                    //check if right url to avoid duplicate because we can have same name ROR but not same url
-                                    //case of affiliation finded with url
-                                    if ($affi['url'] === $affiliationAuthor['id'][0]['id']) {
-                                        if ($counterDisplayedAffiAuthor === $counterAffiAuthor - 1) {
-                                            $templateString .= "<sup>" . ($keyAffi + 1) . "</sup>";
-                                        } else {
-                                            $templateString .= "<sup>" . ($keyAffi + 1) . ",</sup>";
-                                        }
-                                        $counterDisplayedAffiAuthor++;
-                                    }
-                                } elseif ((in_array($affi['affiliation'], $affiliationAuthor, true) && !isset($affiliationAuthor['id'])) && !isset($affi['url'])) {
-                                    //this case is for affiliation which have good name but no url ROR
-                                    if ($counterDisplayedAffiAuthor === $counterAffiAuthor - 1) {
-                                        $templateString .= "<sup>" . ($keyAffi + 1) . "</sup>";
-                                    } else {
-                                        $templateString .= "<sup>" . ($keyAffi + 1) . ",</sup>";
-                                    }
-                                    $counterDisplayedAffiAuthor++;
-                                }
-                            }
-                        }
-                    }
-                }
-                if ($key !== $sizeArr - 1) {
-                    $authorsList .= ';';
-                    $templateString .= '; ';
-                    $orcidText .= "##";
-                }
-
-            }
-            //List of affiliation
-
-            $stringListAffi .= '<ul class="list-unstyled">';
-            foreach ($uniqueAffi as $index => $affi) {
-                if (isset($affi['url'])) {
-                    $stringListAffi .= '<li class="affiliation"><span class="label label-default">' . ($index + 1) . '</span> <a href=' . $affi['url'] . ' target="_blank">' . htmlspecialchars($affi['affiliation']);
-                    if (isset($affi['acronym'])){
-                        $stringListAffi .= " [".$affi['acronym']."]";
-                    }
-                    $stringListAffi.= '</a></li>';
-                } else {
-                    $stringListAffi .= '<li class="affiliation"><span class="label label-default">' . ($index + 1) . '</span> ' . htmlspecialchars($affi['affiliation']) . '</li>';
-                }
-            }
-            $stringListAffi .= '</ul>';
-        }
-        return ['template' => $templateString, 'orcid' => $orcidText, 'listAffi' => $stringListAffi, 'authorsList' => $authorsList];
-    }
-
-    public static function getAuthorByPaperId($paperId): array
-    {
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $select = $db->select()->from(T_PAPER_AUTHORS)->where('PAPERID = ?', $paperId); // prevent empty row
-        return $db->fetchAssoc($select);
+        return $orcid;
     }
 
     /**
-     * @param int $paperId
-     * @return array
-     * @throws JsonException
+     * @param string $orcid
+     * @return string
+     * @deprecated Use normalizeOrcid() instead
      */
-    public static function filterAuthorsAndAffiNumeric(int $paperId)
+    public static function cleanLowerCaseOrcid(string $orcid): string
     {
-        $allauthors = self::getArrayAuthorsAffi($paperId);
-        $arrayAllAffi = [];
-        foreach ($allauthors as $key => $author) {
-            if (isset($author['affiliation'])) {
-                foreach ($author['affiliation'] as $affiliation) {
-                    // we need to distinct all affiliations because we can't know which is which even if is the same string affiliation
-                    // it might be not the same affiliation
-                    $md5nameKey = $affiliation['name'];
-                    if (isset($affiliation['id'])) {
-                        $md5nameKey .= $affiliation['id'][0]['id'] . $affiliation['id'][0]['id-type'];
-                    }
-                    if (array_key_exists(md5($md5nameKey), $arrayAllAffi)) {
-                        $allauthors[$key]['idAffi'][md5($md5nameKey)] = $arrayAllAffi[md5($md5nameKey)];
-                    } else {
-                        $arrayAllAffi[md5($md5nameKey)] = [
-                            "name" => $affiliation['name'],
-                        ];
-                        if (isset($affiliation['id'])) {
-                            $arrayAllAffi[array_key_last($arrayAllAffi)]['url'] = $affiliation['id'][0]['id'];
-                            $arrayAllAffi[array_key_last($arrayAllAffi)]['type'] = $affiliation['id'][0]['id-type'];
-                            if (array_key_exists("acronym",$affiliation['id'][0])) {
-                                $arrayAllAffi[array_key_last($arrayAllAffi)]['acronym'] = $affiliation['id'][0]['acronym'];
-                            }
-                        }
-                        $allauthors[$key]['idAffi'][array_key_last($arrayAllAffi)] = $arrayAllAffi[array_key_last($arrayAllAffi)];
-                    }
-                    ksort($allauthors[$key]['idAffi']);
-                }
-            }
-        }
-        ksort($arrayAllAffi);
-        return ['affiliationNumeric' => $arrayAllAffi, 'authors' => $allauthors];
-
+        return self::normalizeOrcid($orcid);
     }
+
+    // ────────────────────────────────────────────
+    // Orchestration methods (delegate to new classes)
+    // ────────────────────────────────────────────
 
     /**
      * @param int $paperId
@@ -185,12 +45,7 @@ class Episciences_Paper_AuthorsManager
      */
     public static function getArrayAuthorsAffi(int $paperId)
     {
-        $decodedauthors = [];
-        foreach (self::getAuthorByPaperId($paperId) as $value) {
-            $decodedauthors = json_decode($value['authors'], true, 512, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
-        }
-
-        return $decodedauthors;
+        return Episciences_Paper_Authors_Repository::getDecodedAuthors($paperId);
     }
 
     /**
@@ -201,161 +56,35 @@ class Episciences_Paper_AuthorsManager
      */
     public static function findAffiliationsOneAuthorByPaperId(int $paperId, int $idAuthorInJson)
     {
-
-        $authors = self::getAuthorByPaperId($paperId);
-        foreach ($authors as $value) {
-            $jsonAuthorDecoded = json_decode($value['authors'], true, 512, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
-        }
-        if (array_key_exists('affiliation', $jsonAuthorDecoded[$idAuthorInJson])) {
-            return $jsonAuthorDecoded[$idAuthorInJson]['affiliation'];
-        }
-        return "";
+        return Episciences_Paper_Authors_Repository::findAffiliationsOneAuthorByPaperId($paperId, $idAuthorInJson);
     }
 
-    /**
-     * Format for the ROR input in paper View
-     * @param array $affiliation
-     * @return array
-     */
-    public static function formatAffiliationForInputRor(array $affiliation)
-    {
-        $affiliationFormatted = [];
-        foreach ($affiliation as $value) {
-            $url = '';
-            $acronym = '';
-            if (array_key_exists('id', $value)) {
-                $url = ' #' . $value['id'][0]['id'];
-                if (array_key_exists('acronym',$value['id'][0])){
-                    $acronym = ' ['.$value['id'][0]['acronym'].']';
-                }
-            }
-            $affiliationFormatted[] = $value['name'] . $acronym . $url;
-        }
-        return $affiliationFormatted;
-    }
-
-    /**
-     * @param int $paperId
-     * @return bool
-     */
-    public static function deleteAuthorsByPaperId(int $paperId)
-    {
-        if ($paperId < 1) {
-            return false;
-        }
-
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        return ($db->delete(T_PAPER_AUTHORS, ['paperid = ?' => $paperId]) > 0);
-    }
-
-    /**
-     * @param string $orcid
-     * @return string
-     */
-    public static function cleanLowerCaseOrcid(string $orcid): string
-    {
-        $orcidReg = '/\d{4}-\d{4}-\d{4}-\d{3}x+$/'; //wrong pattern for orcid
-        preg_match($orcidReg, $orcid, $matches);
-        if (!empty($matches)) {
-            $orcid = str_replace('x', 'X', $orcid);
-        }
-        return $orcid;
-    }
-
-    /**
-     * Try to catch information related to author like ORCID or AFFILIATION structure with or without ROR From HAL TEI when paper is an HAL paper
-     * @param int $repoId
-     * @param int $paperId
-     * @param string $identifier
-     * @param int $version
-     * @return int
-     * @throws JsonException
-     * @throws \Psr\Cache\InvalidArgumentException
-     */
-    public static function enrichAffiOrcidFromTeiHalInDB(int $repoId, int $paperId, string $identifier, int $version): int
-    {
-        if ($repoId === (int)Episciences_Repositories::HAL_REPO_ID) {
-            $decodeAuthor = [];
-            $selectAuthor = self::getAuthorByPaperId($paperId);
-            foreach ($selectAuthor as $authorsDb) {
-                $decodeAuthor = json_decode($authorsDb['authors'], true, 512, JSON_THROW_ON_ERROR);
-            }
-            self::getHalTei($identifier, $version);
-            $cacheTeiHal = self::getHalTeiCache($identifier, $version);
-            if ($cacheTeiHal !== '') {
-                $xmlString = simplexml_load_string($cacheTeiHal);
-                if (is_object($xmlString) && $xmlString->count() > 0) {
-                    $authorTei = self::getAuthorsFromHalTei($xmlString);
-                    $affiInfo = self::getAffiFromHalTei($xmlString);
-                    $authorTei = self::mergeAuthorInfoAndAffiTei($authorTei, $affiInfo);
-                    $FormattedAuthorsForDb = self::mergeInfoDbAndInfoTei($decodeAuthor, $authorTei);
-                    $newAuthorInfos = new Episciences_Paper_Authors();
-                    $newAuthorInfos->setAuthors(json_encode($FormattedAuthorsForDb, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT));
-                    $newAuthorInfos->setPaperId($paperId);
-                    return self::update($newAuthorInfos);
-                }
-            }
-        }
-        return 0;
-    }
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — HAL TEI cache
+    // ────────────────────────────────────────────
 
     /**
      * @param string $identifier
      * @param int $version
      * @return bool
      * @throws \Psr\Cache\InvalidArgumentException
+     * @deprecated Use Episciences_Hal_TeiCacheManager::fetchAndCache()
      */
     public static function getHalTei(string $identifier, int $version = 0): bool
     {
-        $fileTeiHal = $version === 0 ? 'hal-tei-' . $identifier . ".xml" : 'hal-tei-' . $identifier . '-' . $version . ".xml";
-        $cacheTei = new FilesystemAdapter('halTei', self::ONE_MONTH, dirname(APPLICATION_PATH) . '/cache/');
-        $setsGlobalTei = $cacheTei->getItem($fileTeiHal);
-        $setsGlobalTei->expiresAfter(self::ONE_MONTH);
-        if (!$setsGlobalTei->isHit()) {
-            $getTei = self::getTeiHalByIdentifier($identifier, $version);
-            $setsGlobalTei->set($getTei);
-            $cacheTei->save($setsGlobalTei);
-            return true;
-        }
-        return false;
+        return Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
     }
 
     /**
      * @param string $identifier
      * @param int $version
      * @return string
+     * @deprecated Use Episciences_Hal_TeiCacheManager
      */
     public static function getTeiHalByIdentifier(string $identifier, int $version = 0): string
     {
-        $client = new guzzleClient();
-        if ($version === 0){
-            // last version picked
-            $url = "https://api.archives-ouvertes.fr/search/?q=((halId_s:" . $identifier . " OR halIdSameAs_s:" . $identifier . "))&wt=xml-tei";
-
-        } else {
-            $url = "https://api.archives-ouvertes.fr/search/?q=((halId_s:" . $identifier . " OR halIdSameAs_s:" . $identifier . ") AND version_i:" . $version . ")&wt=xml-tei";
-        }
-        $teiHalResp = '';
-        $timeOut = 3;
-        if (PHP_SAPI === 'cli') {
-            $timeOut = 40;
-        }
-        try {
-            return $client->get($url, [
-                'headers' => [
-                    'User-Agent' => 'CCSD Episciences support@episciences.org',
-                    'Content-Type' => 'application/json',
-                    'Accept' => 'application/json'
-                ],
-                'timeout' => $timeOut
-            ])->getBody()->getContents();
-
-        } catch (GuzzleException $e) {
-
-            trigger_error($e->getMessage());
-
-        }
-        return $teiHalResp;
+        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
+        return Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
     }
 
     /**
@@ -363,329 +92,133 @@ class Episciences_Paper_AuthorsManager
      * @param int $version
      * @return string
      * @throws \Psr\Cache\InvalidArgumentException
+     * @deprecated Use Episciences_Hal_TeiCacheManager::getFromCache()
      */
-
     public static function getHalTeiCache(string $identifier, int $version = 0): string
     {
-        $fileTeiHal = $version === 0 ? 'hal-tei-' . $identifier . ".xml" : 'hal-tei-' . $identifier . '-' . $version . ".xml";
-        $cacheTei = new FilesystemAdapter('halTei', self::ONE_MONTH, dirname(APPLICATION_PATH) . '/cache/');
-        $setsGlobalTei = $cacheTei->getItem($fileTeiHal);
-        $setsGlobalTei->expiresAfter(self::ONE_MONTH);
-        if (!$setsGlobalTei->isHit()) {
-            return '';
-        }
-        return $setsGlobalTei->get();
+        return Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
     }
 
-    /**
-     * @param simpleXMLElement $xmlString
-     * @return array
-     */
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — HAL TEI parser
+    // ────────────────────────────────────────────
 
-    public static function getAuthorsFromHalTei(simpleXMLElement $xmlString): array
+    /**
+     * @param SimpleXMLElement $xmlString
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei()
+     */
+    public static function getAuthorsFromHalTei(SimpleXMLElement $xmlString): array
     {
-        if (!isset($xmlString->text->body->listBibl->biblFull->titleStmt->author)) {
-            return [];
-        }
-        $authors = $xmlString->text->body->listBibl->biblFull->titleStmt->author;
-        $globalAuthorArray = [];
-        foreach ($authors as $author) {
-            foreach ($author->persName as $infoName) {
-                //NAME
-                $globalAuthorArray = self::getAuthorInfoFromXmlTei($infoName, $globalAuthorArray);
-            }
-            //AFFI
-            if (isset($author->affiliation)) {
-                $globalAuthorArray = self::getAuthorStructureFromXmlTei($author, $globalAuthorArray);
-            }
-            //ORCID
-            if (isset($author->idno)) {
-                $globalAuthorArray = self::getOrcidAuthorFromXmlTei($author, $globalAuthorArray);
-            }
-        }
-        return $globalAuthorArray;
+        return Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei($xmlString);
     }
 
     /**
      * @param SimpleXMLElement|null $infoName
      * @param array $globalAuthorArray
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorInfoFromXmlTei()
      */
     public static function getAuthorInfoFromXmlTei(?SimpleXMLElement $infoName, array $globalAuthorArray): array
     {
-        $globalAuthorArray[] = [
-            'given_name' => (string)$infoName->forename,
-            'family' => (string)$infoName->surname,
-            'fullname' => rtrim($infoName->forename . " " . $infoName->surname),
-        ];
-        return $globalAuthorArray;
+        return Episciences_Paper_Authors_HalTeiParser::getAuthorInfoFromXmlTei($infoName, $globalAuthorArray);
     }
 
     /**
      * @param SimpleXMLElement|null $author
      * @param array $globalAuthorArray
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorStructureFromXmlTei()
      */
     public static function getAuthorStructureFromXmlTei(?SimpleXMLElement $author, array $globalAuthorArray): array
     {
-        $i = 0;
-        foreach ($author->affiliation as $aff) {
-            $globalAuthorArray[array_key_last($globalAuthorArray)]['affiliations'][$i] = (string)str_replace("#", '', $aff->attributes()->ref);
-            $i++;
-        }
-        return $globalAuthorArray;
+        return Episciences_Paper_Authors_HalTeiParser::getAuthorStructureFromXmlTei($author, $globalAuthorArray);
     }
 
     /**
      * @param SimpleXMLElement|null $author
      * @param array $globalAuthorArray
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getOrcidAuthorFromXmlTei()
      */
     public static function getOrcidAuthorFromXmlTei(?SimpleXMLElement $author, array $globalAuthorArray): array
     {
-        foreach ($author->idno as $idno) {
-            if ((string)$idno->attributes()->type === "ORCID") {
-                $filterOrcid = substr((string)$idno, strrpos((string)$idno, '/') + 1);
-                $filterOrcid = str_replace('/', '', $filterOrcid);
-                $globalAuthorArray[array_key_last($globalAuthorArray)]['orcid'] = trim($filterOrcid);
-            }
-        }
-        return $globalAuthorArray;
+        return Episciences_Paper_Authors_HalTeiParser::getOrcidAuthorFromXmlTei($author, $globalAuthorArray);
     }
 
     /**
-     * @param simpleXMLElement $xmlString
+     * @param SimpleXMLElement $xmlString
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei()
      */
-    public static function getAffiFromHalTei(simpleXMLElement $xmlString): array
+    public static function getAffiFromHalTei(SimpleXMLElement $xmlString): array
     {
-        $back = $xmlString->text->back;
-        $orgInfo = [];
-        if (isset($back->listOrg)) {
-            foreach ($back->listOrg->org as $org) {
-                $orgInfo[(string)$org->attributes('xml', true)[0]]['name'] = trim((string)$org->orgName);
-                $orgHasRor = 0;
-                if ($org->idno) {
-                    foreach ($org->idno as $orgIdno) {
-                        if ((string)$orgIdno->attributes()->type === 'ROR') {
-                            // remove those which have already ror
-                            $orgIdno = str_replace("https://ror.org/","",$orgIdno);
-                            $orgInfo[(string)$org->attributes('xml', true)[0]]['ROR'] = trim("https://ror.org/" . $orgIdno);
-                            $orgHasRor = 1;
-                        }
-                    }
-                }
-                foreach ($org->orgName as $orgName) {
-                    if ($orgHasRor === 1 && (string)$orgName->attributes()->type === 'acronym') {
-                        $orgInfo[(string)$org->attributes('xml', true)[0]]['acronym'] = trim($orgName);
-                    }
-                }
-            }
-        }
-        return $orgInfo;
+        return Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei($xmlString);
     }
 
     /**
      * @param array $authorTei
      * @param array $affiliationTei
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::mergeAuthorInfoAndAffiTei()
      */
     public static function mergeAuthorInfoAndAffiTei(array $authorTei, array $affiliationTei): array
     {
-        foreach ($authorTei as $index => $author) {
-            if (isset($author["affiliations"])) {
-                foreach ($author["affiliations"] as $indexAffi => $affiliationStruct) {
-                    $authorTei[$index]['affiliations'][$indexAffi] = ['name' => $affiliationTei[$affiliationStruct]['name']];
-                    if (array_key_exists('ROR', $affiliationTei[$affiliationStruct])) {
-                        $authorTei[$index]['affiliations'][$indexAffi]['ROR'] = $affiliationTei[$affiliationStruct]['ROR'];
-                    }
-                    if (array_key_exists('acronym', $affiliationTei[$affiliationStruct])){
-                        $authorTei[$index]['affiliations'][$indexAffi]['acronym'] = $affiliationTei[$affiliationStruct]['acronym'];
-                    }
-                }
-            }
-        }
-        return $authorTei;
+        return Episciences_Paper_Authors_HalTeiParser::mergeAuthorInfoAndAffiTei($authorTei, $affiliationTei);
     }
 
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — Repository
+    // ────────────────────────────────────────────
+
     /**
-     * @param array $authorDb
-     * @param array $authorTei
+     * @param int|string $paperId
      * @return array
+     * @deprecated Use Episciences_Paper_Authors_Repository::getAuthorByPaperId()
      */
-    public static function mergeInfoDbAndInfoTei(array $authorDb, array $authorTei): array
+    public static function getAuthorByPaperId($paperId): array
     {
-
-        foreach ($authorDb as $indexAuthor => $authorInfoDb) {
-            foreach ($authorTei as $indexAuthorTei => $authorInfoTei) {
-                if (($authorInfoDb['fullname'] === $authorInfoTei['fullname'])
-                    || (Episciences_Tools::replaceAccents($authorInfoTei['fullname']) === Episciences_Tools::replaceAccents($authorInfoDb['fullname']))) {
-                    if (array_key_exists('orcid', $authorInfoTei) && !array_key_exists('orcid', $authorInfoDb)) {
-                        $authorDb[$indexAuthor]['orcid'] = $authorInfoTei['orcid'];
-                        if (PHP_SAPI === 'cli') {
-                            self::logInfoMessage("Orcid Added for " . $authorDb[$indexAuthor]['fullname']);
-                        }
-                    }
-                    if (array_key_exists('affiliation', $authorInfoDb) && array_key_exists('affiliations', $authorInfoTei)) {
-                        foreach ($authorInfoTei['affiliations'] as $affiliation) {
-                            if (!in_array($affiliation['name'], array_column($authorInfoDb['affiliation'], 'name'), true)) {
-                                if (array_key_exists('ROR', $affiliation)) {
-                                    $authorDb[$indexAuthor]['affiliation'][] = self::putAffiliationWithRORinArray($affiliation);
-                                } else {
-                                    $authorDb[$indexAuthor]['affiliation'][] = self::putOnlyNameAffiliation($affiliation['name']);
-                                }
-                                if (PHP_SAPI === 'cli') {
-                                    self::logInfoMessage("Affiliation Added with ROR for " . $authorDb[$indexAuthor]['fullname']);
-                                }
-                            } elseif (in_array($affiliation['name'], array_column($authorInfoDb['affiliation'], 'name'))
-                                && array_key_exists('ROR', $affiliation)
-                                && self::affiliationRorExistbyAffi($authorInfoDb['affiliation'][key($authorDb[$indexAuthor]['affiliation'])]) === false) {
-                                $affiliationAcronymToInsert = "";
-                                if (array_key_exists('acronym',$affiliation)) {
-                                    $affiliationAcronymToInsert = $affiliation['acronym'];
-                                }
-                                $authorDb[$indexAuthor]['affiliation'][key($authorDb[$indexAuthor]['affiliation'])]['id'] = self::putOnlyRORAffiliation($affiliation['ROR'],$affiliationAcronymToInsert);
-                                if (PHP_SAPI === 'cli') {
-                                    self::logInfoMessage("ROR to Affiliation Added for " . $authorDb[$indexAuthor]['fullname'] . " - " . $affiliation['name']);
-                                }
-                            }
-                        }
-                    } elseif (array_key_exists('affiliations', $authorInfoTei) && !array_key_exists('affiliation', $authorInfoDb)) {
-                        foreach ($authorInfoTei['affiliations'] as $affiliation) {
-                            if (array_key_exists('ROR', $affiliation)) {
-                                $authorDb[$indexAuthor]['affiliation'][] = self::putAffiliationWithRORinArray($affiliation);
-                                if (PHP_SAPI === 'cli') {
-                                    self::logInfoMessage('New Affiliation with ROR Added for ' . $authorDb[$indexAuthor]['fullname'] . " - " . $affiliation['name']);
-                                }
-                            } else {
-                                $authorDb[$indexAuthor]['affiliation'][] = self::putOnlyNameAffiliation($affiliation['name']);
-                                if (PHP_SAPI === 'cli') {
-                                    self::logInfoMessage('New Affiliation without ROR found, Added for ' . $authorDb[$indexAuthor]['fullname'] . " - " . $affiliation['name']);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return $authorDb;
+        return Episciences_Paper_Authors_Repository::getAuthorByPaperId($paperId);
     }
 
     /**
-     * @param string $msg
-     * @return void
-     * @throws Exception
+     * @param array $authors
+     * @return int
+     * @deprecated Use Episciences_Paper_Authors_Repository::insert()
      */
-    public static function logInfoMessage(string $msg): void
+    public static function insert(array $authors): int
     {
-        $logger = new Logger('AuthorsManager');
-        $logger->pushHandler(new StreamHandler(EPISCIENCES_LOG_PATH . 'getcreatordata_' . date('Y-m-d') . '.log', Logger::INFO));
-        $logger->info($msg);
-    }
-
-    /**
-     * @param array $affiliation
-     * @return array
-     */
-    public static function putAffiliationWithRORinArray(array $affiliation): array
-    {
-        $affiliationArray = [
-            "name" => $affiliation['name'],
-            "id" => [
-                [
-                    'id' => $affiliation['ROR'],
-                    'id-type' => 'ROR'
-                ]
-            ]
-        ];
-        if (array_key_exists('acronym',$affiliation)) {
-            $affiliationArray['id'][0]['acronym'] = $affiliation['acronym'];
-        }
-        return $affiliationArray;
-    }
-
-    /**
-     * @param string $name
-     * @return array
-     */
-    public static function putOnlyNameAffiliation(string $name): array
-    {
-        return [
-            "name" => $name
-        ];
-    }
-
-    /**
-     * @param array $affiliationOfAuthor
-     * @return bool
-     */
-    private static function affiliationRorExistbyAffi(array $affiliationOfAuthor): bool
-    {
-        if (isset($affiliationOfAuthor['id'])) {
-            foreach ($affiliationOfAuthor['id'] as $affiliation) {
-                if ($affiliation['id-type'] === "ROR") {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @param string $ror
-     * @param string|null $acronym
-     * @return array[]
-     */
-    public static function putOnlyRORAffiliation(string $ror, ?string $acronym): array
-    {
-        $arrayAffi = [
-            [
-                'id' => $ror,
-                'id-type' => 'ROR'
-            ]
-        ];
-        if ($acronym !== ""){
-            $arrayAffi[0]['acronym'] = $acronym;
-        }
-        return $arrayAffi;
-    }
-
-    /**
-     * @param array $arrayAffi
-     * @param string|null $acronym
-     * @return bool
-     */
-    public static function acronymAlreadyExist(array $arrayAffi, string $acronym): bool
-    {
-        if (isset($arrayAffi[0]['acronym']) && $arrayAffi[0]['acronym'] === $acronym){
-            return true;
-        }
-        return false;
+        return Episciences_Paper_Authors_Repository::insert($authors);
     }
 
     /**
      * @param Episciences_Paper_Authors $authors
      * @return int
+     * @deprecated Use Episciences_Paper_Authors_Repository::update()
      */
     public static function update(Episciences_Paper_Authors $authors): int
     {
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $authorId = $authors->getAuthorId();
-        if ($authorId !== null) {
-            $where['idauthors = ?'] = $authors->getAuthorId();
-        }
-        $where['paperid = ?'] = $authors->getPaperId();
+        return Episciences_Paper_Authors_Repository::update($authors);
+    }
 
-        $values = [
-            'authors' => $authors->getAuthors()
-        ];
-        try {
-            $resUpdate = $db->update(T_PAPER_AUTHORS, $values, $where);
-        } catch (Zend_Db_Adapter_Exception $exception) {
-            $resUpdate = 0;
-            trigger_error($exception->getMessage(), E_USER_ERROR);
-        }
-        return $resUpdate;
+    /**
+     * @param int $paperId
+     * @return bool
+     * @deprecated Use Episciences_Paper_Authors_Repository::deleteAuthorsByPaperId()
+     */
+    public static function deleteAuthorsByPaperId(int $paperId)
+    {
+        return Episciences_Paper_Authors_Repository::deleteAuthorsByPaperId($paperId);
+    }
+
+    /**
+     * @param Episciences_Paper $paper
+     * @return int
+     * @deprecated Use Episciences_Paper_Authors_Repository::insertFromPaper()
+     */
+    public static function InsertAuthorsFromPapers(Episciences_Paper $paper): int
+    {
+        return Episciences_Paper_Authors_Repository::insertFromPaper($paper);
     }
 
     /**
@@ -693,187 +226,195 @@ class Episciences_Paper_AuthorsManager
      * @param int $paperId
      * @return void
      * @throws Zend_Db_Statement_Exception
+     * @deprecated Use Episciences_Paper_Authors_Repository::verifyExistOrInsert()
      */
     public static function verifyExistOrInsert(int $docId, int $paperId): void
     {
-        $author = self::getAuthorByPaperId($paperId);
+        Episciences_Paper_Authors_Repository::verifyExistOrInsert($docId, $paperId);
+    }
 
-        if (empty($author)) {
-            //COPY PASTE AUTHOR FROM PAPER TO AUTHOR
-            $paper = Episciences_PapersManager::get($docId, false);
-            self::InsertAuthorsFromPapers($paper);
-        }
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — Enrichment
+    // ────────────────────────────────────────────
+
+    /**
+     * @param int $repoId
+     * @param int $paperId
+     * @param string $identifier
+     * @param int $version
+     * @return int
+     * @throws JsonException
+     * @throws \Psr\Cache\InvalidArgumentException
+     * @deprecated Use Episciences_Paper_Authors_EnrichmentService::enrichAffiOrcidFromTeiHalInDB()
+     */
+    public static function enrichAffiOrcidFromTeiHalInDB(int $repoId, int $paperId, string $identifier, int $version): int
+    {
+        return Episciences_Paper_Authors_EnrichmentService::enrichAffiOrcidFromTeiHalInDB($repoId, $paperId, $identifier, $version);
     }
 
     /**
-     * @param Episciences_Paper $paper
-     * @return int
+     * @param array $authorDb
+     * @param array $authorTei
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei()
      */
-    public static function InsertAuthorsFromPapers(Episciences_Paper $paper): int
+    public static function mergeInfoDbAndInfoTei(array $authorDb, array $authorTei): array
     {
-        $result = 0;
-        $paperId = $paper->getPaperid();
-        if (empty(self::getAuthorByPaperId($paperId))){
-            $authors = $paper->getMetadata('authors');
-            foreach ($authors as $author) {
-                $authorsFormatted = Episciences_Tools::reformatOaiDcAuthor($author);
-
-                $exploded = explode(', ', $author);
-
-                $arrayAuthors[] = [
-                    'fullname' => $authorsFormatted,
-                    'given' => $exploded[1] ?? null,
-                    'family' => $exploded[0] ?? null
-                ];
-            }
-
-           $result = Episciences_Paper_AuthorsManager::insert([
-                [
-                    'authors' => json_encode($arrayAuthors, JSON_FORCE_OBJECT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
-                    'paperId' => $paperId
-                ]
-            ]);
-            unset($arrayAuthors);
-        }
-
-        return $result;
+        return Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($authorDb, $authorTei);
     }
 
     /**
-     * @param array $authors
-     * @return int
+     * @param string $msg
+     * @return void
+     * @throws Exception
+     * @deprecated Use Episciences_Paper_Authors_EnrichmentService::logInfoMessage()
      */
-
-    public static function insert(array $authors): int
+    public static function logInfoMessage(string $msg): void
     {
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        Episciences_Paper_Authors_EnrichmentService::logInfoMessage($msg);
+    }
 
-        $values = [];
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — View formatter
+    // ────────────────────────────────────────────
 
-        $affectedRows = 0;
+    /**
+     * @param int|string $paperId
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_ViewFormatter::formatAuthorEnrichmentForViewByPaper()
+     */
+    public static function formatAuthorEnrichmentForViewByPaper($paperId): array
+    {
+        return Episciences_Paper_Authors_ViewFormatter::formatAuthorEnrichmentForViewByPaper($paperId);
+    }
 
+    /**
+     * @param int $paperId
+     * @return array
+     * @throws JsonException
+     * @deprecated Use Episciences_Paper_Authors_ViewFormatter::filterAuthorsAndAffiNumeric()
+     */
+    public static function filterAuthorsAndAffiNumeric(int $paperId)
+    {
+        return Episciences_Paper_Authors_ViewFormatter::filterAuthorsAndAffiNumeric($paperId);
+    }
 
-        foreach ($authors as $author) {
+    // ────────────────────────────────────────────
+    // Backward-compatible proxies — Affiliation helper
+    // ────────────────────────────────────────────
 
-            if (!($author instanceof Episciences_Paper_Authors)) {
+    /**
+     * @param array $affiliation
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildWithRor()
+     */
+    public static function putAffiliationWithRORinArray(array $affiliation): array
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::buildWithRor($affiliation);
+    }
 
-                $author = new Episciences_Paper_Authors($author);
-            }
+    /**
+     * @param string $name
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildNameOnly()
+     */
+    public static function putOnlyNameAffiliation(string $name): array
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::buildNameOnly($name);
+    }
 
-            $values[] = '(' . $db->quote($author->getAuthors()) . ',' . $db->quote($author->getPaperId()) . ')';
+    /**
+     * @param string $ror
+     * @param string|null $acronym
+     * @return array[]
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildRorOnly()
+     */
+    public static function putOnlyRORAffiliation(string $ror, ?string $acronym): array
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::buildRorOnly($ror, $acronym);
+    }
 
-        }
+    /**
+     * @param array $arrayAffi
+     * @param string $acronym
+     * @return bool
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::isAcronymDuplicate()
+     */
+    public static function acronymAlreadyExist(array $arrayAffi, string $acronym): bool
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::isAcronymDuplicate($arrayAffi, $acronym);
+    }
 
-        $sql = 'INSERT INTO ' . $db->quoteIdentifier(T_PAPER_AUTHORS) . ' (`authors`,`paperId`) VALUES ';
-
-        if (!empty($values)) {
-
-            try {
-                //Prepares and executes an SQL
-                /** @var Zend_Db_Statement_Interface $result */
-                $result = $db->query($sql . implode(', ', $values));
-
-                $affectedRows = $result->rowCount();
-
-            } catch (Exception $e) {
-                trigger_error($e->getMessage(), E_USER_ERROR);
-            }
-        }
-
-        return $affectedRows;
+    /**
+     * Format for the ROR input in paper View
+     * @param array $affiliation
+     * @return array
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor()
+     */
+    public static function formatAffiliationForInputRor(array $affiliation)
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor($affiliation);
     }
 
     /**
      * @param array $acronyms
      * @param string $haystack
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::setOrUpdateRorAcronym()
      */
     public static function setOrUpdateRorAcronym(array $acronyms, string $haystack): string
     {
-        $strAcronym = '';
-        foreach ($acronyms as $acronym) {
-            if ($acronym !== '' && str_contains($haystack, $acronym)) {
-                $strAcronym = $acronym;
-            }
-        }
-        return $strAcronym;
+        return Episciences_Paper_Authors_AffiliationHelper::setOrUpdateRorAcronym($acronyms, $haystack);
     }
 
     /**
-     * only for export
      * @param string $name
      * @param string $acronym
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::eraseAcronymInName()
      */
-    public static function eraseAcronymInName(string $name,string $acronym): string {
-        $cleanedCompleteNameForExport = str_replace($acronym,"",$name);
-        return rtrim($cleanedCompleteNameForExport);
+    public static function eraseAcronymInName(string $name, string $acronym): string
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::eraseAcronymInName($name, $acronym);
     }
 
     /**
      * @param string $acronym
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::cleanAcronym()
      */
-    public static function cleanAcronym(string $acronym): string {
-        $acronym = trim($acronym);
-        return substr($acronym, 1, -1);
+    public static function cleanAcronym(string $acronym): string
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::cleanAcronym($acronym);
     }
+
     /**
      * @param array $affiliationOfAuthor
      * @return bool
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::hasAcronym()
      */
-    public static function AcronymExist(array $affiliationOfAuthor): bool {
-        if (isset($affiliationOfAuthor['id'])) {
-            foreach ($affiliationOfAuthor['id'] as $key => $affiliation) {
-                if ($key === "acronym") {
-                    return true;
-                }
-            }
-        }
-        return false;
+    public static function AcronymExist(array $affiliationOfAuthor): bool
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::hasAcronym($affiliationOfAuthor);
     }
 
     /**
      * @param array $affiliationDb
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms()
      */
-    public static function getAcronymExisting(array $affiliationDb): string {
-        $acronymList = [];
-        $strAcronymList = '';
-        foreach ($affiliationDb as $affiliation){
-            if (isset($affiliation['id'])) {
-                foreach ($affiliation['id'] as $affiliationInfo) {
-                    if (array_key_exists('acronym',$affiliationInfo)) {
-                        $acronymList[] = $affiliationInfo['acronym'];
-                    }
-                }
-            }
-        }
-        if (!empty($acronymList)){
-            $acronymList = array_unique($acronymList);
-            $acronymList = array_map(static function($value){
-                return "[".$value."]";
-            },$acronymList);
-            $strAcronymList = self::formatAcronymList($acronymList);
-        }
-        return $strAcronymList;
+    public static function getAcronymExisting(array $affiliationDb): string
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms($affiliationDb);
     }
 
     /**
      * @param array $acronymList
      * @return string
+     * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::formatAcronymList()
      */
-    public static function formatAcronymList(array $acronymList): string {
-        $strList = '';
-        $size = sizeof($acronymList);
-        $i = 1;
-        foreach ($acronymList as $value){
-            $strList.= $value;
-            if ($size !== $i){
-                $strList .= '||';
-            }
-            $i++;
-        }
-        return $strList;
+    public static function formatAcronymList(array $acronymList): string
+    {
+        return Episciences_Paper_Authors_AffiliationHelper::formatAcronymList($acronymList);
     }
 }

--- a/library/Episciences/Paper/LicenceManager.php
+++ b/library/Episciences/Paper/LicenceManager.php
@@ -87,8 +87,8 @@ class Episciences_Paper_LicenceManager
      */
     public static function getLicenceFromTeiHal(string $identifier, int $version): string
     {
-        Episciences_Paper_AuthorsManager::getHalTei($identifier, $version);
-        $cacheTeiHal = Episciences_Paper_AuthorsManager::getHalTeiCache($identifier, $version);
+        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
+        $cacheTeiHal = Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
         $xmlString = simplexml_load_string($cacheTeiHal);
         $licence = '';
         if (isset($xmlString->text->body->listBibl->biblFull->publicationStmt->availability->licence, $xmlString->text->body->listBibl->biblFull->publicationStmt->availability->licence->attributes()->target)) {

--- a/library/Episciences/Paper/LicenceManager.php
+++ b/library/Episciences/Paper/LicenceManager.php
@@ -87,8 +87,7 @@ class Episciences_Paper_LicenceManager
      */
     public static function getLicenceFromTeiHal(string $identifier, int $version): string
     {
-        Episciences_Hal_TeiCacheManager::fetchAndCache($identifier, $version);
-        $cacheTeiHal = Episciences_Hal_TeiCacheManager::getFromCache($identifier, $version);
+        $cacheTeiHal = Episciences_Hal_TeiCacheManager::fetchAndGet($identifier, $version);
         $xmlString = simplexml_load_string($cacheTeiHal);
         $licence = '';
         if (isset($xmlString->text->body->listBibl->biblFull->publicationStmt->availability->licence, $xmlString->text->body->listBibl->biblFull->publicationStmt->availability->licence->attributes()->target)) {

--- a/library/Episciences/Repositories/ARCHE/Hooks.php
+++ b/library/Episciences/Repositories/ARCHE/Hooks.php
@@ -245,7 +245,7 @@ class Episciences_Repositories_ARCHE_Hooks implements Episciences_Repositories_H
             $value = (string)$identifier;
 
             if ($scheme === 'ORCID' && !empty($value)) {
-                $tmp['orcid'] = $value;
+                $tmp['orcid'] = Episciences_Paper_AuthorsManager::normalizeOrcid($value);
             } // $scheme === 'ARCHE' is ignored for now
         }
 

--- a/library/Episciences/Repositories/Zenodo/Hooks.php
+++ b/library/Episciences/Repositories/Zenodo/Hooks.php
@@ -445,7 +445,7 @@ class Episciences_Repositories_Zenodo_Hooks implements Episciences_Repositories_
                 $tmp['family'] = isset($explodedName[0]) ? trim($explodedName[0]) : '';
 
                 if (isset($author['orcid']) && $author['orcid'] !== '') {
-                    $tmp['orcid'] = $author['orcid'];
+                    $tmp['orcid'] = Episciences_Paper_AuthorsManager::normalizeOrcid($author['orcid']);
                 }
 
                 if (isset($author['affiliation'])) {

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_AuthorsManagerTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_AuthorsManagerTest.php
@@ -24,6 +24,27 @@ final class Episciences_Paper_AuthorsManagerTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testNormalizeOrcid(): void
+    {
+        // Lowercase x → X
+        self::assertEquals('0000-2222-5555-444X', Episciences_Paper_AuthorsManager::normalizeOrcid('0000-2222-5555-444x'));
+        // Already uppercase X
+        self::assertEquals('0000-2222-5555-444X', Episciences_Paper_AuthorsManager::normalizeOrcid('0000-2222-5555-444X'));
+        // No X digit
+        self::assertEquals('0000-0002-9193-9560', Episciences_Paper_AuthorsManager::normalizeOrcid('0000-0002-9193-9560'));
+        // Strip https URL prefix
+        self::assertEquals('0000-0002-9193-9560', Episciences_Paper_AuthorsManager::normalizeOrcid('https://orcid.org/0000-0002-9193-9560'));
+        // Strip http URL prefix
+        self::assertEquals('0000-0002-9193-9560', Episciences_Paper_AuthorsManager::normalizeOrcid('http://orcid.org/0000-0002-9193-9560'));
+        // Strip URL prefix + fix lowercase x
+        self::assertEquals('0000-2222-5555-444X', Episciences_Paper_AuthorsManager::normalizeOrcid('https://orcid.org/0000-2222-5555-444x'));
+        // Whitespace trimming
+        self::assertEquals('0000-0002-9193-9560', Episciences_Paper_AuthorsManager::normalizeOrcid('  0000-0002-9193-9560  '));
+    }
+
+    /**
      * @dataProvider sampleTeiAuthor
      */
     public function testFormatNameAuthorFromTei(iterable $sampleTeiAuthor): void

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_AffiliationHelperTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_AffiliationHelperTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Paper_Authors_AffiliationHelper;
+use PHPUnit\Framework\TestCase;
+
+final class Episciences_Paper_Authors_AffiliationHelperTest extends TestCase
+{
+    public function testBuildWithRorWithAcronym(): void
+    {
+        $input = [
+            'name' => 'Centre National de la Recherche Scientifique',
+            'ROR' => 'https://ror.org/02feahw73',
+            'acronym' => 'CNRS',
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildWithRor($input);
+
+        self::assertEquals('Centre National de la Recherche Scientifique', $result['name']);
+        self::assertArrayHasKey('id', $result);
+        self::assertCount(1, $result['id']);
+        self::assertEquals('https://ror.org/02feahw73', $result['id'][0]['id']);
+        self::assertEquals('ROR', $result['id'][0]['id-type']);
+        self::assertEquals('CNRS', $result['id'][0]['acronym']);
+    }
+
+    public function testBuildWithRorWithoutAcronym(): void
+    {
+        $input = [
+            'name' => 'Université de Paris',
+            'ROR' => 'https://ror.org/05f82e368',
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildWithRor($input);
+
+        self::assertEquals('Université de Paris', $result['name']);
+        self::assertEquals('https://ror.org/05f82e368', $result['id'][0]['id']);
+        self::assertEquals('ROR', $result['id'][0]['id-type']);
+        self::assertArrayNotHasKey('acronym', $result['id'][0]);
+    }
+
+    public function testBuildNameOnly(): void
+    {
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildNameOnly('Some University');
+
+        self::assertEquals(['name' => 'Some University'], $result);
+    }
+
+    public function testBuildRorOnlyWithAcronym(): void
+    {
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildRorOnly('https://ror.org/02feahw73', 'CNRS');
+
+        self::assertCount(1, $result);
+        self::assertEquals('https://ror.org/02feahw73', $result[0]['id']);
+        self::assertEquals('ROR', $result[0]['id-type']);
+        self::assertEquals('CNRS', $result[0]['acronym']);
+    }
+
+    public function testBuildRorOnlyWithoutAcronym(): void
+    {
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildRorOnly('https://ror.org/02feahw73', '');
+
+        self::assertCount(1, $result);
+        self::assertEquals('https://ror.org/02feahw73', $result[0]['id']);
+        self::assertEquals('ROR', $result[0]['id-type']);
+        self::assertArrayNotHasKey('acronym', $result[0]);
+    }
+
+    public function testBuildRorOnlyWithNullAcronym(): void
+    {
+        $result = Episciences_Paper_Authors_AffiliationHelper::buildRorOnly('https://ror.org/02feahw73', null);
+
+        self::assertArrayNotHasKey('acronym', $result[0]);
+    }
+
+    public function testHasRorReturnsTrueWhenPresent(): void
+    {
+        $affiliation = [
+            'name' => 'CNRS',
+            'id' => [
+                ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR']
+            ]
+        ];
+
+        self::assertTrue(Episciences_Paper_Authors_AffiliationHelper::hasRor($affiliation));
+    }
+
+    public function testHasRorReturnsFalseWhenMissing(): void
+    {
+        $affiliation = ['name' => 'Some Lab'];
+
+        self::assertFalse(Episciences_Paper_Authors_AffiliationHelper::hasRor($affiliation));
+    }
+
+    public function testHasRorReturnsFalseForNonRorIdentifier(): void
+    {
+        $affiliation = [
+            'name' => 'Some Lab',
+            'id' => [
+                ['id' => 'https://isni.org/isni/0000000121663029', 'id-type' => 'ISNI']
+            ]
+        ];
+
+        self::assertFalse(Episciences_Paper_Authors_AffiliationHelper::hasRor($affiliation));
+    }
+
+    public function testHasAcronymReturnsTrueWhenPresent(): void
+    {
+        $affiliation = [
+            'name' => 'CNRS',
+            'id' => [
+                ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']
+            ]
+        ];
+
+        self::assertTrue(Episciences_Paper_Authors_AffiliationHelper::hasAcronym($affiliation));
+    }
+
+    public function testHasAcronymReturnsFalseWhenMissing(): void
+    {
+        $affiliation = [
+            'name' => 'Some Lab',
+            'id' => [
+                ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR']
+            ]
+        ];
+
+        self::assertFalse(Episciences_Paper_Authors_AffiliationHelper::hasAcronym($affiliation));
+    }
+
+    public function testIsAcronymDuplicateReturnsTrue(): void
+    {
+        $identifiers = [
+            ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']
+        ];
+
+        self::assertTrue(Episciences_Paper_Authors_AffiliationHelper::isAcronymDuplicate($identifiers, 'CNRS'));
+    }
+
+    public function testIsAcronymDuplicateReturnsFalse(): void
+    {
+        $identifiers = [
+            ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']
+        ];
+
+        self::assertFalse(Episciences_Paper_Authors_AffiliationHelper::isAcronymDuplicate($identifiers, 'INRIA'));
+    }
+
+    public function testGetExistingAcronymsWithMultiple(): void
+    {
+        $affiliations = [
+            [
+                'name' => 'CNRS',
+                'id' => [['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']]
+            ],
+            [
+                'name' => 'INRIA',
+                'id' => [['id' => 'https://ror.org/02vjkv261', 'id-type' => 'ROR', 'acronym' => 'INRIA']]
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms($affiliations);
+
+        self::assertEquals('[CNRS]||[INRIA]', $result);
+    }
+
+    public function testGetExistingAcronymsEmpty(): void
+    {
+        $affiliations = [
+            ['name' => 'Some Lab'],
+        ];
+
+        self::assertEquals('', Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms($affiliations));
+    }
+
+    public function testGetExistingAcronymsDeduplicates(): void
+    {
+        $affiliations = [
+            [
+                'name' => 'CNRS Lab 1',
+                'id' => [['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']]
+            ],
+            [
+                'name' => 'CNRS Lab 2',
+                'id' => [['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']]
+            ],
+        ];
+
+        self::assertEquals('[CNRS]', Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms($affiliations));
+    }
+
+    public function testFormatAcronymList(): void
+    {
+        self::assertEquals('[A]||[B]||[C]', Episciences_Paper_Authors_AffiliationHelper::formatAcronymList(['[A]', '[B]', '[C]']));
+    }
+
+    public function testSetOrUpdateRorAcronymFindsMatch(): void
+    {
+        $acronyms = ['CNRS', 'INRIA'];
+        $haystack = 'Centre National de la Recherche Scientifique CNRS Paris';
+
+        self::assertEquals('CNRS', Episciences_Paper_Authors_AffiliationHelper::setOrUpdateRorAcronym($acronyms, $haystack));
+    }
+
+    public function testSetOrUpdateRorAcronymNoMatch(): void
+    {
+        $acronyms = ['INRIA', 'INSERM'];
+        $haystack = 'Some random university name';
+
+        self::assertEquals('', Episciences_Paper_Authors_AffiliationHelper::setOrUpdateRorAcronym($acronyms, $haystack));
+    }
+
+    public function testEraseAcronymInName(): void
+    {
+        $result = Episciences_Paper_Authors_AffiliationHelper::eraseAcronymInName('CNRS - Paris [CNRS]', '[CNRS]');
+
+        self::assertEquals('CNRS - Paris', $result);
+    }
+
+    public function testCleanAcronym(): void
+    {
+        self::assertEquals('CNRS', Episciences_Paper_Authors_AffiliationHelper::cleanAcronym('[CNRS]'));
+        self::assertEquals('INRIA', Episciences_Paper_Authors_AffiliationHelper::cleanAcronym(' [INRIA] '));
+    }
+
+    public function testFormatAffiliationForInputRorWithRorAndAcronym(): void
+    {
+        $affiliations = [
+            [
+                'name' => 'Centre National de la Recherche Scientifique',
+                'id' => [
+                    ['id' => 'https://ror.org/02feahw73', 'id-type' => 'ROR', 'acronym' => 'CNRS']
+                ]
+            ]
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor($affiliations);
+
+        self::assertCount(1, $result);
+        self::assertEquals(
+            'Centre National de la Recherche Scientifique [CNRS] #https://ror.org/02feahw73',
+            $result[0]
+        );
+    }
+
+    public function testFormatAffiliationForInputRorWithRorNoAcronym(): void
+    {
+        $affiliations = [
+            [
+                'name' => 'Université de Paris',
+                'id' => [
+                    ['id' => 'https://ror.org/05f82e368', 'id-type' => 'ROR']
+                ]
+            ]
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor($affiliations);
+
+        self::assertEquals('Université de Paris #https://ror.org/05f82e368', $result[0]);
+    }
+
+    public function testFormatAffiliationForInputRorNameOnly(): void
+    {
+        $affiliations = [
+            ['name' => 'Some Lab']
+        ];
+
+        $result = Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor($affiliations);
+
+        self::assertEquals('Some Lab', $result[0]);
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_EnrichmentServiceTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_EnrichmentServiceTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Paper_Authors_EnrichmentService;
+use PHPUnit\Framework\TestCase;
+
+final class Episciences_Paper_Authors_EnrichmentServiceTest extends TestCase
+{
+    /**
+     * ORCID should be added from TEI when DB author has none
+     */
+    public function testMergeAddsOrcidWhenMissing(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'John Doe', 'given' => 'John', 'family' => 'Doe'],
+        ];
+
+        $teiAuthors = [
+            ['fullname' => 'John Doe', 'given_name' => 'John', 'family' => 'Doe', 'orcid' => '0000-0001-2345-6789'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertArrayHasKey('orcid', $result[0]);
+        self::assertEquals('0000-0001-2345-6789', $result[0]['orcid']);
+    }
+
+    /**
+     * ORCID should NOT be overwritten when DB author already has one
+     */
+    public function testMergeDoesNotOverwriteExistingOrcid(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'John Doe', 'given' => 'John', 'family' => 'Doe', 'orcid' => '0000-0001-1111-1111'],
+        ];
+
+        $teiAuthors = [
+            ['fullname' => 'John Doe', 'given_name' => 'John', 'family' => 'Doe', 'orcid' => '0000-0001-2222-2222'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertEquals('0000-0001-1111-1111', $result[0]['orcid']);
+    }
+
+    /**
+     * Affiliation with ROR should be added when DB author has no affiliations
+     */
+    public function testMergeAddsNewAffiliationWithRor(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'Jane Smith', 'given' => 'Jane', 'family' => 'Smith'],
+        ];
+
+        $teiAuthors = [
+            [
+                'fullname' => 'Jane Smith',
+                'given_name' => 'Jane',
+                'family' => 'Smith',
+                'affiliations' => [
+                    ['name' => 'CNRS', 'ROR' => 'https://ror.org/02feahw73', 'acronym' => 'CNRS'],
+                ],
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertArrayHasKey('affiliation', $result[0]);
+        self::assertCount(1, $result[0]['affiliation']);
+        self::assertEquals('CNRS', $result[0]['affiliation'][0]['name']);
+        self::assertArrayHasKey('id', $result[0]['affiliation'][0]);
+        self::assertEquals('https://ror.org/02feahw73', $result[0]['affiliation'][0]['id'][0]['id']);
+        self::assertEquals('ROR', $result[0]['affiliation'][0]['id'][0]['id-type']);
+    }
+
+    /**
+     * Affiliation without ROR should be added as name-only
+     */
+    public function testMergeAddsNewAffiliationWithoutRor(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'Jane Smith', 'given' => 'Jane', 'family' => 'Smith'],
+        ];
+
+        $teiAuthors = [
+            [
+                'fullname' => 'Jane Smith',
+                'given_name' => 'Jane',
+                'family' => 'Smith',
+                'affiliations' => [
+                    ['name' => 'Some University'],
+                ],
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertArrayHasKey('affiliation', $result[0]);
+        self::assertEquals('Some University', $result[0]['affiliation'][0]['name']);
+        self::assertArrayNotHasKey('id', $result[0]['affiliation'][0]);
+    }
+
+    /**
+     * Non-matching authors should not be enriched
+     */
+    public function testMergeDoesNotEnrichNonMatchingAuthors(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'Alice Martin', 'given' => 'Alice', 'family' => 'Martin'],
+        ];
+
+        $teiAuthors = [
+            ['fullname' => 'Bob Dupont', 'given_name' => 'Bob', 'family' => 'Dupont', 'orcid' => '0000-0001-9999-9999'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertArrayNotHasKey('orcid', $result[0]);
+        self::assertArrayNotHasKey('affiliation', $result[0]);
+    }
+
+    /**
+     * Accent-insensitive name matching should work (e.g. é vs e)
+     */
+    public function testMergeMatchesAccentInsensitiveNames(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'Hélène Müller', 'given' => 'Hélène', 'family' => 'Müller'],
+        ];
+
+        $teiAuthors = [
+            ['fullname' => 'Helene Muller', 'given_name' => 'Helene', 'family' => 'Muller', 'orcid' => '0000-0003-1111-2222'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertArrayHasKey('orcid', $result[0]);
+        self::assertEquals('0000-0003-1111-2222', $result[0]['orcid']);
+    }
+
+    /**
+     * An already-existing affiliation should not be duplicated
+     */
+    public function testMergeDoesNotDuplicateExistingAffiliation(): void
+    {
+        $dbAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given' => 'John',
+                'family' => 'Doe',
+                'affiliation' => [
+                    ['name' => 'Existing Lab'],
+                ],
+            ],
+        ];
+
+        $teiAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given_name' => 'John',
+                'family' => 'Doe',
+                'affiliations' => [
+                    ['name' => 'Existing Lab'],
+                ],
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertCount(1, $result[0]['affiliation']);
+    }
+
+    /**
+     * A new affiliation should be appended alongside existing ones
+     */
+    public function testMergeAppendsNewAffiliationToExisting(): void
+    {
+        $dbAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given' => 'John',
+                'family' => 'Doe',
+                'affiliation' => [
+                    ['name' => 'Lab Alpha'],
+                ],
+            ],
+        ];
+
+        $teiAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given_name' => 'John',
+                'family' => 'Doe',
+                'affiliations' => [
+                    ['name' => 'Lab Beta', 'ROR' => 'https://ror.org/00000001'],
+                ],
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertCount(2, $result[0]['affiliation']);
+        self::assertEquals('Lab Alpha', $result[0]['affiliation'][0]['name']);
+        self::assertEquals('Lab Beta', $result[0]['affiliation'][1]['name']);
+    }
+
+    /**
+     * Empty TEI authors array should return DB authors unchanged
+     */
+    public function testMergeWithEmptyTeiReturnsDbUnchanged(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'John Doe', 'given' => 'John', 'family' => 'Doe'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, []);
+
+        self::assertEquals($dbAuthors, $result);
+    }
+
+    /**
+     * Empty DB authors array should return empty
+     */
+    public function testMergeWithEmptyDbReturnsEmpty(): void
+    {
+        $teiAuthors = [
+            ['fullname' => 'John Doe', 'given_name' => 'John', 'family' => 'Doe', 'orcid' => '0000-0001-0000-0000'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei([], $teiAuthors);
+
+        self::assertEmpty($result);
+    }
+
+    /**
+     * ROR should be added to an existing affiliation that lacks one
+     */
+    public function testMergeAddsRorToExistingAffiliationWithoutRor(): void
+    {
+        $dbAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given' => 'John',
+                'family' => 'Doe',
+                'affiliation' => [
+                    ['name' => 'CNRS'],
+                ],
+            ],
+        ];
+
+        $teiAuthors = [
+            [
+                'fullname' => 'John Doe',
+                'given_name' => 'John',
+                'family' => 'Doe',
+                'affiliations' => [
+                    ['name' => 'CNRS', 'ROR' => 'https://ror.org/02feahw73', 'acronym' => 'CNRS'],
+                ],
+            ],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertCount(1, $result[0]['affiliation']);
+        self::assertArrayHasKey('id', $result[0]['affiliation'][0]);
+        self::assertEquals('https://ror.org/02feahw73', $result[0]['affiliation'][0]['id'][0]['id']);
+    }
+
+    /**
+     * Multiple authors should be enriched independently
+     */
+    public function testMergeEnrichesMultipleAuthorsIndependently(): void
+    {
+        $dbAuthors = [
+            ['fullname' => 'Alice Martin', 'given' => 'Alice', 'family' => 'Martin'],
+            ['fullname' => 'Bob Dupont', 'given' => 'Bob', 'family' => 'Dupont'],
+        ];
+
+        $teiAuthors = [
+            ['fullname' => 'Alice Martin', 'given_name' => 'Alice', 'family' => 'Martin', 'orcid' => '0000-0001-1111-1111'],
+            ['fullname' => 'Bob Dupont', 'given_name' => 'Bob', 'family' => 'Dupont', 'orcid' => '0000-0002-2222-2222'],
+        ];
+
+        $result = Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei($dbAuthors, $teiAuthors);
+
+        self::assertEquals('0000-0001-1111-1111', $result[0]['orcid']);
+        self::assertEquals('0000-0002-2222-2222', $result[1]['orcid']);
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_HalTeiParserTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_HalTeiParserTest.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Paper_Authors_HalTeiParser;
+use PHPUnit\Framework\TestCase;
+
+final class Episciences_Paper_Authors_HalTeiParserTest extends TestCase
+{
+    const DATA_DIR = '/data/';
+
+    /**
+     * Verify basic author name extraction from a TEI persName element
+     */
+    public function testGetAuthorInfoFromXmlTei(): void
+    {
+        $personName = simplexml_load_string(
+            '<persName>
+                <forename type="first">Marie</forename>
+                <surname>Curie</surname>
+            </persName>'
+        );
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAuthorInfoFromXmlTei($personName, []);
+
+        self::assertCount(1, $result);
+        self::assertEquals('Marie', $result[0]['given_name']);
+        self::assertEquals('Curie', $result[0]['family']);
+        self::assertEquals('Marie Curie', $result[0]['fullname']);
+    }
+
+    /**
+     * Verify multiple affiliations are extracted with numeric indices (bug fix regression test)
+     *
+     * This specifically tests the SimpleXML foreach fix: affiliations must be
+     * stored with numeric array indices (0, 1, 2...), not the XML element name
+     * string "affiliation" which would cause all entries to overwrite each other.
+     */
+    public function testGetAuthorStructureFromXmlTeiMultipleAffiliations(): void
+    {
+        $authorNode = simplexml_load_string(
+            '<author role="aut">
+                <persName>
+                    <forename type="first">Marie</forename>
+                    <surname>Curie</surname>
+                </persName>
+                <affiliation ref="#struct-111"/>
+                <affiliation ref="#struct-222"/>
+                <affiliation ref="#struct-333"/>
+            </author>'
+        );
+
+        $existingAuthors = [
+            ['given_name' => 'Marie', 'family' => 'Curie', 'fullname' => 'Marie Curie']
+        ];
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAuthorStructureFromXmlTei($authorNode, $existingAuthors);
+
+        self::assertArrayHasKey('affiliations', $result[0]);
+        self::assertCount(3, $result[0]['affiliations']);
+        self::assertEquals('struct-111', $result[0]['affiliations'][0]);
+        self::assertEquals('struct-222', $result[0]['affiliations'][1]);
+        self::assertEquals('struct-333', $result[0]['affiliations'][2]);
+    }
+
+    /**
+     * Verify single affiliation also works correctly
+     */
+    public function testGetAuthorStructureFromXmlTeiSingleAffiliation(): void
+    {
+        $authorNode = simplexml_load_string(
+            '<author role="aut">
+                <persName>
+                    <forename type="first">Albert</forename>
+                    <surname>Einstein</surname>
+                </persName>
+                <affiliation ref="#struct-999"/>
+            </author>'
+        );
+
+        $existingAuthors = [
+            ['given_name' => 'Albert', 'family' => 'Einstein', 'fullname' => 'Albert Einstein']
+        ];
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAuthorStructureFromXmlTei($authorNode, $existingAuthors);
+
+        self::assertCount(1, $result[0]['affiliations']);
+        self::assertEquals('struct-999', $result[0]['affiliations'][0]);
+    }
+
+    /**
+     * Verify ORCID extraction from TEI with URL prefix stripping
+     */
+    public function testGetOrcidAuthorFromXmlTeiStripsUrl(): void
+    {
+        $authorNode = simplexml_load_string(
+            '<author role="aut">
+                <persName>
+                    <forename type="first">Marie</forename>
+                    <surname>Curie</surname>
+                </persName>
+                <idno type="ORCID">https://orcid.org/0000-0001-2345-678X</idno>
+            </author>'
+        );
+
+        $existingAuthors = [
+            ['given_name' => 'Marie', 'family' => 'Curie', 'fullname' => 'Marie Curie']
+        ];
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getOrcidAuthorFromXmlTei($authorNode, $existingAuthors);
+
+        self::assertArrayHasKey('orcid', $result[0]);
+        self::assertEquals('0000-0001-2345-678X', $result[0]['orcid']);
+    }
+
+    /**
+     * Verify ORCID with lowercase x is normalized to uppercase X
+     */
+    public function testGetOrcidAuthorFromXmlTeiNormalizesLowercaseX(): void
+    {
+        $authorNode = simplexml_load_string(
+            '<author role="aut">
+                <persName>
+                    <forename type="first">John</forename>
+                    <surname>Doe</surname>
+                </persName>
+                <idno type="ORCID">https://orcid.org/0000-0001-2345-678x</idno>
+            </author>'
+        );
+
+        $existingAuthors = [
+            ['given_name' => 'John', 'family' => 'Doe', 'fullname' => 'John Doe']
+        ];
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getOrcidAuthorFromXmlTei($authorNode, $existingAuthors);
+
+        self::assertEquals('0000-0001-2345-678X', $result[0]['orcid']);
+    }
+
+    /**
+     * Verify affiliation details are extracted from TEI back/listOrg section
+     */
+    public function testGetAffiFromHalTeiExtractsOrganizations(): void
+    {
+        $tei = simplexml_load_file(__DIR__ . self::DATA_DIR . 'halTeiWithSeveralsAuthorsProvider.xml');
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei($tei);
+
+        self::assertIsArray($result);
+        self::assertCount(21, $result);
+        self::assertArrayHasKey('struct-7127', $result);
+        self::assertEquals('Université de Caen Normandie', $result['struct-7127']['name']);
+        self::assertEquals('https://ror.org/051kpcy16', $result['struct-7127']['ROR']);
+    }
+
+    /**
+     * Verify empty TEI returns empty array for affiliations
+     */
+    public function testGetAffiFromHalTeiEmptyDocument(): void
+    {
+        $tei = simplexml_load_file(__DIR__ . self::DATA_DIR . 'halTeiEmptyProvider.xml');
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei($tei);
+
+        self::assertEmpty($result);
+    }
+
+    /**
+     * Verify mergeAuthorInfoAndAffiTei replaces struct IDs with actual organization info
+     */
+    public function testMergeAuthorInfoAndAffiTeiResolvesStructRefs(): void
+    {
+        $authors = [
+            [
+                'given_name' => 'Marie',
+                'family' => 'Curie',
+                'fullname' => 'Marie Curie',
+                'affiliations' => ['struct-100', 'struct-200'],
+            ],
+            [
+                'given_name' => 'Albert',
+                'family' => 'Einstein',
+                'fullname' => 'Albert Einstein',
+            ],
+        ];
+
+        $affiliations = [
+            'struct-100' => ['name' => 'Sorbonne', 'ROR' => 'https://ror.org/0000001', 'acronym' => 'SU'],
+            'struct-200' => ['name' => 'CNRS'],
+        ];
+
+        $result = Episciences_Paper_Authors_HalTeiParser::mergeAuthorInfoAndAffiTei($authors, $affiliations);
+
+        // First author has resolved affiliations
+        self::assertCount(2, $result[0]['affiliations']);
+        self::assertEquals('Sorbonne', $result[0]['affiliations'][0]['name']);
+        self::assertEquals('https://ror.org/0000001', $result[0]['affiliations'][0]['ROR']);
+        self::assertEquals('SU', $result[0]['affiliations'][0]['acronym']);
+        self::assertEquals('CNRS', $result[0]['affiliations'][1]['name']);
+        self::assertArrayNotHasKey('ROR', $result[0]['affiliations'][1]);
+
+        // Second author has no affiliations key
+        self::assertArrayNotHasKey('affiliations', $result[1]);
+    }
+
+    /**
+     * Verify full pipeline: getAuthorsFromHalTei extracts and produces correct structure
+     */
+    public function testGetAuthorsFromHalTeiFullPipeline(): void
+    {
+        $tei = simplexml_load_file(__DIR__ . self::DATA_DIR . 'halTeiProvider.xml');
+
+        $authors = Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei($tei);
+
+        self::assertNotEmpty($authors);
+        self::assertEquals('Don', $authors[0]['given_name']);
+        self::assertEquals('Zagier', $authors[0]['family']);
+        self::assertEquals('Don Zagier', $authors[0]['fullname']);
+        self::assertArrayHasKey('affiliations', $authors[0]);
+        // Regression test: affiliations must be numerically indexed
+        self::assertEquals('struct-426005', $authors[0]['affiliations'][0]);
+        self::assertArrayHasKey('orcid', $authors[0]);
+        self::assertEquals('0000-0004-8099-840X', $authors[0]['orcid']);
+    }
+
+    /**
+     * Verify empty TEI returns empty array
+     */
+    public function testGetAuthorsFromHalTeiReturnsEmptyForEmptyDoc(): void
+    {
+        $tei = simplexml_load_file(__DIR__ . self::DATA_DIR . 'halTeiEmptyProvider.xml');
+
+        $result = Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei($tei);
+
+        self::assertEmpty($result);
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_ViewFormatterTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Authors_ViewFormatterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Paper_Authors_ViewFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class Episciences_Paper_Authors_ViewFormatterTest extends TestCase
+{
+    public function testFormatAuthorsWithFullData(): void
+    {
+        $authors = [
+            [
+                'fullname' => 'John Doe',
+                'orcid' => '0000-0001-2345-678X',
+                'affiliation' => [
+                    ['name' => 'University A', 'id' => [['id' => 'https://ror.org/1', 'id-type' => 'ROR']]]
+                ]
+            ],
+            [
+                'fullname' => 'Jane Smith',
+                'affiliation' => [
+                    ['name' => 'University A', 'id' => [['id' => 'https://ror.org/1', 'id-type' => 'ROR']]],
+                    ['name' => 'University B']
+                ]
+            ]
+        ];
+
+        $result = Episciences_Paper_Authors_ViewFormatter::formatAuthors($authors);
+
+        // Check author list text
+        self::assertEquals('John Doe;Jane Smith', $result['authorsList']);
+
+        // Check ORCID text
+        self::assertEquals('0000-0001-2345-678X##NULL', $result['orcid']);
+
+        // Check Affiliation List HTML
+        $this->assertStringContainsString('University A', $result['listAffi']);
+        $this->assertStringContainsString('University B', $result['listAffi']);
+        // Verify deduplication (University A should appear once in list)
+        self::assertEquals(1, substr_count($result['listAffi'], 'University A'));
+    }
+
+    public function testFormatAuthorsEscapesXssInAcronym(): void
+    {
+        $authors = [
+            [
+                'fullname' => 'Hacker',
+                'affiliation' => [
+                    [
+                        'name' => 'Evil Corp',
+                        'id' => [
+                            [
+                                'id' => 'https://ror.org/evil',
+                                'id-type' => 'ROR',
+                                'acronym' => '<script>alert(1)</script>'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $result = Episciences_Paper_Authors_ViewFormatter::formatAuthors($authors);
+
+        self::assertStringNotContainsString('<script>', $result['listAffi']);
+        self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $result['listAffi']);
+    }
+
+    public function testFormatAuthorsHandlesEmptyInput(): void
+    {
+        $result = Episciences_Paper_Authors_ViewFormatter::formatAuthors([]);
+
+        self::assertEquals('', $result['template']);
+        self::assertEquals('', $result['orcid']);
+        self::assertEquals('', $result['listAffi']);
+        self::assertEquals('', $result['authorsList']);
+    }
+
+    public function testSuperscriptLogic(): void
+    {
+        $authors = [
+            [
+                'fullname' => 'Author 1',
+                'affiliation' => [
+                    ['name' => 'A'], // Should be 1
+                    ['name' => 'B']  // Should be 2
+                ]
+            ],
+            [
+                'fullname' => 'Author 2',
+                'affiliation' => [
+                    ['name' => 'B'], // Should be 2
+                    ['name' => 'C']  // Should be 3
+                ]
+            ]
+        ];
+
+        $result = Episciences_Paper_Authors_ViewFormatter::formatAuthors($authors);
+
+        // Author 1 superscripts: 1,2
+        $this->assertStringContainsString('<sup>1,</sup><sup>2</sup>', $result['template']);
+
+        // Author 2 superscripts: 2,3
+        $this->assertStringContainsString('<sup>2,</sup><sup>3</sup>', $result['template']);
+    }
+}


### PR DESCRIPTION
## Summary

- **Refactored** `Episciences_Paper_AuthorsManager` (879-line God Class) into 6 focused classes:
  - `Episciences_Hal_TeiCacheManager` — HAL TEI cache & HTTP
  - `Episciences_Paper_Authors_HalTeiParser` — TEI XML parsing
  - `Episciences_Paper_Authors_Repository` — Database CRUD
  - `Episciences_Paper_Authors_EnrichmentService` — DB/TEI author data merging
  - `Episciences_Paper_Authors_AffiliationHelper` — Affiliation/ROR/acronym utilities
  - `Episciences_Paper_Authors_ViewFormatter` — HTML display formatting
- `AuthorsManager` kept as orchestrator with all backward-compatible `@deprecated` proxies — **no caller changes needed**
- Applied PHP best practices: constants, meaningful variable names, typed parameters, extracted helper methods

## Bug fixes (initial refactor)

- **ORCID normalization**: `cleanLowerCaseOrcid()` did not strip `https://orcid.org/` URL prefix → new `normalizeOrcid()` handles URL stripping, trimming, and lowercase `x` → `X`
- Applied `normalizeOrcid()` in **Zenodo** and **ARCHE** hooks where raw ORCID values were stored without normalization
- `findAffiliationsOneAuthorByPaperId()`: fixed potential undefined variable on empty author rows
- `hasAcronym()`: fixed nested `id` array iteration (was comparing top-level numeric keys instead of inspecting each identifier sub-array — consistent with `hasRor()`)

## Code review fixes (15 issues)

### Critical
- **XSS fix**: `ViewFormatter::buildAuthorHtml()` and `buildAffiliationListHtml()` — HTML attributes (`href`, `data-original-title`) and affiliation **acronyms** were unquoted or unescaped; now properly quoted and escaped with `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')`
- **Data corruption fix**: `HalTeiParser::getAuthorsFromHalTei()` — added check to ensure `persName` was processed before enriching, preventing metadata from being attached to the wrong author in case of malformed TEI
- **`key()` bug**: `EnrichmentService::mergeExistingAffiliations()` — `key()` always returned 0 instead of the actual matching affiliation key; replaced with `array_search()`
- **Circular dependency**: moved `normalizeOrcid()` implementation from `AuthorsManager` to `HalTeiParser`; `AuthorsManager::normalizeOrcid()` is now a deprecated proxy

### Medium
- **`html_entity_decode(htmlspecialchars())` no-op** in `ViewFormatter` — split into `` (plain text) and `` (HTML)
- **`JSON_DECODE_FLAGS`** in `Repository` contained encode-only flags — reduced to `JSON_THROW_ON_ERROR`
- **Dead `expiresAfter()`** on read path in `TeiCacheManager::getFromCache()` — removed
- **Double cache adapter instantiation** — added `TeiCacheManager::fetchAndGet()`; updated 3 callers (`EnrichmentService`, `LicenceManager`, `AuthorsManager`)
- **Loop documentation** — added clarifying comments on single-row loops in `Repository` and `ViewFormatter`
- **`setOrUpdateRorAcronym`** returned last match — added `break` for deterministic first match
- **Solr query injection** in `TeiCacheManager::buildApiUrl()` — applied `urlencode()` on identifier

### Low
- **Duplicated `ONE_MONTH` constant** — `AuthorsManager::ONE_MONTH` now references `TeiCacheManager::ONE_MONTH`
- **`isAcronymDuplicate`** checked only `[0]` — replaced with `foreach` loop (consistent with `hasRor()` / `hasAcronym()`)

## Test plan

- [x] 45 new unit tests added across 4 test files:
  - `Episciences_Paper_Authors_AffiliationHelperTest` (19 tests)
  - `Episciences_Paper_Authors_EnrichmentServiceTest` (12 tests)
  - `Episciences_Paper_Authors_HalTeiParserTest` (10 tests)
  - `Episciences_Paper_Authors_ViewFormatterTest` (4 tests) — covers HTML display & XSS prevention
- [x] All 519 tests pass (1907 assertions, 4 pre-existing skips)
- [x] Key tests still pass: `testNormalizeOrcid`, `testFormatOrcidFromTeiHal`, `testMergeAddsRorToExistingAffiliationWithoutRor`
- [ ] Verify paper display with enriched authors (ORCID + ROR affiliations)
- [ ] Verify `LicenceManager::getLicenceFromTeiHal()` still works
- [ ] Test `scripts/getCreatorData.php` on a HAL paper