### PR TITLE
fix: make dev-setup work on fresh Docker installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,61 @@ All notable changes to this project will be documented in the [CHANGELOG.md](./C
 
 ### Development Setup
 
-To set up a local development environment using Docker, run:
+For a detailed guide including troubleshooting, see [docs/dev-setup.md](./docs/dev-setup.md).
+
+#### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose v2](https://docs.docker.com/compose/install/)
+- Add the following line to `/etc/hosts`:
+  ```
+  127.0.0.1 localhost dev.episciences.org oai-dev.episciences.org data-dev.episciences.org manager-dev.episciences.org
+  ```
+
+#### First-time Setup
+
+On a fresh machine, Docker images must be built before starting containers:
 
 ```bash
 make dev-setup
 ```
 
+`make dev-setup` automatically runs `make build` first (safe to run repeatedly — Docker uses the cache on subsequent runs).
+
 This command will:
-1. **Initialize Configuration**: It will copy `config/dist-dev.pwd.json` to `config/pwd.json` (asking for confirmation if it already exists).
-2. Start the Docker containers.
-3. Install PHP dependencies via Composer.
-4. **Generate Sample Data**: It will automatically generate **30 random test users** using Faker for the 'dev' journal (RVID 1). These users are distributed as follows: 1 Chief Editor, 2 Administrators, 5 Editors, and 22 Members.
-5. **Create Bot User**: A fixed `episciences-bot` user will be created (login: `episciences-bot`, password: `botPassword123`, role: `member`).
-6. Set up the Solr search engine and index the sample content.
+1. **Build Docker images** (`make build`).
+2. **Initialize Configuration**: Copy `config/dist-dev.pwd.json` to `config/pwd.json` (asking for confirmation if it already exists).
+3. Start the Docker containers.
+4. **Initialize `data/dev`**: Create the required journal data directory and seed it with `navigation.json` so the application bootstraps correctly.
+5. Install PHP dependencies via Composer.
+6. **Generate Sample Data**: Automatically generate **30 random test users** for the 'dev' journal (RVID 1): 1 Chief Editor, 2 Administrators, 5 Editors, and 22 Members.
+7. **Create Bot User**: A fixed `episciences-bot` user (login: `episciences-bot`, password: `botPassword123`, role: `member`).
+8. Set up the Solr search engine and index the sample content.
+
+#### Accessing the Journal
+
+After setup, open: **http://dev.episciences.org/**
+
+> Make sure the `/etc/hosts` entry above is in place before trying to access the site.
 
 #### Test User Credentials
-The generated users all have the default password: `password123`.
-You can check the logs during `make dev-setup` to see the generated usernames.
-The `episciences-bot` user has a fixed login (`episciences-bot`) and password (`botPassword123`).
+
+After `make dev-setup`, a summary table of all generated usernames, roles, and email addresses is printed in the terminal.
+
+| Account | Login | Password |
+|---------|-------|----------|
+| Generated users (×30) | see terminal table | `password123` |
+| Bot user | `episciences-bot` | `botPassword123` |
+
+#### Rootless Docker / Permission Issues
+
+If `composer-install` fails with a permission error, override the container user:
+
+```bash
+make dev-setup CNTR_USER_ID=0:0
+```
 
 #### Database Operations
+
 You can also manually load or backup databases:
 - `make load-dev-db`: Load the development datasets with sample data.
 - `make load-db-episciences`: Load a dump from `~/tmp/episciences.sql`.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,184 @@
+# Developer Setup Guide
+
+This guide walks through setting up a local Episciences development environment from scratch using Docker.
+
+---
+
+## Prerequisites
+
+| Requirement | Minimum version |
+|-------------|-----------------|
+| Docker | 24.x |
+| Docker Compose | v2 (plugin, not standalone `docker-compose`) |
+| Git | any recent version |
+
+Verify your installation:
+
+```bash
+docker --version
+docker compose version
+```
+
+---
+
+## /etc/hosts Configuration
+
+The application uses virtual-host-based routing. Add the following line to `/etc/hosts` **before** starting the containers:
+
+```bash
+sudo sh -c 'echo "127.0.0.1 localhost dev.episciences.org oai-dev.episciences.org data-dev.episciences.org manager-dev.episciences.org" >> /etc/hosts'
+```
+
+Verify:
+
+```bash
+ping -c1 dev.episciences.org
+```
+
+---
+
+## First-time Setup
+
+```bash
+git clone <repository-url>
+cd episciences
+make dev-setup
+```
+
+`make dev-setup` performs the following steps automatically:
+
+1. **`make build`** — builds all Docker images (Apache vhost, PHP-FPM, etc.)
+2. **`make copy-config`** — copies `config/dist-dev.pwd.json` → `config/pwd.json`
+3. **`make setup-logs`** — creates log directories with correct permissions
+4. **`make up`** — starts all containers in detached mode
+5. **`make wait-for-db`** — waits until MySQL is accepting connections
+6. **`make init-data-dir`** — creates `data/dev/` with sub-directories and seeds `navigation.json`
+7. **`make composer-install`** — installs PHP dependencies
+8. **`make load-dev-db`** — loads the development SQL dataset
+9. **`make init-dev-users`** — creates 30 test users and prints a summary table
+10. **`make create-bot-user`** — creates the fixed `episciences-bot` account
+11. **`make collection`** — creates the Solr `episciences` collection
+12. **`make index`** — indexes sample content into Solr
+
+When it completes, open **http://dev.episciences.org/** in your browser.
+
+---
+
+## Regular Workflow
+
+```bash
+# Start containers
+make up
+
+# Stop containers
+make down
+
+# Restart everything
+make restart
+
+# View logs
+make logs
+# Or for a specific container:
+make logs CONTAINER=php-fpm
+```
+
+---
+
+## Available Services
+
+| Service | URL |
+|---------|-----|
+| Journal | http://dev.episciences.org/ |
+| Manager | http://manager-dev.episciences.org/dev/ |
+| OAI-PMH | http://oai-dev.episciences.org/ |
+| Data | http://data-dev.episciences.org/ |
+| PhpMyAdmin | http://localhost:8001/ |
+| Apache Solr | http://localhost:8983/solr |
+
+---
+
+## Credentials
+
+| Account | Login | Password | Role |
+|---------|-------|----------|------|
+| Bot user | `episciences-bot` | `botPassword123` | member |
+| Generated users (×30) | see terminal table after setup | `password123` | various |
+
+The terminal prints a table of all generated usernames after `make init-dev-users` completes.
+Users are distributed as: 1 Chief Editor, 2 Administrators, 5 Editors, 22 Members.
+
+---
+
+## Troubleshooting
+
+### Rootless Docker / `composer-install` permission error
+
+If you see a permission-denied error during `composer-install`, your host UID does not match the
+container's expected `1000:1000`. Override it:
+
+```bash
+make dev-setup CNTR_USER_ID=0:0
+```
+
+Or, to run only composer as root without redoing the full setup:
+
+```bash
+make composer-install CNTR_USER_ID=0:0
+```
+
+### `data/dev` not created / "navigation.json" fatal error
+
+The application needs `data/dev/config/navigation.json` to bootstrap. This is created automatically
+by `make init-data-dir` (which is part of `make dev-setup`). If you skipped it or the directory was
+deleted, run:
+
+```bash
+make init-data-dir
+```
+
+This requires the containers to be running (`make up` first).
+
+### `copy-config` prompt hangs in CI or non-interactive shell
+
+`make copy-config` asks for confirmation interactively when `config/pwd.json` already exists.
+In non-interactive environments, pre-create the file before running `make dev-setup`:
+
+```bash
+cp config/dist-dev.pwd.json config/pwd.json
+make dev-setup
+```
+
+### Finding generated usernames
+
+After `make init-dev-users` runs, a table listing every username, role, and email is printed to
+stdout. If you missed it, you can re-run the command alone:
+
+```bash
+make init-dev-users
+```
+
+Note: this will attempt to create users again; duplicate-email errors are reported but do not
+break the existing accounts.
+
+### Database reset
+
+To start over with a clean database:
+
+```bash
+make down
+make clean-mysql    # WARNING: deletes all MySQL volumes — prompts for confirmation
+make dev-setup
+```
+
+---
+
+## Database Operations Reference
+
+| Command | Description                                                 |
+|---------|-------------------------------------------------------------|
+| `make load-dev-db` | Load the development SQL dataset, inludes the 'Dev' journal |
+| `make load-db-episciences` | Restore from `~/tmp/episciences.sql`                        |
+| `make load-db-auth` | Restore from `~/tmp/cas_users.sql`                          |
+| `make backup-db` | Dump current databases to `~/tmp/`                          |
+| `make shell-mysql` | Open a MySQL shell in the container                         |
+| `make clean-mysql` | Delete MySQL volumes (irreversible, prompts)                |


### PR DESCRIPTION
## Summary

- **`make build` added as first prerequisite of `dev-setup`** — custom Docker images (Apache vhost) do not exist on a fresh machine; `docker compose up` had nothing to run
- **New `init-data-dir` target** — `data/dev/` was missing on fresh installs, causing `realpath()` to return `false`, setting `REVIEW_PATH='/'`, and Bootstrap to attempt `mkdir('/config')` → fatal error; the new target creates the directory tree and seeds `navigation.json` from `data/default/`
- **`InitDevUsersCommand` fix** — `Episciences_User::save()` returns `0` when the MySQL CAS adapter is used (dev only) because `lastInsertId()` is not updated for explicit-UID INSERTs; the command now reads `$user->getUid()` which is correctly set on the object inside `save()`; production behavior (real CAS adapter) is unchanged
- **Username table** — generated usernames, roles and emails are now printed as a summary table after `make init-dev-users`
- **Docs** — README Development Setup section expanded; new `docs/dev-setup.md` with prerequisites, step-by-step guide, troubleshooting (rootless Docker, `data/dev`, CI non-interactive), and credentials reference

## Files changed

| File | Change |
|------|--------|
| `Makefile` | add `build` dep, `init-data-dir` target, `CNTR_USER_ID` comment |
| `scripts/InitDevUsersCommand.php` | `getUid()` fallback, `$io->table()` output |
| `README.md` | expanded Development Setup section |
| `docs/dev-setup.md` | new — comprehensive developer setup guide |

## Test plan

- [ ] Fresh clone (or `rm -rf data/dev vendor`), run `make dev-setup` — completes without errors
- [ ] `/etc/hosts` entry in place, `http://dev.episciences.org/` loads
- [ ] Username table appears in terminal after `init-dev-users`
- [ ] Log in as a generated user with `password123` — access works
- [ ] Log in as `episciences-bot` / `botPassword123` — access works