### PR TITLE
test: add unit tests for User/Auth classes, fix filterEmail() security bug

### DIFF
--- a/library/Ccsd/Auth/Adapter/Idp.php
+++ b/library/Ccsd/Auth/Adapter/Idp.php
@@ -374,16 +374,13 @@ class Idp implements AdapterInterface {
      */
     public function filterEmail($email) : bool
     {
-        $isOK = false;
+        $emailFilters = ['@inra.fr', '@irstea.fr', '@inrae.fr'];
 
-        $emailFilters = ['@inra.fr','@irstea.fr','@inrae.fr'];
-
-        foreach($emailFilters as $emailFilter){
-            $result = preg_match('/'.$emailFilter.'/',$email);
-            if ($result!==0 && $result!==false){
-                $isOK = true;
+        foreach ($emailFilters as $emailFilter) {
+            if (preg_match('/' . preg_quote($emailFilter, '/') . '$/', $email)) {
+                return true;
             }
         }
-        return $isOK;
+        return false;
     }
 }

--- a/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_CasAbstractTest.php
+++ b/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_CasAbstractTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace unit\library\Ccsd\Auth\Adapter;
+
+use Ccsd_Auth_Adapter_CasAbstract;
+use Ccsd_User_Models_User;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Minimal concrete subclass to allow instantiation of the abstract class
+ * without triggering CAS constant lookups in the constructor.
+ */
+class CasAdapterTestDouble extends Ccsd_Auth_Adapter_CasAbstract
+{
+    protected function setLogger(): void {}
+    protected function setCasOptions(): self { return $this; }
+}
+
+/**
+ * Unit tests for Ccsd_Auth_Adapter_CasAbstract
+ *
+ * Tests pure logic: getters/setters, setServiceURL with empty params,
+ * setIdentityStructure, constants, and buildLoginDestinationUrl via setServiceURL.
+ * authenticate() requires phpCAS and is not tested here.
+ *
+ * @covers Ccsd_Auth_Adapter_CasAbstract
+ */
+class Ccsd_Auth_Adapter_CasAbstractTest extends TestCase
+{
+    private CasAdapterTestDouble $adapter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = new CasAdapterTestDouble();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testDefaultLoginActionConstant(): void
+    {
+        $this->assertSame('login', Ccsd_Auth_Adapter_CasAbstract::DEFAULT_LOGIN_ACTION);
+    }
+
+    public function testDefaultLogoutActionConstant(): void
+    {
+        $this->assertSame('logout', Ccsd_Auth_Adapter_CasAbstract::DEFAULT_LOGOUT_ACTION);
+    }
+
+    public function testDefaultAuthControllerConstant(): void
+    {
+        $this->assertSame('user', Ccsd_Auth_Adapter_CasAbstract::DEFAULT_AUTH_CONTROLLER);
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasVersion / getCasVersion
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasVersion(): void
+    {
+        $this->adapter->setCasVersion('2.0');
+        $this->assertSame('2.0', $this->adapter->getCasVersion());
+    }
+
+    public function testSetCasVersionReturnsFluent(): void
+    {
+        $result = $this->adapter->setCasVersion('3.0');
+        $this->assertInstanceOf(CasAdapterTestDouble::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasHostname / getCasHostname
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasHostname(): void
+    {
+        $this->adapter->setCasHostname('cas.example.com');
+        $this->assertSame('cas.example.com', $this->adapter->getCasHostname());
+    }
+
+    public function testSetCasHostnameReturnsFluent(): void
+    {
+        $result = $this->adapter->setCasHostname('host.example.com');
+        $this->assertInstanceOf(CasAdapterTestDouble::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasPort / getCasPort
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasPort(): void
+    {
+        $this->adapter->setCasPort(8443);
+        $this->assertSame(8443, $this->adapter->getCasPort());
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasUrl / getCasUrl
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasUrl(): void
+    {
+        $this->adapter->setCasUrl('/cas');
+        $this->assertSame('/cas', $this->adapter->getCasUrl());
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasStartSessions / getCasStartSessions
+    // -------------------------------------------------------------------------
+
+    public function testDefaultCasStartSessionsIsFalse(): void
+    {
+        $this->assertFalse($this->adapter->getCasStartSessions());
+    }
+
+    public function testSetCasStartSessionsTrue(): void
+    {
+        $this->adapter->setCasStartSessions(true);
+        $this->assertTrue($this->adapter->getCasStartSessions());
+    }
+
+    public function testSetCasStartSessionsFalse(): void
+    {
+        $this->adapter->setCasStartSessions(true);
+        $this->adapter->setCasStartSessions(false);
+        $this->assertFalse($this->adapter->getCasStartSessions());
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasSslValidation / getCasSslValidation
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasSslValidation(): void
+    {
+        $this->adapter->setCasSslValidation(true);
+        $this->assertTrue($this->adapter->getCasSslValidation());
+    }
+
+    // -------------------------------------------------------------------------
+    // setCasCACert / getCasCACert
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCasCACert(): void
+    {
+        $this->adapter->setCasCACert('/etc/ssl/certs/ca.pem');
+        $this->assertSame('/etc/ssl/certs/ca.pem', $this->adapter->getCasCACert());
+    }
+
+    // -------------------------------------------------------------------------
+    // setServiceURL / getServiceURL — empty params
+    // -------------------------------------------------------------------------
+
+    public function testDefaultServiceUrlIsEmpty(): void
+    {
+        $this->assertSame('', $this->adapter->getServiceURL());
+    }
+
+    public function testSetServiceUrlWithEmptyParamsStoresEmptyString(): void
+    {
+        $this->adapter->setServiceURL([]);
+        $this->assertSame('', $this->adapter->getServiceURL());
+    }
+
+    public function testSetServiceUrlReturnsFluent(): void
+    {
+        $result = $this->adapter->setServiceURL([]);
+        $this->assertInstanceOf(CasAdapterTestDouble::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setServiceURL — delegates to buildLoginDestinationUrl (via $_SERVER)
+    // -------------------------------------------------------------------------
+
+    public function testSetServiceUrlBuildsUrlWithForwardControllerAndAction(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'test.example.com';
+        $_SERVER['SERVER_PORT'] = '443'; // standard HTTPS port — no port suffix expected
+
+        $this->adapter->setServiceURL([
+            'forward-controller' => 'paper',
+            'forward-action'     => 'view',
+        ]);
+
+        $url = $this->adapter->getServiceURL();
+        $this->assertStringContainsString('/user/login', $url);
+        $this->assertStringContainsString('forward-controller/paper', $url);
+        $this->assertStringContainsString('forward-action/view', $url);
+    }
+
+    public function testSetServiceUrlWithNullForwardControllerUsesDefault(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'test.example.com';
+        $_SERVER['SERVER_PORT'] = '443';
+
+        $this->adapter->setServiceURL(['other-param' => 'value']);
+
+        $url = $this->adapter->getServiceURL();
+        // No forward-controller param → default path used
+        $this->assertStringContainsString('/user/login', $url);
+        $this->assertStringContainsString('forward-controller/user', $url);
+    }
+
+    public function testSetServiceUrlSkipsInternalParamsFromAppending(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'test.example.com';
+        $_SERVER['SERVER_PORT'] = '443';
+
+        $this->adapter->setServiceURL([
+            'forward-controller' => 'paper',
+            'forward-action'     => 'view',
+            'controller'         => 'user',   // should be skipped
+            'action'             => 'login',  // should be skipped
+            'module'             => 'journal', // should be skipped
+            'ticket'             => 'ST-123',  // should be skipped
+        ]);
+
+        $url = $this->adapter->getServiceURL();
+        $this->assertStringNotContainsString('controller/user', $url);
+        $this->assertStringNotContainsString('action/login', $url);
+        $this->assertStringNotContainsString('module', $url);
+        $this->assertStringNotContainsString('ticket', $url);
+    }
+
+    public function testSetServiceUrlWithNonStandardPortAppendsPort(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'test.example.com';
+        $_SERVER['SERVER_PORT'] = '8080';
+
+        $this->adapter->setServiceURL([
+            'forward-controller' => 'index',
+            'forward-action'     => 'index',
+        ]);
+
+        $url = $this->adapter->getServiceURL();
+        $this->assertStringContainsString(':8080', $url);
+    }
+
+    public function testSetServiceUrlWithPort80DoesNotAppendPort(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'test.example.com';
+        $_SERVER['SERVER_PORT'] = '80';
+
+        $this->adapter->setServiceURL([
+            'forward-controller' => 'index',
+            'forward-action'     => 'index',
+        ]);
+
+        $url = $this->adapter->getServiceURL();
+        $this->assertStringNotContainsString(':80', $url);
+    }
+
+    // -------------------------------------------------------------------------
+    // setIdentityStructure / getIdentityStructure
+    // -------------------------------------------------------------------------
+
+    public function testDefaultIdentityStructureIsNull(): void
+    {
+        $this->assertNull($this->adapter->getIdentityStructure());
+    }
+
+    public function testSetAndGetIdentityStructure(): void
+    {
+        $user = new Ccsd_User_Models_User();
+        $user->setUid(42);
+        $this->adapter->setIdentityStructure($user);
+
+        $result = $this->adapter->getIdentityStructure();
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+        $this->assertSame(42, $result->getUid());
+    }
+
+    // -------------------------------------------------------------------------
+    // alt_login default implementation
+    // -------------------------------------------------------------------------
+
+    public function testAltLoginReturnsTrueByDefault(): void
+    {
+        $user = new Ccsd_User_Models_User();
+        $result = $this->adapter->alt_login($user, []);
+        $this->assertTrue($result);
+    }
+}

--- a/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_IdpTest.php
+++ b/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_IdpTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace unit\library\Ccsd\Auth\Adapter;
+
+use Ccsd\Auth\Adapter\Idp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd\Auth\Adapter\Idp
+ *
+ * Tests pure static logic: adaptCreateValueFromIdp(), getIdpLogin(), filterEmail().
+ * Authentication flows require SimpleSAML and are not tested here.
+ *
+ * @covers \Ccsd\Auth\Adapter\Idp
+ */
+class Ccsd_Auth_Adapter_IdpTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testAdapterNameConstant(): void
+    {
+        $this->assertSame('IDP', Idp::AdapterName);
+    }
+
+    // -------------------------------------------------------------------------
+    // adaptCreateValueFromIdp — field mapping
+    // -------------------------------------------------------------------------
+
+    private function makeAttributes(
+        string $mail       = 'user@example.com',
+        string $displayName = 'Alice Smith',
+        string $sn          = 'Smith',
+        string $givenName   = 'Alice',
+        string $uid         = 'asmith'
+    ): array {
+        return [
+            'mail'        => [$mail],
+            'displayName' => [$displayName],
+            'sn'          => [$sn],
+            'givenName'   => [$givenName],
+            'uid'         => [$uid],
+        ];
+    }
+
+    public function testAdaptCreateValueFromIdpMapsUsernameFromMail(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes());
+        $this->assertSame('user@example.com', $result['USERNAME']);
+    }
+
+    public function testAdaptCreateValueFromIdpMapsEmailFromMail(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes());
+        $this->assertSame('user@example.com', $result['EMAIL']);
+    }
+
+    public function testAdaptCreateValueFromIdpMapsFullnameFromDisplayName(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes(displayName: 'Marie Curie'));
+        $this->assertSame('Marie Curie', $result['FULLNAME']);
+    }
+
+    public function testAdaptCreateValueFromIdpMapsLastnameFromSn(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes(sn: 'Curie'));
+        $this->assertSame('Curie', $result['LASTNAME']);
+    }
+
+    public function testAdaptCreateValueFromIdpMapsFirstnameFromGivenName(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes(givenName: 'Marie'));
+        $this->assertSame('Marie', $result['FIRSTNAME']);
+    }
+
+    public function testAdaptCreateValueFromIdpReturnsAllExpectedKeys(): void
+    {
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes());
+        $this->assertArrayHasKey('USERNAME', $result);
+        $this->assertArrayHasKey('FULLNAME', $result);
+        $this->assertArrayHasKey('EMAIL', $result);
+        $this->assertArrayHasKey('LASTNAME', $result);
+        $this->assertArrayHasKey('FIRSTNAME', $result);
+    }
+
+    public function testAdaptCreateValueFromIdpUsernameEqualsEmail(): void
+    {
+        // USERNAME and EMAIL both come from mail[0]
+        $result = Idp::adaptCreateValueFromIdp($this->makeAttributes(mail: 'contact@inrae.fr'));
+        $this->assertSame($result['EMAIL'], $result['USERNAME']);
+    }
+
+    // -------------------------------------------------------------------------
+    // getIdpLogin
+    // -------------------------------------------------------------------------
+
+    public function testGetIdpLoginReturnsUidFirstElement(): void
+    {
+        $result = Idp::getIdpLogin($this->makeAttributes(uid: 'jdoe42'));
+        $this->assertSame('jdoe42', $result);
+    }
+
+    public function testGetIdpLoginReturnsStringValue(): void
+    {
+        $result = Idp::getIdpLogin($this->makeAttributes(uid: '0001'));
+        $this->assertSame('0001', $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // filterEmail — valid domains
+    // -------------------------------------------------------------------------
+
+    public function testFilterEmailAcceptsInraFr(): void
+    {
+        $idp = new Idp();
+        $this->assertTrue($idp->filterEmail('user@inra.fr'));
+    }
+
+    public function testFilterEmailAcceptsIrsteaFr(): void
+    {
+        $idp = new Idp();
+        $this->assertTrue($idp->filterEmail('agent@irstea.fr'));
+    }
+
+    public function testFilterEmailAcceptsInraeFr(): void
+    {
+        $idp = new Idp();
+        $this->assertTrue($idp->filterEmail('researcher@inrae.fr'));
+    }
+
+    public function testFilterEmailRejectsGmailCom(): void
+    {
+        $idp = new Idp();
+        $this->assertFalse($idp->filterEmail('user@gmail.com'));
+    }
+
+    public function testFilterEmailRejectsUnrelatedDomain(): void
+    {
+        $idp = new Idp();
+        $this->assertFalse($idp->filterEmail('user@example.com'));
+    }
+
+    public function testFilterEmailRejectsEmptyString(): void
+    {
+        $idp = new Idp();
+        $this->assertFalse($idp->filterEmail(''));
+    }
+
+    // -------------------------------------------------------------------------
+    // filterEmail — dot escaped, only literal domain separator matches
+    // -------------------------------------------------------------------------
+
+    public function testFilterEmailRejectsInraWithNonDotSeparator(): void
+    {
+        $idp = new Idp();
+        // '@inraXfr' must not match: the dot is now escaped with preg_quote()
+        $this->assertFalse($idp->filterEmail('user@inraXfr'));
+    }
+
+    // -------------------------------------------------------------------------
+    // filterEmail — trailing $ anchor prevents subdomain injection
+    // -------------------------------------------------------------------------
+
+    public function testFilterEmailRejectsDomainWithInraSuffix(): void
+    {
+        $idp = new Idp();
+        // '@inra.fr.evil.com' must not match: the '$' anchor enforces end-of-string
+        $this->assertFalse($idp->filterEmail('attacker@inra.fr.evil.com'));
+    }
+
+    public function testFilterEmailRejectsSubdomainSpoofing(): void
+    {
+        $idp = new Idp();
+        // A domain that merely contains '@inra' must not pass
+        $this->assertFalse($idp->filterEmail('user@notinra.fr'));
+    }
+}

--- a/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_OrcidTest.php
+++ b/tests/unit/library/Ccsd/Auth/Adapter/Ccsd_Auth_Adapter_OrcidTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace unit\library\Ccsd\Auth\Adapter;
+
+use Ccsd_Auth_Adapter_Orcid;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd_Auth_Adapter_Orcid
+ *
+ * Tests pure static logic: adaptCreateValueFromOrcid(), toHtml(), constants.
+ * getOrcidWithToken() requires network access (curl to ORCID endpoint)
+ * and is not tested here.
+ *
+ * @covers Ccsd_Auth_Adapter_Orcid
+ */
+class Ccsd_Auth_Adapter_OrcidTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testGrantTypeConstant(): void
+    {
+        $this->assertSame('authorization_code', Ccsd_Auth_Adapter_Orcid::GRANT_TYPE);
+    }
+
+    public function testAdapterNameConstant(): void
+    {
+        $this->assertSame('ORCID', Ccsd_Auth_Adapter_Orcid::AdapterName);
+    }
+
+    // -------------------------------------------------------------------------
+    // adaptCreateValueFromOrcid — field mapping
+    // -------------------------------------------------------------------------
+
+    private function makeOrcidAttributes(
+        string $orcid = '0000-0001-2345-6789',
+        string $name  = 'Jane Doe'
+    ): array {
+        return [
+            'orcid' => $orcid,
+            'name'  => $name,
+        ];
+    }
+
+    public function testAdaptCreateValueFromOrcidMapsOrcidField(): void
+    {
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes(orcid: '0000-0002-9999-0001')
+        );
+        $this->assertSame('0000-0002-9999-0001', $result['ORCID']);
+    }
+
+    public function testAdaptCreateValueFromOrcidUsesOrcidAsUsername(): void
+    {
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes(orcid: '0000-0001-1111-2222')
+        );
+        $this->assertSame('0000-0001-1111-2222', $result['USERNAME']);
+    }
+
+    public function testAdaptCreateValueFromOrcidMapsNameToLastname(): void
+    {
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes(name: 'Pierre Curie')
+        );
+        $this->assertSame('Pierre Curie', $result['LASTNAME']);
+    }
+
+    public function testAdaptCreateValueFromOrcidEmailIsNull(): void
+    {
+        // ORCID does not provide email — hardcoded null
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes()
+        );
+        $this->assertNull($result['EMAIL']);
+    }
+
+    public function testAdaptCreateValueFromOrcidFirstnameIsNull(): void
+    {
+        // ORCID only provides full name — FIRSTNAME is hardcoded null
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes()
+        );
+        $this->assertNull($result['FIRSTNAME']);
+    }
+
+    public function testAdaptCreateValueFromOrcidReturnsAllExpectedKeys(): void
+    {
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes()
+        );
+        $this->assertArrayHasKey('ORCID',     $result);
+        $this->assertArrayHasKey('USERNAME',  $result);
+        $this->assertArrayHasKey('EMAIL',     $result);
+        $this->assertArrayHasKey('LASTNAME',  $result);
+        $this->assertArrayHasKey('FIRSTNAME', $result);
+    }
+
+    public function testAdaptCreateValueFromOrcidOrcidEqualsUsername(): void
+    {
+        $result = Ccsd_Auth_Adapter_Orcid::adaptCreateValueFromOrcid(
+            $this->makeOrcidAttributes(orcid: '0000-0003-9999-7777')
+        );
+        $this->assertSame($result['ORCID'], $result['USERNAME']);
+    }
+
+    // -------------------------------------------------------------------------
+    // toHtml
+    // -------------------------------------------------------------------------
+
+    public function testToHtmlReturnsAdapterName(): void
+    {
+        $adapter = new Ccsd_Auth_Adapter_Orcid();
+        $this->assertSame('ORCID', $adapter->toHtml([]));
+    }
+
+    public function testToHtmlIgnoresAttributeParam(): void
+    {
+        $adapter = new Ccsd_Auth_Adapter_Orcid();
+        // toHtml() ignores $attr entirely, always returns the constant
+        $this->assertSame('ORCID', $adapter->toHtml(['orcid' => '0000-0001-0000-0000']));
+    }
+}

--- a/tests/unit/library/Ccsd/Auth/Ccsd_Auth_AdapterFactoryTest.php
+++ b/tests/unit/library/Ccsd/Auth/Ccsd_Auth_AdapterFactoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace unit\library\Ccsd\Auth;
+
+use Ccsd\Auth\AdapterFactory;
+use Ccsd\Auth\Adapter\DbTable;
+use Ccsd\Auth\Adapter\Idp;
+use Ccsd\Auth\Adapter\Mysql;
+use Ccsd_Auth_Adapter_Cas;
+use Ccsd_Auth_Adapter_Orcid;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd\Auth\AdapterFactory
+ *
+ * Tests the factory method getTypedAdapter() for all known types and edge cases.
+ * Note: instantiation of adapters is tested, not authentication itself.
+ *
+ * @covers \Ccsd\Auth\AdapterFactory
+ */
+class Ccsd_Auth_AdapterFactoryTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private function skipIfDbTableClassMissing(): void
+    {
+        if (!class_exists('Ccsd\Db\Adapter\DbTable')) {
+            $this->markTestSkipped('Ccsd\Db\Adapter\DbTable class not found in test env.');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Known adapter types
+    // -------------------------------------------------------------------------
+
+    public function testGetTypedAdapterDbReturnsDbTableInstance(): void
+    {
+        $this->skipIfDbTableClassMissing();
+        $adapter = AdapterFactory::getTypedAdapter('DB');
+        $this->assertInstanceOf(DbTable::class, $adapter);
+    }
+
+    public function testGetTypedAdapterCasReturnsCasInstance(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('CAS');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Cas::class, $adapter);
+    }
+
+    public function testGetTypedAdapterIdpReturnsIdpInstance(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('IDP');
+        $this->assertInstanceOf(Idp::class, $adapter);
+    }
+
+    public function testGetTypedAdapterOrcidReturnsOrcidInstance(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('ORCID');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Orcid::class, $adapter);
+    }
+
+    public function testGetTypedAdapterMysqlReturnsMysqlInstance(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('MYSQL');
+        $this->assertInstanceOf(Mysql::class, $adapter);
+    }
+
+    // -------------------------------------------------------------------------
+    // Case-insensitive matching
+    // -------------------------------------------------------------------------
+
+    public function testGetTypedAdapterIsCaseInsensitiveForDb(): void
+    {
+        $this->skipIfDbTableClassMissing();
+        $adapter = AdapterFactory::getTypedAdapter('db');
+        $this->assertInstanceOf(DbTable::class, $adapter);
+    }
+
+    public function testGetTypedAdapterIsCaseInsensitiveForCas(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('cas');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Cas::class, $adapter);
+    }
+
+    public function testGetTypedAdapterIsCaseInsensitiveForIdp(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('idp');
+        $this->assertInstanceOf(Idp::class, $adapter);
+    }
+
+    public function testGetTypedAdapterIsCaseInsensitiveForOrcid(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('orcid');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Orcid::class, $adapter);
+    }
+
+    public function testGetTypedAdapterMixedCaseOrCid(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('OrCiD');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Orcid::class, $adapter);
+    }
+
+    // -------------------------------------------------------------------------
+    // Default / unknown type
+    // -------------------------------------------------------------------------
+
+    /**
+     * @note BUG/DESIGN: Unknown types silently fall back to CAS adapter.
+     *       This could mask misconfiguration (e.g. typo in authType config).
+     *       Expected: an exception or null. Actual: CAS adapter.
+     */
+    public function testGetTypedAdapterUnknownTypeDefaultsToCas(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('UNKNOWN');
+        // Default case returns CAS — silent fallback may hide misconfiguration
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Cas::class, $adapter);
+    }
+
+    public function testGetTypedAdapterEmptyStringDefaultsToCas(): void
+    {
+        $adapter = AdapterFactory::getTypedAdapter('');
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Cas::class, $adapter);
+    }
+
+    public function testGetTypedAdapterNullCoercedToEmptyStringDefaultsToCas(): void
+    {
+        // getTypedAdapter performs (string) cast: null → '' → default CAS
+        $adapter = AdapterFactory::getTypedAdapter(null);
+        $this->assertInstanceOf(Ccsd_Auth_Adapter_Cas::class, $adapter);
+    }
+
+    // -------------------------------------------------------------------------
+    // Return type: all adapters implement AdapterInterface
+    // -------------------------------------------------------------------------
+
+    public function testAllAdaptersImplementAdapterInterface(): void
+    {
+        $types = ['CAS', 'IDP', 'ORCID', 'MYSQL'];
+        foreach ($types as $type) {
+            $adapter = AdapterFactory::getTypedAdapter($type);
+            $this->assertInstanceOf(
+                \Ccsd\Auth\Adapter\AdapterInterface::class,
+                $adapter,
+                "Adapter for type '$type' must implement AdapterInterface"
+            );
+        }
+        // DB requires Ccsd\Db\Adapter\DbTable which is absent from this test env
+    }
+}

--- a/tests/unit/library/Ccsd/Auth/Ccsd_Auth_AssoTest.php
+++ b/tests/unit/library/Ccsd/Auth/Ccsd_Auth_AssoTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace unit\library\Ccsd\Auth;
+
+use Ccsd\Auth\Asso;
+use Ccsd\Auth\Asso\Orcid as AssoOrcid;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd\Auth\Asso and Ccsd\Auth\Asso\Orcid
+ *
+ * Tests constructor, getters, and logic bugs.
+ * save(), load(), exists() require DB and are not tested here.
+ *
+ * @covers \Ccsd\Auth\Asso
+ * @covers \Ccsd\Auth\Asso\Orcid
+ */
+class Ccsd_Auth_AssoTest extends TestCase
+{
+    private Asso $asso;
+
+    protected function setUp(): void
+    {
+        $this->asso = new Asso(
+            'login42',       // uid
+            'renater',       // federationName
+            'https://idp.example.com', // federationId
+            99,              // uidCcsd
+            'Doe',           // lastName
+            'John',          // firstName
+            'john@example.com', // email
+            true             // valid
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor + getters
+    // -------------------------------------------------------------------------
+
+    public function testGetUidReturnsConstructorValue(): void
+    {
+        $this->assertSame('login42', $this->asso->getUid());
+    }
+
+    public function testGetUidCcsdReturnsConstructorValue(): void
+    {
+        $this->assertSame(99, $this->asso->getUidCcsd());
+    }
+
+    public function testGetFederationNameReturnsConstructorValue(): void
+    {
+        $this->assertSame('renater', $this->asso->getFederationName());
+    }
+
+    public function testGetFederationIdReturnsConstructorValue(): void
+    {
+        $this->assertSame('https://idp.example.com', $this->asso->getFederationId());
+    }
+
+    public function testGetLastNameReturnsConstructorValue(): void
+    {
+        $this->assertSame('Doe', $this->asso->getLastName());
+    }
+
+    public function testGetFirstNameReturnsConstructorValue(): void
+    {
+        $this->assertSame('John', $this->asso->getFirstName());
+    }
+
+    public function testGetEmailReturnsConstructorValue(): void
+    {
+        $this->assertSame('john@example.com', $this->asso->getEmail());
+    }
+
+    // -------------------------------------------------------------------------
+    // valid() — BUG: always returns true
+    // -------------------------------------------------------------------------
+
+    public function testValidAlwaysReturnsTrueRegardlessOfSetValid(): void
+    {
+        // Valid=true in constructor → valid() returns true (expected)
+        $this->assertTrue($this->asso->valid());
+    }
+
+    /**
+     * @note BUG: valid() always returns `true` (hardcoded), ignoring $this->valid.
+     *       Calling setValid(false) stores the value in $this->valid, but
+     *       valid() never reads it — it always returns `return true`.
+     *       This means it's impossible to mark an Asso as invalid; the guard
+     *       in save() can never be triggered by application code.
+     */
+    public function testValidReturnsTrueEvenAfterSetValidFalse(): void
+    {
+        $asso = new Asso('uid', 'fed', 'fedId', 1, 'last', 'first', 'a@b.com', false);
+        // BUG: should return false after setValid(false), but always returns true
+        $this->assertTrue($asso->valid());
+    }
+
+    public function testSetValidDoesNotAffectValidReturnValue(): void
+    {
+        $this->asso->setValid(false);
+        // BUG: valid() always returns true regardless of $this->valid
+        $this->assertTrue($this->asso->valid());
+    }
+
+    // -------------------------------------------------------------------------
+    // Asso\Orcid — constructor, constants, field mapping
+    // -------------------------------------------------------------------------
+
+    public function testOrcidAssoFedeFederationConstant(): void
+    {
+        $this->assertSame('Orcid', AssoOrcid::ASSOFEDE);
+    }
+
+    public function testOrcidAssoFedeidConstant(): void
+    {
+        $this->assertSame('Orcid', AssoOrcid::ASSOFEDEID);
+    }
+
+    public function testOrcidAssoConstructorSetsOrcidAsUid(): void
+    {
+        $orcid = new AssoOrcid('0000-0001-2345-6789', 42, 'Jane Doe', 'jane@example.com');
+        $this->assertSame('0000-0001-2345-6789', $orcid->getUid());
+    }
+
+    public function testOrcidAssoConstructorSetsUidCcsd(): void
+    {
+        $orcid = new AssoOrcid('0000-0001-0000-0000', 77, 'Bob Smith', 'bob@example.com');
+        $this->assertSame(77, $orcid->getUidCcsd());
+    }
+
+    public function testOrcidAssoConstructorSetsFederationNameToOrcid(): void
+    {
+        $orcid = new AssoOrcid('0000-0001-0000-0000', 1, 'Name', '');
+        $this->assertSame('Orcid', $orcid->getFederationName());
+    }
+
+    public function testOrcidAssoConstructorSetsFederationIdToOrcid(): void
+    {
+        $orcid = new AssoOrcid('0000-0001-0000-0000', 1, 'Name', '');
+        $this->assertSame('Orcid', $orcid->getFederationId());
+    }
+
+    public function testOrcidAssoConstructorMapsNameToLastname(): void
+    {
+        // parent::__construct() called with ($orcid, 'Orcid', 'Orcid', $uidCcsd, $name, '', $email)
+        // $name goes to $lastName, firstName is always ''
+        $orcid = new AssoOrcid('0000-0002-0000-0000', 1, 'Full Name', 'mail@x.com');
+        $this->assertSame('Full Name', $orcid->getLastName());
+    }
+
+    public function testOrcidAssoConstructorFirstNameIsAlwaysEmpty(): void
+    {
+        // ORCID doesn't split first/last name — firstName hardcoded as ''
+        $orcid = new AssoOrcid('0000-0003-0000-0000', 1, 'Full Name', 'mail@x.com');
+        $this->assertSame('', $orcid->getFirstName());
+    }
+
+    public function testOrcidAssoConstructorSetsEmail(): void
+    {
+        $orcid = new AssoOrcid('0000-0004-0000-0000', 1, 'Name', 'orcid@test.org');
+        $this->assertSame('orcid@test.org', $orcid->getEmail());
+    }
+
+    public function testOrcidAssoValidAlwaysReturnsTrue(): void
+    {
+        // Inherits the same BUG as Asso::valid()
+        $orcid = new AssoOrcid('0000-0005-0000-0000', 1, 'Name', '', false);
+        $this->assertTrue($orcid->valid());
+    }
+}

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserFtpQuotaTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserFtpQuotaTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace unit\library\Ccsd\User;
+
+use Ccsd_User_Models_UserFtpQuota;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd_User_Models_UserFtpQuota
+ *
+ * Tests pure logic: default property values, setters/getters,
+ * null-fallback to constants for bytes/files limits.
+ * save() requires DB and is not tested here.
+ *
+ * @covers Ccsd_User_Models_UserFtpQuota
+ */
+class Ccsd_User_Models_UserFtpQuotaTest extends TestCase
+{
+    private Ccsd_User_Models_UserFtpQuota $quota;
+
+    protected function setUp(): void
+    {
+        $this->quota = new Ccsd_User_Models_UserFtpQuota();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testFtpQuotaConstant(): void
+    {
+        $this->assertSame(5368709120, Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA);
+    }
+
+    public function testFtpQuotaFilesConstant(): void
+    {
+        $this->assertSame(5000, Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA_FILES);
+    }
+
+    // -------------------------------------------------------------------------
+    // Default property values
+    // -------------------------------------------------------------------------
+
+    public function testDefaultQuotaTypeIsUser(): void
+    {
+        $this->assertSame('user', $this->quota->getQuota_type());
+    }
+
+    public function testDefaultParSessionIsFalse(): void
+    {
+        $this->assertSame('false', $this->quota->getPar_session());
+    }
+
+    public function testDefaultLimitTypeIsSoft(): void
+    {
+        $this->assertSame('soft', $this->quota->getLimit_type());
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $quota = new Ccsd_User_Models_UserFtpQuota([
+            'Id'       => 3,
+            'username' => 'jdoe',
+        ]);
+
+        $this->assertSame(3, $quota->getId());
+        $this->assertSame('jdoe', $quota->getUsername());
+    }
+
+    // -------------------------------------------------------------------------
+    // setId / getId
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetId(): void
+    {
+        $this->quota->setId(10);
+        $this->assertSame(10, $this->quota->getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // setUsername / getUsername
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUsername(): void
+    {
+        $this->quota->setUsername('alice');
+        $this->assertSame('alice', $this->quota->getUsername());
+    }
+
+    // -------------------------------------------------------------------------
+    // setQuota_type / getQuota_type
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetQuotaType(): void
+    {
+        $this->quota->setQuota_type('group');
+        $this->assertSame('group', $this->quota->getQuota_type());
+    }
+
+    // -------------------------------------------------------------------------
+    // setPar_session / getPar_session
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetParSession(): void
+    {
+        $this->quota->setPar_session('true');
+        $this->assertSame('true', $this->quota->getPar_session());
+    }
+
+    // -------------------------------------------------------------------------
+    // setLimit_type / getLimit_type
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetLimitType(): void
+    {
+        $this->quota->setLimit_type('hard');
+        $this->assertSame('hard', $this->quota->getLimit_type());
+    }
+
+    // -------------------------------------------------------------------------
+    // bytes_up_limit — null defaults to CCSD_FTP_QUOTA
+    // -------------------------------------------------------------------------
+
+    public function testSetBytesUpLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setBytes_up_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA, $this->quota->getBytes_up_limit());
+    }
+
+    public function testSetBytesUpLimitWithExplicitValue(): void
+    {
+        $this->quota->setBytes_up_limit(1073741824); // 1 GB
+        $this->assertSame(1073741824, $this->quota->getBytes_up_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // bytes_down_limit — null defaults to CCSD_FTP_QUOTA
+    // -------------------------------------------------------------------------
+
+    public function testSetBytesDownLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setBytes_down_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA, $this->quota->getBytes_down_limit());
+    }
+
+    public function testSetBytesDownLimitWithExplicitValue(): void
+    {
+        $this->quota->setBytes_down_limit(2147483648);
+        $this->assertSame(2147483648, $this->quota->getBytes_down_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // bytes_transfer_limit — null defaults to CCSD_FTP_QUOTA
+    // -------------------------------------------------------------------------
+
+    public function testSetBytesTransferLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setBytes_transfer_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA, $this->quota->getBytes_transfer_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // files_up_limit — null defaults to CCSD_FTP_QUOTA_FILES
+    // -------------------------------------------------------------------------
+
+    public function testSetFilesUpLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setFiles_up_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA_FILES, $this->quota->getFiles_up_limit());
+    }
+
+    public function testSetFilesUpLimitWithExplicitValue(): void
+    {
+        $this->quota->setFiles_up_limit(100);
+        $this->assertSame(100, $this->quota->getFiles_up_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // files_down_limit — null defaults to CCSD_FTP_QUOTA_FILES
+    // -------------------------------------------------------------------------
+
+    public function testSetFilesDownLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setFiles_down_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA_FILES, $this->quota->getFiles_down_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // files_transfer_limit — null defaults to CCSD_FTP_QUOTA_FILES
+    // -------------------------------------------------------------------------
+
+    public function testSetFilesTransferLimitWithNullDefaultsToConstant(): void
+    {
+        $this->quota->setFiles_transfer_limit(null);
+        $this->assertSame(Ccsd_User_Models_UserFtpQuota::CCSD_FTP_QUOTA_FILES, $this->quota->getFiles_transfer_limit());
+    }
+
+    // -------------------------------------------------------------------------
+    // Total counters (bytes)
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetBytesUpTotal(): void
+    {
+        $this->quota->setBytes_up_total(512000);
+        $this->assertSame(512000, $this->quota->getBytes_up_total());
+    }
+
+    public function testSetAndGetBytesDownTotal(): void
+    {
+        $this->quota->setBytes_down_total(1024000);
+        $this->assertSame(1024000, $this->quota->getBytes_down_total());
+    }
+
+    public function testSetAndGetBytesTransferTotal(): void
+    {
+        $this->quota->setBytes_transfer_total(2048000);
+        $this->assertSame(2048000, $this->quota->getBytes_transfer_total());
+    }
+
+    // -------------------------------------------------------------------------
+    // Total counters (files)
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetFilesUpTotal(): void
+    {
+        $this->quota->setFiles_up_total(10);
+        $this->assertSame(10, $this->quota->getFiles_up_total());
+    }
+
+    public function testSetAndGetFilesDownTotal(): void
+    {
+        $this->quota->setFiles_down_total(20);
+        $this->assertSame(20, $this->quota->getFiles_down_total());
+    }
+
+    public function testSetAndGetFilesTransferTotal(): void
+    {
+        $this->quota->setFiles_transfer_total(30);
+        $this->assertSame(30, $this->quota->getFiles_transfer_total());
+    }
+
+    // -------------------------------------------------------------------------
+    // Fluent interface
+    // -------------------------------------------------------------------------
+
+    public function testSettersReturnFluent(): void
+    {
+        $result = $this->quota
+            ->setId(1)
+            ->setUsername('user')
+            ->setQuota_type('user')
+            ->setPar_session('false')
+            ->setLimit_type('soft')
+            ->setBytes_up_limit(null)
+            ->setBytes_down_limit(null)
+            ->setFiles_up_limit(null);
+
+        $this->assertInstanceOf(Ccsd_User_Models_UserFtpQuota::class, $result);
+    }
+}

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTest.php
@@ -1,0 +1,358 @@
+<?php
+
+namespace unit\library\Ccsd\User;
+
+use Ccsd_User_Models_User;
+use InvalidArgumentException;
+use LengthException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd_User_Models_User
+ *
+ * Tests pure logic: setters/getters, uid/password/valid validation,
+ * timestamp defaults, ftp_home default, toArray keys.
+ * save() requires DB and is not tested here.
+ *
+ * @covers Ccsd_User_Models_User
+ */
+class Ccsd_User_Models_UserTest extends TestCase
+{
+    private Ccsd_User_Models_User $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new Ccsd_User_Models_User();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testPasswordHashSizeIs128(): void
+    {
+        $this->assertSame(128, Ccsd_User_Models_User::PASSWORD_HASH_SIZE);
+    }
+
+    public function testValidValuesConstant(): void
+    {
+        $this->assertSame([0, 1, 3, 4], Ccsd_User_Models_User::VALID_VALUES);
+    }
+
+    public function testFtpPathConstant(): void
+    {
+        $this->assertSame('/ftp/', Ccsd_User_Models_User::CCSD_FTP_PATH);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testDefaultConstructorCreatesEmptyUser(): void
+    {
+        $this->assertNull($this->user->getUid());
+        $this->assertNull($this->user->getUsername());
+        $this->assertNull($this->user->getEmail());
+    }
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $user = new Ccsd_User_Models_User([
+            'uid'      => 42,
+            'username' => 'jdoe',
+            'email'    => 'jdoe@example.com',
+        ]);
+
+        $this->assertSame(42, $user->getUid());
+        $this->assertSame('jdoe', $user->getUsername());
+        $this->assertSame('jdoe@example.com', $user->getEmail());
+    }
+
+    // -------------------------------------------------------------------------
+    // setUid / getUid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUid(): void
+    {
+        $this->user->setUid(10);
+        $this->assertSame(10, $this->user->getUid());
+    }
+
+    public function testSetUidWithEmptyStringSetsNull(): void
+    {
+        $this->user->setUid('');
+        $this->assertNull($this->user->getUid());
+    }
+
+    public function testSetUidWithZeroThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->user->setUid(0);
+    }
+
+    public function testSetUidWithNegativeValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->user->setUid(-1);
+    }
+
+    public function testSetUidReturnsFluent(): void
+    {
+        $result = $this->user->setUid(5);
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setPassword / getPassword
+    // -------------------------------------------------------------------------
+
+    public function testSetPasswordHashesWith128CharSha512(): void
+    {
+        $this->user->setPassword('secret');
+        $this->assertSame(128, strlen($this->user->getPassword()));
+    }
+
+    public function testSetPasswordEmptyStringSetsNull(): void
+    {
+        $this->user->setPassword('');
+        $this->assertNull($this->user->getPassword());
+    }
+
+    public function testSetPasswordProducesHexString(): void
+    {
+        $this->user->setPassword('test123');
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{128}$/', $this->user->getPassword());
+    }
+
+    public function testSetPasswordIsDeterministic(): void
+    {
+        $this->user->setPassword('mypassword');
+        $hash1 = $this->user->getPassword();
+
+        $other = new Ccsd_User_Models_User();
+        $other->setPassword('mypassword');
+        $hash2 = $other->getPassword();
+
+        $this->assertSame($hash1, $hash2);
+    }
+
+    public function testSetPasswordReturnsFluent(): void
+    {
+        $result = $this->user->setPassword('pass');
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setValid / getValid
+    // -------------------------------------------------------------------------
+
+    public function testSetValidWithZero(): void
+    {
+        $this->user->setValid(0);
+        $this->assertSame(0, $this->user->getValid());
+    }
+
+    public function testSetValidWithOne(): void
+    {
+        $this->user->setValid(1);
+        $this->assertSame(1, $this->user->getValid());
+    }
+
+    public function testSetValidWithThree(): void
+    {
+        $this->user->setValid(3);
+        $this->assertSame(3, $this->user->getValid());
+    }
+
+    public function testSetValidWithFour(): void
+    {
+        $this->user->setValid(4);
+        $this->assertSame(4, $this->user->getValid());
+    }
+
+    public function testSetValidWithInvalidValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->user->setValid(2);
+    }
+
+    public function testSetValidWithNegativeValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->user->setValid(-1);
+    }
+
+    public function testSetValidReturnsFluent(): void
+    {
+        $result = $this->user->setValid(1);
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setTime_registered / getTime_registered
+    // -------------------------------------------------------------------------
+
+    public function testSetTimeRegisteredWithExplicitValue(): void
+    {
+        $this->user->setTime_registered('2024-01-15 10:00:00');
+        $this->assertSame('2024-01-15 10:00:00', $this->user->getTime_registered());
+    }
+
+    public function testSetTimeRegisteredWithNullUsesCurrentDate(): void
+    {
+        $before = date('Y-m-d H:i');
+        $this->user->setTime_registered(null);
+        $after = date('Y-m-d H:i');
+
+        $stored = $this->user->getTime_registered();
+        $this->assertNotNull($stored);
+        // Check that the stored date starts with the current minute
+        $this->assertGreaterThanOrEqual($before, substr($stored, 0, 16));
+        $this->assertLessThanOrEqual($after, substr($stored, 0, 16));
+    }
+
+    public function testSetTimeRegisteredReturnsFluent(): void
+    {
+        $result = $this->user->setTime_registered('2024-01-01 00:00:00');
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setFtp_home / getFtp_home
+    // -------------------------------------------------------------------------
+
+    public function testSetFtpHomeWithExplicitValue(): void
+    {
+        $this->user->setFtp_home('/ftp/custom');
+        $this->assertSame('/ftp/custom', $this->user->getFtp_home());
+    }
+
+    public function testSetFtpHomeWithNullUsesUidPath(): void
+    {
+        $this->user->setUid(99);
+        $this->user->setFtp_home(null);
+        $this->assertSame('/ftp/99', $this->user->getFtp_home());
+    }
+
+    public function testSetFtpHomeReturnsFluent(): void
+    {
+        $result = $this->user->setFtp_home('/ftp/test');
+        $this->assertInstanceOf(Ccsd_User_Models_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setEmail / getEmail
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetEmail(): void
+    {
+        $this->user->setEmail('user@example.com');
+        $this->assertSame('user@example.com', $this->user->getEmail());
+    }
+
+    // -------------------------------------------------------------------------
+    // setFirstname / getFirstname / setLastname / getLastname
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetFirstname(): void
+    {
+        $this->user->setFirstname('Alice');
+        $this->assertSame('Alice', $this->user->getFirstname());
+    }
+
+    public function testSetAndGetLastname(): void
+    {
+        $this->user->setLastname('Smith');
+        $this->assertSame('Smith', $this->user->getLastname());
+    }
+
+    // -------------------------------------------------------------------------
+    // setUsername / getUsername
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUsername(): void
+    {
+        $this->user->setUsername('asmith');
+        $this->assertSame('asmith', $this->user->getUsername());
+    }
+
+    // -------------------------------------------------------------------------
+    // setCiv / getCiv
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetCiv(): void
+    {
+        $this->user->setCiv('Dr');
+        $this->assertSame('Dr', $this->user->getCiv());
+    }
+
+    // -------------------------------------------------------------------------
+    // setMiddlename / getMiddlename
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetMiddlename(): void
+    {
+        $this->user->setMiddlename('Jean');
+        $this->assertSame('Jean', $this->user->getMiddlename());
+    }
+
+    // -------------------------------------------------------------------------
+    // setUuid / getUuid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUuid(): void
+    {
+        $uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+        $this->user->setUuid($uuid);
+        $this->assertSame($uuid, $this->user->getUuid());
+    }
+
+    public function testDefaultUuidIsNull(): void
+    {
+        $this->assertNull($this->user->getUuid());
+    }
+
+    public function testSetUuidWithNullClearsValue(): void
+    {
+        $this->user->setUuid('some-uuid');
+        $this->user->setUuid(null);
+        $this->assertNull($this->user->getUuid());
+    }
+
+    // -------------------------------------------------------------------------
+    // toArray
+    // -------------------------------------------------------------------------
+
+    public function testToArrayContainsExpectedKeys(): void
+    {
+        $result = $this->user->toArray();
+
+        $expectedKeys = [
+            'uid', 'username', 'civ', 'lastname', 'firstname',
+            'middlename', 'email', 'time_registered', 'time_modified', 'ftp_home',
+        ];
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $result, "Key '$key' missing from toArray()");
+        }
+    }
+
+    public function testToArrayValuesMatchSetters(): void
+    {
+        $this->user->setUid(7);
+        $this->user->setUsername('bob');
+        $this->user->setEmail('bob@test.com');
+        $this->user->setFirstname('Bob');
+        $this->user->setLastname('Doe');
+        $this->user->setCiv('Mr');
+
+        $result = $this->user->toArray();
+
+        $this->assertSame(7, $result['uid']);
+        $this->assertSame('bob', $result['username']);
+        $this->assertSame('bob@test.com', $result['email']);
+        $this->assertSame('Bob', $result['firstname']);
+        $this->assertSame('Doe', $result['lastname']);
+        $this->assertSame('Mr', $result['civ']);
+    }
+}

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTokensTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTokensTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace unit\library\Ccsd\User;
+
+use Ccsd_User_Models_UserTokens;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Ccsd_User_Models_UserTokens
+ *
+ * Tests token generation, uid/token/email validation, getTime_modified fallback.
+ * DB-related operations (save, find) are not tested here.
+ *
+ * @covers Ccsd_User_Models_UserTokens
+ */
+class Ccsd_User_Models_UserTokensTest extends TestCase
+{
+    private Ccsd_User_Models_UserTokens $tokens;
+
+    protected function setUp(): void
+    {
+        $this->tokens = new Ccsd_User_Models_UserTokens();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testTokenStringLengthIs40(): void
+    {
+        $this->assertSame(40, Ccsd_User_Models_UserTokens::TOKEN_STRING_LENGTH);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testDefaultConstructorCreatesEmptyObject(): void
+    {
+        $this->assertNull($this->tokens->getUid());
+        $this->assertNull($this->tokens->getToken());
+        $this->assertNull($this->tokens->getEmail());
+    }
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $tokens = new Ccsd_User_Models_UserTokens([
+            'uid'   => 5,
+            'email' => 'test@example.com',
+        ]);
+
+        $this->assertSame(5, (int) $tokens->getUid());
+        $this->assertSame('test@example.com', $tokens->getEmail());
+    }
+
+    // -------------------------------------------------------------------------
+    // generateUserToken
+    // -------------------------------------------------------------------------
+
+    public function testGenerateUserTokenProduces40CharString(): void
+    {
+        $this->tokens->generateUserToken();
+        $this->assertSame(40, strlen($this->tokens->getToken()));
+    }
+
+    public function testGenerateUserTokenProducesHexString(): void
+    {
+        $this->tokens->generateUserToken();
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{40}$/', $this->tokens->getToken());
+    }
+
+    // -------------------------------------------------------------------------
+    // setToken / getToken
+    // -------------------------------------------------------------------------
+
+    public function testSetValidToken(): void
+    {
+        $token = sha1('valid_token');
+        $this->tokens->setToken($token);
+        $this->assertSame($token, $this->tokens->getToken());
+    }
+
+    public function testSetTokenWithTooShortValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->tokens->setToken('short');
+    }
+
+    public function testSetTokenWithTooLongValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->tokens->setToken(str_repeat('a', 41));
+    }
+
+    public function testSetTokenWithEmptyStringThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->tokens->setToken('');
+    }
+
+    public function testSetTokenReturnsFluent(): void
+    {
+        $result = $this->tokens->setToken(sha1('fluent'));
+        $this->assertInstanceOf(Ccsd_User_Models_UserTokens::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setUid / getUid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUidWithValidPositiveInt(): void
+    {
+        $this->tokens->setUid(42);
+        $this->assertSame(42, (int) $this->tokens->getUid());
+    }
+
+    public function testSetUidWithEmptyStringSetsNull(): void
+    {
+        $this->tokens->setUid('');
+        $this->assertNull($this->tokens->getUid());
+    }
+
+    public function testSetUidWithZeroThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->tokens->setUid(0);
+    }
+
+    public function testSetUidWithNegativeValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->tokens->setUid(-3);
+    }
+
+    public function testSetUidReturnsFluent(): void
+    {
+        $result = $this->tokens->setUid(1);
+        $this->assertInstanceOf(Ccsd_User_Models_UserTokens::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setEmail / getEmail
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetEmail(): void
+    {
+        $this->tokens->setEmail('user@domain.com');
+        $this->assertSame('user@domain.com', $this->tokens->getEmail());
+    }
+
+    public function testSetEmailReturnsFluent(): void
+    {
+        $result = $this->tokens->setEmail('a@b.com');
+        $this->assertInstanceOf(Ccsd_User_Models_UserTokens::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setUsage / getUsage
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUsage(): void
+    {
+        $this->tokens->setUsage('ACCOUNT_ACTIVATION');
+        $this->assertSame('ACCOUNT_ACTIVATION', $this->tokens->getUsage());
+    }
+
+    public function testSetUsageReturnsFluent(): void
+    {
+        $result = $this->tokens->setUsage('ANY_USAGE');
+        $this->assertInstanceOf(Ccsd_User_Models_UserTokens::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setTime_modified / getTime_modified
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetTimeModified(): void
+    {
+        $this->tokens->setTime_modified('2024-05-01 12:00:00');
+        $this->assertSame('2024-05-01 12:00:00', $this->tokens->getTime_modified());
+    }
+
+    public function testGetTimeModifiedReturnsCurrentDateWhenEmpty(): void
+    {
+        // getTime_modified() returns date('Y-m-d H:i:s') when _time_modified is empty
+        $before = date('Y-m-d H:i');
+        $result = $this->tokens->getTime_modified();
+        $after = date('Y-m-d H:i');
+
+        $this->assertNotEmpty($result);
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result);
+        $this->assertGreaterThanOrEqual($before, substr($result, 0, 16));
+        $this->assertLessThanOrEqual($after, substr($result, 0, 16));
+    }
+
+    public function testGetTimeModifiedReturnsStoredValueWhenSet(): void
+    {
+        $this->tokens->setTime_modified('2023-12-31 23:59:59');
+        // Must return stored value, not current date
+        $this->assertSame('2023-12-31 23:59:59', $this->tokens->getTime_modified());
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_TmpUsersManagerTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_TmpUsersManagerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_TmpUsersManager;
+use Episciences_User_Tmp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_TmpUsersManager
+ *
+ * @covers Episciences_TmpUsersManager
+ */
+class Episciences_TmpUsersManagerTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // findById
+    // -------------------------------------------------------------------------
+
+    public function testFindByIdWithNonExistentIdReturnsFalse(): void
+    {
+        // ID 0 and very large IDs should not exist in the database
+        $result = Episciences_TmpUsersManager::findById(0);
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithLargeNonExistentIdReturnsFalse(): void
+    {
+        $result = Episciences_TmpUsersManager::findById(999999999);
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithNegativeIdReturnsFalse(): void
+    {
+        $result = Episciences_TmpUsersManager::findById(-1);
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdReturnsFalseOrTmpUserInstance(): void
+    {
+        $result = Episciences_TmpUsersManager::findById(1);
+        // Either false (not found) or an Episciences_User_Tmp instance (found)
+        $this->assertTrue(
+            $result === false || $result instanceof Episciences_User_Tmp,
+            'Expected false or Episciences_User_Tmp instance'
+        );
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_UserManagerTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_UserManagerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_UserManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_UserManager
+ *
+ * Tests the early-return edge cases that do not require database access,
+ * and DB-dependent queries that can be exercised in the Docker test environment.
+ *
+ * @covers Episciences_UserManager
+ */
+class Episciences_UserManagerTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // getCorrespondingUidFromUuid — early returns (no DB needed)
+    // -------------------------------------------------------------------------
+
+    public function testGetCorrespondingUidFromUuidWithEmptyStringReturnsZero(): void
+    {
+        $result = Episciences_UserManager::getCorrespondingUidFromUuid('');
+        $this->assertSame(0, $result);
+    }
+
+    public function testGetCorrespondingUidFromUuidWithDefaultEmptyArgReturnsZero(): void
+    {
+        $result = Episciences_UserManager::getCorrespondingUidFromUuid();
+        $this->assertSame(0, $result);
+    }
+
+    public function testGetCorrespondingUidFromUuidWithNonExistentUuidReturnsZero(): void
+    {
+        // A well-formed UUID that does not exist in the database
+        $result = Episciences_UserManager::getCorrespondingUidFromUuid('00000000-0000-0000-0000-000000000000');
+        $this->assertSame(0, $result);
+    }
+
+    public function testGetCorrespondingUidFromUuidReturnsInt(): void
+    {
+        $result = Episciences_UserManager::getCorrespondingUidFromUuid('non-existent-uuid-value');
+        $this->assertIsInt($result);
+    }
+
+    // -------------------------------------------------------------------------
+    // getUuidFromUid — early returns (no DB needed)
+    // -------------------------------------------------------------------------
+
+    public function testGetUuidFromUidWithZeroReturnsNull(): void
+    {
+        $result = Episciences_UserManager::getUuidFromUid(0);
+        $this->assertNull($result);
+    }
+
+    public function testGetUuidFromUidWithNonExistentUidReturnsNullOrString(): void
+    {
+        // UID 999999999 is extremely unlikely to exist
+        $result = Episciences_UserManager::getUuidFromUid(999999999);
+        // Either null (not found) or a string UUID (if it exists)
+        $this->assertTrue($result === null || is_string($result));
+    }
+
+    // -------------------------------------------------------------------------
+    // getSubmittedPapersQuery — verifies it returns a Zend_Db_Select instance
+    // -------------------------------------------------------------------------
+
+    public function testGetSubmittedPapersQueryReturnsZendDbSelect(): void
+    {
+        $select = Episciences_UserManager::getSubmittedPapersQuery(1);
+        $this->assertInstanceOf(\Zend_Db_Select::class, $select);
+    }
+
+    public function testGetSubmittedPapersQuerySqlContainsPapersTable(): void
+    {
+        $select = Episciences_UserManager::getSubmittedPapersQuery(42);
+        $sql = (string) $select;
+        $this->assertStringContainsStringIgnoringCase('PAPERS', $sql);
+    }
+
+    public function testGetSubmittedPapersQuerySqlContainsUidCondition(): void
+    {
+        $select = Episciences_UserManager::getSubmittedPapersQuery(42);
+        $sql = (string) $select;
+        $this->assertStringContainsString('42', $sql);
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_UserTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_UserTest.php
@@ -1,0 +1,611 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_Acl;
+use Episciences_User;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User
+ *
+ * Focuses on pure logic: setters/getters, role checks, alias handling.
+ * DB-dependent methods (find, save, loadRoles, etc.) are not tested here.
+ *
+ * @covers Episciences_User
+ */
+class Episciences_UserTest extends TestCase
+{
+    private Episciences_User $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new Episciences_User();
+    }
+
+    // -------------------------------------------------------------------------
+    // screenName
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetScreenName(): void
+    {
+        $this->user->setScreenName('John Doe');
+        $this->assertSame('John Doe', $this->user->getScreenName());
+    }
+
+    public function testSetScreenNameReplacesSlashWithSpace(): void
+    {
+        $this->user->setScreenName('John/Doe');
+        $this->assertSame('John Doe', $this->user->getScreenName());
+    }
+
+    public function testSetScreenNameTrimsSlashesOnBothSides(): void
+    {
+        $this->user->setScreenName('A/B/C');
+        $this->assertSame('A B C', $this->user->getScreenName());
+    }
+
+    // -------------------------------------------------------------------------
+    // langueid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetLangueid(): void
+    {
+        $this->user->setLangueid('fr');
+        $this->assertSame('fr', $this->user->getLangueid());
+    }
+
+    public function testGetLangueidReturnsNullWhenNotSet(): void
+    {
+        $this->assertNull($this->user->getLangueid());
+    }
+
+    public function testSetLangueidReturnsFluent(): void
+    {
+        $result = $this->user->setLangueid('en');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // socialMedias
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetSocialMedias(): void
+    {
+        $this->user->setSocialMedias('https://twitter.com/test');
+        $this->assertSame('https://twitter.com/test', $this->user->getSocialMedias());
+    }
+
+    public function testSetSocialMediasTrimsWhitespace(): void
+    {
+        $this->user->setSocialMedias('  https://twitter.com/test  ');
+        $this->assertSame('https://twitter.com/test', $this->user->getSocialMedias());
+    }
+
+    public function testSetSocialMediasWithNullDoesNotOverrideExistingValue(): void
+    {
+        $this->user->setSocialMedias('https://twitter.com/test');
+        $this->user->setSocialMedias(null);
+        $this->assertSame('https://twitter.com/test', $this->user->getSocialMedias());
+    }
+
+    public function testGetSocialMediasReturnsNullByDefault(): void
+    {
+        $this->assertNull($this->user->getSocialMedias());
+    }
+
+    public function testSetSocialMediasReturnsFluent(): void
+    {
+        $result = $this->user->setSocialMedias('https://twitter.com/test');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // webSites
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetWebSites(): void
+    {
+        $sites = ['https://example.com', 'https://example.org'];
+        $this->user->setWebSites($sites);
+        $result = $this->user->getWebSites();
+        $this->assertContains('https://example.com', $result);
+        $this->assertContains('https://example.org', $result);
+    }
+
+    public function testSetWebSitesFiltersInvalidUrls(): void
+    {
+        $sites = ['https://valid.com', 'not-a-valid-url', 'also invalid'];
+        $this->user->setWebSites($sites);
+        $result = $this->user->getWebSites();
+        $this->assertContains('https://valid.com', $result);
+        $this->assertNotContains('not-a-valid-url', $result);
+        $this->assertNotContains('also invalid', $result);
+    }
+
+    public function testSetWebSitesWithNullSetsNullValue(): void
+    {
+        $this->user->setWebSites(null);
+        $this->assertNull($this->user->getWebSites());
+    }
+
+    public function testGetWebSitesReturnsNullByDefault(): void
+    {
+        $this->assertNull($this->user->getWebSites());
+    }
+
+    public function testSetWebSitesReturnsFluent(): void
+    {
+        $result = $this->user->setWebSites(['https://example.com']);
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // orcid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetOrcid(): void
+    {
+        $this->user->setOrcid('0000-0002-9193-9560');
+        $this->assertSame('0000-0002-9193-9560', $this->user->getOrcid());
+    }
+
+    public function testGetOrcidReturnsNullByDefault(): void
+    {
+        $this->assertNull($this->user->getOrcid());
+    }
+
+    public function testSetOrcidWithNull(): void
+    {
+        $this->user->setOrcid('0000-0002-9193-9560');
+        $this->user->setOrcid(null);
+        $this->assertNull($this->user->getOrcid());
+    }
+
+    public function testSetOrcidReturnsFluent(): void
+    {
+        $result = $this->user->setOrcid('0000-0001-2345-6789');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // affiliations
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetAffiliations(): void
+    {
+        $affiliations = [['name' => 'CNRS', 'country' => 'FR']];
+        $this->user->setAffiliations($affiliations);
+        $this->assertSame($affiliations, $this->user->getAffiliations());
+    }
+
+    public function testGetAffiliationsReturnsNullByDefault(): void
+    {
+        $this->assertNull($this->user->getAffiliations());
+    }
+
+    public function testSetAffiliationsWithNull(): void
+    {
+        $this->user->setAffiliations(['some' => 'data']);
+        $this->user->setAffiliations(null);
+        $this->assertNull($this->user->getAffiliations());
+    }
+
+    public function testSetAffiliationsReturnsFluent(): void
+    {
+        $result = $this->user->setAffiliations([]);
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // biography
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetBiography(): void
+    {
+        $this->user->setBiography('A researcher in computer science.');
+        $this->assertSame('A researcher in computer science.', $this->user->getBiography());
+    }
+
+    public function testGetBiographyReturnsNullByDefault(): void
+    {
+        $this->assertNull($this->user->getBiography());
+    }
+
+    public function testSetBiographyWithNull(): void
+    {
+        $this->user->setBiography('Some bio');
+        $this->user->setBiography(null);
+        $this->assertNull($this->user->getBiography());
+    }
+
+    public function testSetBiographyReturnsFluent(): void
+    {
+        $result = $this->user->setBiography('Bio text');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // apiPassword
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetApiPassword(): void
+    {
+        $this->user->setApiPassword('hashed_password_xyz');
+        $this->assertSame('hashed_password_xyz', $this->user->getApiPassword());
+    }
+
+    public function testSetApiPasswordReturnsFluent(): void
+    {
+        $result = $this->user->setApiPassword('hash');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // is_valid
+    // -------------------------------------------------------------------------
+
+    public function testDefaultIsValidIsOne(): void
+    {
+        $this->assertSame(1, $this->user->getIs_valid());
+    }
+
+    public function testSetIsValidToZero(): void
+    {
+        $this->user->setIs_valid(0);
+        $this->assertSame(0, $this->user->getIs_valid());
+    }
+
+    public function testSetIsValidReturnsFluent(): void
+    {
+        $result = $this->user->setIs_valid(1);
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // registrationDate
+    // -------------------------------------------------------------------------
+
+    public function testSetRegistrationDateWithExplicitValue(): void
+    {
+        $this->user->setRegistrationDate('2024-01-15 10:00:00');
+        $this->assertSame('2024-01-15 10:00:00', $this->user->getRegistrationDate());
+    }
+
+    public function testSetRegistrationDateWithNullSetsCurrentDateTime(): void
+    {
+        $this->user->setRegistrationDate(null);
+        $date = $this->user->getRegistrationDate();
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $date);
+    }
+
+    public function testSetRegistrationDateReturnsFluent(): void
+    {
+        $result = $this->user->setRegistrationDate('2024-01-01 00:00:00');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // modificationDate
+    // -------------------------------------------------------------------------
+
+    public function testSetModificationDateWithExplicitValue(): void
+    {
+        $this->user->setModificationDate('2024-06-01 12:00:00');
+        $this->assertSame('2024-06-01 12:00:00', $this->user->getModificationDate());
+    }
+
+    public function testSetModificationDateWithNullSetsCurrentDateTime(): void
+    {
+        $this->user->setModificationDate(null);
+        $date = $this->user->getModificationDate();
+        $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $date);
+    }
+
+    public function testSetModificationDateReturnsFluent(): void
+    {
+        $result = $this->user->setModificationDate('2024-01-01 00:00:00');
+        $this->assertInstanceOf(Episciences_User::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // hasAccountData
+    // -------------------------------------------------------------------------
+
+    public function testSetHasAccountDataToTrue(): void
+    {
+        $this->user->setHasAccountData(true);
+        $this->assertTrue($this->user->getHasAccountData());
+    }
+
+    public function testSetHasAccountDataToFalse(): void
+    {
+        $this->user->setHasAccountData(false);
+        $this->assertFalse($this->user->getHasAccountData());
+    }
+
+    public function testSetHasAccountDataThrowsOnStringArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line */
+        $this->user->setHasAccountData('true');
+    }
+
+    public function testSetHasAccountDataThrowsOnIntArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @phpstan-ignore-next-line */
+        $this->user->setHasAccountData(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Role checks — pre-set roles to avoid DB access
+    // -------------------------------------------------------------------------
+
+    public function testHasRoleReturnsTrueForExistingRole(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_EDITOR]]);
+        $this->assertTrue($this->user->hasRole(Episciences_Acl::ROLE_EDITOR));
+    }
+
+    public function testHasRoleReturnsFalseForNonExistentRole(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_MEMBER]]);
+        $this->assertFalse($this->user->hasRole(Episciences_Acl::ROLE_EDITOR));
+    }
+
+    public function testHasRoleReturnsFalseWhenRolesArrayIsEmpty(): void
+    {
+        $this->user->setRoles([]);
+        $this->assertFalse($this->user->hasRole(Episciences_Acl::ROLE_MEMBER));
+    }
+
+    public function testIsEditor(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_EDITOR]]);
+        $this->assertTrue($this->user->isEditor());
+        $this->assertFalse($this->user->isReviewer());
+    }
+
+    public function testIsReviewer(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_REVIEWER]]);
+        $this->assertTrue($this->user->isReviewer());
+        $this->assertFalse($this->user->isEditor());
+    }
+
+    public function testIsChiefEditor(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_CHIEF_EDITOR]]);
+        $this->assertTrue($this->user->isChiefEditor());
+    }
+
+    public function testIsMember(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_MEMBER]]);
+        $this->assertTrue($this->user->isMember());
+    }
+
+    public function testIsAdministrator(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_ADMIN]]);
+        $this->assertTrue($this->user->isAdministrator());
+    }
+
+    public function testIsRoot(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_ROOT]]);
+        $this->assertTrue($this->user->isRoot());
+    }
+
+    public function testIsAuthor(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_AUTHOR]]);
+        $this->assertTrue($this->user->isAuthor());
+    }
+
+    public function testIsCopyEditor(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_COPY_EDITOR]]);
+        $this->assertTrue($this->user->isCopyEditor());
+    }
+
+    public function testIsSecretary(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_SECRETARY]]);
+        $this->assertTrue($this->user->isSecretary());
+    }
+
+    public function testIsWebmaster(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_WEBMASTER]]);
+        $this->assertTrue($this->user->isWebmaster());
+    }
+
+    public function testIsGuestEditor(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_GUEST_EDITOR]]);
+        $this->assertTrue($this->user->isGuestEditor());
+    }
+
+    public function testUserWithMultipleRoles(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_EDITOR,
+            Episciences_Acl::ROLE_REVIEWER,
+        ]]);
+        $this->assertTrue($this->user->isEditor());
+        $this->assertTrue($this->user->isReviewer());
+        $this->assertFalse($this->user->isAdministrator());
+    }
+
+    // -------------------------------------------------------------------------
+    // hasOnlyAdministratorRole
+    // -------------------------------------------------------------------------
+
+    public function testHasOnlyAdministratorRoleWithSingleAdminRole(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_ADMIN]]);
+        $this->assertTrue($this->user->hasOnlyAdministratorRole());
+    }
+
+    public function testHasOnlyAdministratorRoleWithAdminAndEditor(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ADMIN,
+            Episciences_Acl::ROLE_EDITOR,
+        ]]);
+        $this->assertFalse($this->user->hasOnlyAdministratorRole());
+    }
+
+    public function testHasOnlyAdministratorRoleWithAdminAndChiefEditor(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ADMIN,
+            Episciences_Acl::ROLE_CHIEF_EDITOR,
+        ]]);
+        $this->assertFalse($this->user->hasOnlyAdministratorRole());
+    }
+
+    public function testHasOnlyAdministratorRoleWithAdminAndSecretary(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ADMIN,
+            Episciences_Acl::ROLE_SECRETARY,
+        ]]);
+        $this->assertFalse($this->user->hasOnlyAdministratorRole());
+    }
+
+    public function testHasOnlyAdministratorRoleWithAdminAndCopyEditor(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ADMIN,
+            Episciences_Acl::ROLE_COPY_EDITOR,
+        ]]);
+        $this->assertFalse($this->user->hasOnlyAdministratorRole());
+    }
+
+    public function testHasOnlyAdministratorRoleForNonAdmin(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_EDITOR]]);
+        $this->assertFalse($this->user->hasOnlyAdministratorRole());
+    }
+
+    // -------------------------------------------------------------------------
+    // isNotAllowedToDeclareConflict
+    // -------------------------------------------------------------------------
+
+    public function testIsNotAllowedToDeclareConflictForRootOnly(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_ROOT]]);
+        $this->assertTrue($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    public function testIsNotAllowedToDeclareConflictForAdminOnly(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_ADMIN]]);
+        $this->assertTrue($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    public function testIsAllowedToDeclareConflictForRootWithEditorRole(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ROOT,
+            Episciences_Acl::ROLE_EDITOR,
+        ]]);
+        $this->assertFalse($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    public function testIsAllowedToDeclareConflictForAdminWithChiefEditorRole(): void
+    {
+        $this->user->setRoles([RVID => [
+            Episciences_Acl::ROLE_ADMIN,
+            Episciences_Acl::ROLE_CHIEF_EDITOR,
+        ]]);
+        $this->assertFalse($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    public function testIsAllowedToDeclareConflictForEditorAlone(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_EDITOR]]);
+        $this->assertFalse($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    public function testIsAllowedToDeclareConflictForReviewer(): void
+    {
+        $this->user->setRoles([RVID => [Episciences_Acl::ROLE_REVIEWER]]);
+        $this->assertFalse($this->user->isNotAllowedToDeclareConflict());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAllRoles
+    // -------------------------------------------------------------------------
+
+    public function testGetAllRolesWhenRolesAlreadySet(): void
+    {
+        $roles = [RVID => [Episciences_Acl::ROLE_EDITOR, Episciences_Acl::ROLE_MEMBER]];
+        $this->user->setRoles($roles);
+        $this->assertSame($roles, $this->user->getAllRoles());
+    }
+
+    // -------------------------------------------------------------------------
+    // Alias management (no DB needed when pre-setting aliases)
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetAlias(): void
+    {
+        $this->user->setAlias(42, 7);
+        $this->assertSame(7, $this->user->getAlias(42));
+    }
+
+    public function testGetAliasReturnsNullForUnknownDocId(): void
+    {
+        $this->user->setAliases([]);
+        $this->assertNull($this->user->getAlias(999));
+    }
+
+    public function testHasAlias(): void
+    {
+        $this->user->setAliases([42 => 1]);
+        $this->assertTrue($this->user->hasAlias(42));
+    }
+
+    public function testHasAliasReturnsFalseForUnknownDocId(): void
+    {
+        $this->user->setAliases([]);
+        $this->assertFalse($this->user->hasAlias(999));
+    }
+
+    public function testSetAliasesAndGetAliases(): void
+    {
+        $aliases = [10 => 1, 20 => 2, 30 => 3];
+        $this->user->setAliases($aliases);
+        $this->assertSame($aliases, $this->user->getAliases());
+    }
+
+    public function testGetAliasFallsBackToAliasesArrayWhenSet(): void
+    {
+        $this->user->setAliases([100 => 5, 200 => 9]);
+        $this->assertSame(5, $this->user->getAlias(100));
+        $this->assertSame(9, $this->user->getAlias(200));
+        $this->assertNull($this->user->getAlias(999));
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor with options array
+    // -------------------------------------------------------------------------
+
+    public function testConstructorWithOptionsArray(): void
+    {
+        $user = new Episciences_User([
+            'SCREEN_NAME' => 'Test User',
+            'LANGUEID'    => 'en',
+            'ORCID'       => '0000-0001-1234-5678',
+        ]);
+
+        $this->assertSame('Test User', $user->getScreenName());
+        $this->assertSame('en', $user->getLangueid());
+        $this->assertSame('0000-0001-1234-5678', $user->getOrcid());
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_AssignmentTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_AssignmentTest.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_Assignment;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_Assignment
+ *
+ * Tests pure logic (setters/getters, options constructor, constants).
+ * The save() method requires a DB connection and is not tested here.
+ *
+ * @covers Episciences_User_Assignment
+ */
+class Episciences_User_AssignmentTest extends TestCase
+{
+    private Episciences_User_Assignment $assignment;
+
+    protected function setUp(): void
+    {
+        $this->assignment = new Episciences_User_Assignment();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testItemConstants(): void
+    {
+        $this->assertSame('paper',   Episciences_User_Assignment::ITEM_PAPER);
+        $this->assertSame('section', Episciences_User_Assignment::ITEM_SECTION);
+        $this->assertSame('volume',  Episciences_User_Assignment::ITEM_VOLUME);
+    }
+
+    public function testRoleConstants(): void
+    {
+        $this->assertSame('reviewer',   Episciences_User_Assignment::ROLE_REVIEWER);
+        $this->assertSame('editor',     Episciences_User_Assignment::ROLE_EDITOR);
+        $this->assertSame('copyeditor', Episciences_User_Assignment::ROLE_COPY_EDITOR);
+    }
+
+    public function testStatusConstants(): void
+    {
+        $this->assertSame('pending',   Episciences_User_Assignment::STATUS_PENDING);
+        $this->assertSame('active',    Episciences_User_Assignment::STATUS_ACTIVE);
+        $this->assertSame('inactive',  Episciences_User_Assignment::STATUS_INACTIVE);
+        $this->assertSame('expired',   Episciences_User_Assignment::STATUS_EXPIRED);
+        $this->assertSame('cancelled', Episciences_User_Assignment::STATUS_CANCELLED);
+        $this->assertSame('declined',  Episciences_User_Assignment::STATUS_DECLINED);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testDefaultConstructorCreatesEmptyAssignment(): void
+    {
+        $this->assertNull($this->assignment->getId());
+        $this->assertNull($this->assignment->getItemid());
+        $this->assertNull($this->assignment->getUid());
+        $this->assertNull($this->assignment->getRoleid());
+        $this->assertNull($this->assignment->getStatus());
+    }
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $assignment = new Episciences_User_Assignment([
+            'id'     => 99,
+            'uid'    => 42,
+            'itemid' => 7,
+            'item'   => Episciences_User_Assignment::ITEM_PAPER,
+            'roleid' => Episciences_User_Assignment::ROLE_REVIEWER,
+            'status' => Episciences_User_Assignment::STATUS_ACTIVE,
+        ]);
+
+        $this->assertSame(99, $assignment->getId());
+        $this->assertSame(42, $assignment->getUid());
+        $this->assertSame(7, $assignment->getItemid());
+        $this->assertSame(Episciences_User_Assignment::ITEM_PAPER, $assignment->getItem());
+        $this->assertSame(Episciences_User_Assignment::ROLE_REVIEWER, $assignment->getRoleid());
+        $this->assertSame(Episciences_User_Assignment::STATUS_ACTIVE, $assignment->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // id
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetId(): void
+    {
+        $this->assignment->setId(123);
+        $this->assertSame(123, $this->assignment->getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // invitation_id
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetInvitationId(): void
+    {
+        $this->assignment->setInvitation_id(55);
+        $this->assertSame(55, $this->assignment->getInvitation_id());
+    }
+
+    // -------------------------------------------------------------------------
+    // itemid — cast to int
+    // -------------------------------------------------------------------------
+
+    public function testSetItemidCastsToInt(): void
+    {
+        $this->assignment->setItemid('42');
+        $this->assertSame(42, $this->assignment->getItemid());
+    }
+
+    public function testSetAndGetItemid(): void
+    {
+        $this->assignment->setItemid(10);
+        $this->assertSame(10, $this->assignment->getItemid());
+    }
+
+    // -------------------------------------------------------------------------
+    // rvid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetRvid(): void
+    {
+        $this->assignment->setRvid(3);
+        $this->assertSame(3, $this->assignment->getRvid());
+    }
+
+    // -------------------------------------------------------------------------
+    // item
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetItem(): void
+    {
+        $this->assignment->setItem(Episciences_User_Assignment::ITEM_VOLUME);
+        $this->assertSame(Episciences_User_Assignment::ITEM_VOLUME, $this->assignment->getItem());
+    }
+
+    // -------------------------------------------------------------------------
+    // uid — cast to int
+    // -------------------------------------------------------------------------
+
+    public function testSetUidCastsToInt(): void
+    {
+        $this->assignment->setUid('15');
+        $this->assertSame(15, $this->assignment->getUid());
+    }
+
+    // -------------------------------------------------------------------------
+    // from_uid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetFromUid(): void
+    {
+        $this->assignment->setFrom_uid(77);
+        $this->assertSame(77, $this->assignment->getFrom_uid());
+    }
+
+    public function testSetFromUidWithNull(): void
+    {
+        $this->assignment->setFrom_uid(null);
+        $this->assertNull($this->assignment->getFrom_uid());
+    }
+
+    public function testDefaultFromUidIsNull(): void
+    {
+        $this->assertNull($this->assignment->getFrom_uid());
+    }
+
+    public function testSetFromUidReturnsFluent(): void
+    {
+        $result = $this->assignment->setFrom_uid(5);
+        $this->assertInstanceOf(Episciences_User_Assignment::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // tmp_user
+    // -------------------------------------------------------------------------
+
+    public function testIsTmpUserDefaultsToZero(): void
+    {
+        $this->assertSame(0, $this->assignment->isTmp_user());
+    }
+
+    public function testSetTmpUserToTrue(): void
+    {
+        $this->assignment->setTmp_user(true);
+        $this->assertTrue((bool) $this->assignment->isTmp_user());
+    }
+
+    public function testSetTmpUserToFalse(): void
+    {
+        $this->assignment->setTmp_user(false);
+        $this->assertFalse((bool) $this->assignment->isTmp_user());
+    }
+
+    public function testSetTmpUserToOne(): void
+    {
+        $this->assignment->setTmp_user(1);
+        $this->assertSame(1, $this->assignment->isTmp_user());
+    }
+
+    // -------------------------------------------------------------------------
+    // roleid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetRoleid(): void
+    {
+        $this->assignment->setRoleid(Episciences_User_Assignment::ROLE_EDITOR);
+        $this->assertSame(Episciences_User_Assignment::ROLE_EDITOR, $this->assignment->getRoleid());
+    }
+
+    // -------------------------------------------------------------------------
+    // status
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetStatus(): void
+    {
+        $this->assignment->setStatus(Episciences_User_Assignment::STATUS_PENDING);
+        $this->assertSame(Episciences_User_Assignment::STATUS_PENDING, $this->assignment->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // when / deadline
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetWhen(): void
+    {
+        $this->assignment->setWhen('2024-03-15 10:00:00');
+        $this->assertSame('2024-03-15 10:00:00', $this->assignment->getWhen());
+    }
+
+    public function testSetAndGetDeadline(): void
+    {
+        $this->assignment->setDeadline('2024-06-30 23:59:59');
+        $this->assertSame('2024-06-30 23:59:59', $this->assignment->getDeadline());
+    }
+
+    // -------------------------------------------------------------------------
+    // setOptions
+    // -------------------------------------------------------------------------
+
+    public function testSetOptionsIgnoresUnknownKeys(): void
+    {
+        $this->assignment->setOptions(['nonexistentkey' => 'value', 'status' => 'active']);
+        $this->assertSame('active', $this->assignment->getStatus());
+    }
+
+    public function testSetOptionsReturnsFluent(): void
+    {
+        $result = $this->assignment->setOptions(['status' => 'pending']);
+        $this->assertInstanceOf(Episciences_User_Assignment::class, $result);
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_AssignmentsManagerTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_AssignmentsManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_AssignmentsManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_AssignmentsManager
+ *
+ * Tests the early-return guard in findById() that does not require DB.
+ * Other methods (getList, find) require DB and are not tested here.
+ *
+ * @covers Episciences_User_AssignmentsManager
+ */
+class Episciences_User_AssignmentsManagerTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // findById — non-numeric guard (no DB access)
+    // -------------------------------------------------------------------------
+
+    public function testFindByIdWithStringReturnsFalse(): void
+    {
+        $result = Episciences_User_AssignmentsManager::findById('not-a-number');
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithEmptyStringReturnsFalse(): void
+    {
+        $result = Episciences_User_AssignmentsManager::findById('');
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithArrayReturnsFalse(): void
+    {
+        $result = Episciences_User_AssignmentsManager::findById([1, 2, 3]);
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithNullReturnsFalse(): void
+    {
+        $result = Episciences_User_AssignmentsManager::findById(null);
+        $this->assertFalse($result);
+    }
+
+    public function testFindByIdWithNumericStringPassesGuard(): void
+    {
+        // '42' is_numeric → passes guard, then queries DB for non-existent ID
+        $result = Episciences_User_AssignmentsManager::findById('42');
+        // Either false (not found) or an Assignment instance (found)
+        $this->assertTrue(
+            $result === false || $result instanceof \Episciences_User_Assignment,
+            'Expected false or Episciences_User_Assignment'
+        );
+    }
+
+    public function testFindByIdWithLargeNonExistentIdReturnsFalse(): void
+    {
+        $result = Episciences_User_AssignmentsManager::findById(999999999);
+        $this->assertFalse($result);
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_InvitationAnswerTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_InvitationAnswerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_InvitationAnswer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_InvitationAnswer
+ *
+ * Tests pure logic: setters/getters, detail sanitization (strip_tags,
+ * htmlspecialchars, trim), getDetail/setDetail, constants.
+ * save() requires DB and is not tested here.
+ *
+ * @covers Episciences_User_InvitationAnswer
+ */
+class Episciences_User_InvitationAnswerTest extends TestCase
+{
+    private Episciences_User_InvitationAnswer $answer;
+
+    protected function setUp(): void
+    {
+        $this->answer = new Episciences_User_InvitationAnswer();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testAnswerConstants(): void
+    {
+        $this->assertSame('yes', Episciences_User_InvitationAnswer::ANSWER_YES);
+        $this->assertSame('no',  Episciences_User_InvitationAnswer::ANSWER_NO);
+    }
+
+    public function testDetailConstants(): void
+    {
+        $this->assertSame('delay',            Episciences_User_InvitationAnswer::DETAIL_DELAY);
+        $this->assertSame('reviewer_suggest', Episciences_User_InvitationAnswer::DETAIL_SUGGEST);
+        $this->assertSame('comment',          Episciences_User_InvitationAnswer::DETAIL_COMMENT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testDefaultConstructorCreatesEmptyAnswer(): void
+    {
+        $this->assertNull($this->answer->getId());
+        $this->assertNull($this->answer->getAnswer());
+        $this->assertNull($this->answer->getAnswer_date());
+    }
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $answer = new Episciences_User_InvitationAnswer([
+            'id'     => 5,
+            'answer' => Episciences_User_InvitationAnswer::ANSWER_YES,
+        ]);
+
+        $this->assertSame(5, $answer->getId());
+        $this->assertSame(Episciences_User_InvitationAnswer::ANSWER_YES, $answer->getAnswer());
+    }
+
+    // -------------------------------------------------------------------------
+    // id
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetId(): void
+    {
+        $this->answer->setId(12);
+        $this->assertSame(12, $this->answer->getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // answer
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetAnswer(): void
+    {
+        $this->answer->setAnswer(Episciences_User_InvitationAnswer::ANSWER_NO);
+        $this->assertSame(Episciences_User_InvitationAnswer::ANSWER_NO, $this->answer->getAnswer());
+    }
+
+    // -------------------------------------------------------------------------
+    // answer_date
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetAnswerDate(): void
+    {
+        $this->answer->setAnswer_date('2024-03-01 14:30:00');
+        $this->assertSame('2024-03-01 14:30:00', $this->answer->getAnswer_date());
+    }
+
+    // -------------------------------------------------------------------------
+    // setDetails / getDetails — cleanDetailValue sanitization
+    // -------------------------------------------------------------------------
+
+    public function testSetDetailsStripsHtmlTags(): void
+    {
+        $this->answer->setDetails([
+            Episciences_User_InvitationAnswer::DETAIL_COMMENT => '<b>Bold</b> comment',
+        ]);
+        $details = $this->answer->getDetails();
+        $this->assertStringNotContainsString('<b>', $details[Episciences_User_InvitationAnswer::DETAIL_COMMENT]);
+        $this->assertStringContainsString('Bold', $details[Episciences_User_InvitationAnswer::DETAIL_COMMENT]);
+    }
+
+    public function testSetDetailsEscapesHtmlEntities(): void
+    {
+        // Note: cleanDetailValue is applied in both setDetails() and getDetails(),
+        // causing double HTML-encoding: '&' → '&amp;' → '&amp;amp;', '>' → '&gt;' → '&amp;gt;'.
+        $this->answer->setDetails([
+            Episciences_User_InvitationAnswer::DETAIL_COMMENT => 'A & B > C',
+        ]);
+        $details = $this->answer->getDetails();
+        $value = $details[Episciences_User_InvitationAnswer::DETAIL_COMMENT];
+
+        // Raw special characters must not appear in the output
+        $this->assertStringNotContainsString(' & ', $value);
+        $this->assertStringNotContainsString(' > ', $value);
+        // After double encoding, '&' becomes '&amp;amp;'
+        $this->assertStringContainsString('&amp;amp;', $value);
+    }
+
+    public function testSetDetailsTrimsWhitespace(): void
+    {
+        $this->answer->setDetails([
+            Episciences_User_InvitationAnswer::DETAIL_COMMENT => '  trimmed  ',
+        ]);
+        $details = $this->answer->getDetails();
+        $this->assertSame('trimmed', $details[Episciences_User_InvitationAnswer::DETAIL_COMMENT]);
+    }
+
+    public function testSetDetailsWithMultipleKeys(): void
+    {
+        $this->answer->setDetails([
+            Episciences_User_InvitationAnswer::DETAIL_DELAY   => '2 weeks',
+            Episciences_User_InvitationAnswer::DETAIL_COMMENT => 'Happy to review',
+        ]);
+        $details = $this->answer->getDetails();
+        $this->assertArrayHasKey(Episciences_User_InvitationAnswer::DETAIL_DELAY, $details);
+        $this->assertArrayHasKey(Episciences_User_InvitationAnswer::DETAIL_COMMENT, $details);
+        $this->assertSame('2 weeks', $details[Episciences_User_InvitationAnswer::DETAIL_DELAY]);
+        $this->assertSame('Happy to review', $details[Episciences_User_InvitationAnswer::DETAIL_COMMENT]);
+    }
+
+    public function testSetDetailsWithEmptyArray(): void
+    {
+        $this->answer->setDetails([]);
+        $this->assertSame([], $this->answer->getDetails());
+    }
+
+    // -------------------------------------------------------------------------
+    // getDetail / setDetail
+    // -------------------------------------------------------------------------
+
+    public function testSetDetailAndGetDetail(): void
+    {
+        $this->answer->setDetail(Episciences_User_InvitationAnswer::DETAIL_SUGGEST, 'John Doe');
+        $result = $this->answer->getDetail(Episciences_User_InvitationAnswer::DETAIL_SUGGEST);
+        $this->assertSame('John Doe', $result);
+    }
+
+    public function testGetDetailReturnsFalseForMissingKey(): void
+    {
+        $this->assertFalse($this->answer->getDetail('nonexistent_key'));
+    }
+
+    public function testSetDetailStripsTagsFromValue(): void
+    {
+        $this->answer->setDetail(Episciences_User_InvitationAnswer::DETAIL_COMMENT, '<script>alert(1)</script>safe');
+        $result = $this->answer->getDetail(Episciences_User_InvitationAnswer::DETAIL_COMMENT);
+        $this->assertStringNotContainsString('<script>', $result);
+        $this->assertStringContainsString('safe', $result);
+    }
+
+    public function testSetDetailTrimsValue(): void
+    {
+        $this->answer->setDetail(Episciences_User_InvitationAnswer::DETAIL_DELAY, '  3 days  ');
+        $result = $this->answer->getDetail(Episciences_User_InvitationAnswer::DETAIL_DELAY);
+        $this->assertSame('3 days', $result);
+    }
+
+    public function testGetDetailsDefaultIsEmptyArray(): void
+    {
+        $this->assertSame([], $this->answer->getDetails());
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_InvitationTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_InvitationTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_Invitation;
+use Episciences_User_InvitationAnswer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_Invitation
+ *
+ * Tests pure logic (setters/getters, hasExpired, isAnswered, loadAnswer early return).
+ * save() requires DB and is not tested here.
+ *
+ * @covers Episciences_User_Invitation
+ */
+class Episciences_User_InvitationTest extends TestCase
+{
+    private Episciences_User_Invitation $invitation;
+
+    protected function setUp(): void
+    {
+        $this->invitation = new Episciences_User_Invitation();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testStatusConstants(): void
+    {
+        $this->assertSame('pending',   Episciences_User_Invitation::STATUS_PENDING);
+        $this->assertSame('accepted',  Episciences_User_Invitation::STATUS_ACCEPTED);
+        $this->assertSame('declined',  Episciences_User_Invitation::STATUS_DECLINED);
+        $this->assertSame('cancelled', Episciences_User_Invitation::STATUS_CANCELLED);
+    }
+
+    public function testTypeConstants(): void
+    {
+        $this->assertSame('reviewer', Episciences_User_Invitation::TYPE_REVIEWER);
+        $this->assertSame('editor',   Episciences_User_Invitation::TYPE_EDITOR);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    public function testDefaultConstructorCreatesEmptyInvitation(): void
+    {
+        $this->assertNull($this->invitation->getId());
+        $this->assertNull($this->invitation->getStatus());
+        $this->assertNull($this->invitation->getSending_date());
+        $this->assertNull($this->invitation->getExpiration_date());
+        $this->assertNull($this->invitation->getSender_uid());
+    }
+
+    public function testConstructorWithOptionsPopulatesFields(): void
+    {
+        $invitation = new Episciences_User_Invitation([
+            'id'     => 10,
+            'aid'    => 5,
+            'status' => Episciences_User_Invitation::STATUS_PENDING,
+        ]);
+
+        $this->assertSame(10, $invitation->getId());
+        $this->assertSame(5, $invitation->getAid());
+        $this->assertSame(Episciences_User_Invitation::STATUS_PENDING, $invitation->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // id
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetId(): void
+    {
+        $this->invitation->setId(42);
+        $this->assertSame(42, $this->invitation->getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // aid — cast to int
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetAid(): void
+    {
+        $this->invitation->setAid(7);
+        $this->assertSame(7, $this->invitation->getAid());
+    }
+
+    public function testGetAidCastsToInt(): void
+    {
+        $this->invitation->setAid('15');
+        $this->assertSame(15, $this->invitation->getAid());
+    }
+
+    public function testGetAidDefaultIsZeroWhenNotSet(): void
+    {
+        // getAid() returns (int)null = 0
+        $this->assertSame(0, $this->invitation->getAid());
+    }
+
+    // -------------------------------------------------------------------------
+    // status
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetStatus(): void
+    {
+        $this->invitation->setStatus(Episciences_User_Invitation::STATUS_ACCEPTED);
+        $this->assertSame(Episciences_User_Invitation::STATUS_ACCEPTED, $this->invitation->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // sending_date / expiration_date
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetSendingDate(): void
+    {
+        $this->invitation->setSending_date('2024-01-10 09:00:00');
+        $this->assertSame('2024-01-10 09:00:00', $this->invitation->getSending_date());
+    }
+
+    public function testSetAndGetExpirationDate(): void
+    {
+        $this->invitation->setExpiration_date('2024-02-10 09:00:00');
+        $this->assertSame('2024-02-10 09:00:00', $this->invitation->getExpiration_date());
+    }
+
+    // -------------------------------------------------------------------------
+    // hasExpired
+    // -------------------------------------------------------------------------
+
+    public function testHasExpiredReturnsFalseForFutureDate(): void
+    {
+        $this->invitation->setExpiration_date('2099-12-31 23:59:59');
+        $this->assertFalse($this->invitation->hasExpired());
+    }
+
+    public function testHasExpiredReturnsTrueForPastDate(): void
+    {
+        $this->invitation->setExpiration_date('2000-01-01 00:00:00');
+        $this->assertTrue($this->invitation->hasExpired());
+    }
+
+    // -------------------------------------------------------------------------
+    // isAnswered
+    // -------------------------------------------------------------------------
+
+    public function testIsAnsweredReturnsFalseWithNoAnswer(): void
+    {
+        $this->assertFalse($this->invitation->isAnswered());
+    }
+
+    public function testIsAnsweredReturnsTrueWhenAnswerSet(): void
+    {
+        $answer = new Episciences_User_InvitationAnswer();
+        $this->invitation->setAnswer($answer);
+        $this->assertTrue($this->invitation->isAnswered());
+    }
+
+    // -------------------------------------------------------------------------
+    // loadAnswer — early return when no id
+    // -------------------------------------------------------------------------
+
+    public function testLoadAnswerReturnsFalseWhenNoId(): void
+    {
+        // getId() returns null → early return false
+        $this->assertFalse($this->invitation->loadAnswer());
+    }
+
+    // -------------------------------------------------------------------------
+    // setOptions
+    // -------------------------------------------------------------------------
+
+    public function testSetOptionsIgnoresUnknownKeys(): void
+    {
+        $this->invitation->setOptions([
+            'unknownfield' => 'value',
+            'status'       => Episciences_User_Invitation::STATUS_DECLINED,
+        ]);
+        $this->assertSame(Episciences_User_Invitation::STATUS_DECLINED, $this->invitation->getStatus());
+    }
+
+    public function testSetOptionsReturnsFluent(): void
+    {
+        $result = $this->invitation->setOptions(['status' => 'pending']);
+        $this->assertInstanceOf(Episciences_User_Invitation::class, $result);
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_TmpTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_TmpTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_Tmp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_Tmp
+ *
+ * Tests pure logic: setters/getters, generateScreen_name, getUid override.
+ * DB-dependent methods (find, save, delete, availableUsername) are not tested here.
+ *
+ * @covers Episciences_User_Tmp
+ */
+class Episciences_User_TmpTest extends TestCase
+{
+    private Episciences_User_Tmp $user;
+
+    protected function setUp(): void
+    {
+        $this->user = new Episciences_User_Tmp();
+    }
+
+    // -------------------------------------------------------------------------
+    // getUid — overrides parent to always return null
+    // -------------------------------------------------------------------------
+
+    public function testGetUidAlwaysReturnsNull(): void
+    {
+        $this->assertNull($this->user->getUid());
+    }
+
+    // -------------------------------------------------------------------------
+    // id
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetId(): void
+    {
+        $this->user->setId(42);
+        $this->assertSame(42, $this->user->getId());
+    }
+
+    public function testDefaultIdIsNull(): void
+    {
+        $this->assertNull($this->user->getId());
+    }
+
+    // -------------------------------------------------------------------------
+    // status
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetStatus(): void
+    {
+        $this->user->setStatus('pending');
+        $this->assertSame('pending', $this->user->getStatus());
+    }
+
+    public function testDefaultStatusIsNull(): void
+    {
+        $this->assertNull($this->user->getStatus());
+    }
+
+    // -------------------------------------------------------------------------
+    // generateScreen_name
+    // -------------------------------------------------------------------------
+
+    public function testGenerateScreenNameConcatenatesFirstAndLastName(): void
+    {
+        $this->user->setFirstname('Marie');
+        $this->user->setLastname('Curie');
+        $this->user->generateScreen_name();
+
+        $this->assertSame('Marie Curie', $this->user->getScreenName());
+    }
+
+    public function testGenerateScreenNameTrimsSurroundingSpaces(): void
+    {
+        $this->user->setFirstname('');
+        $this->user->setLastname('Solo');
+        $this->user->generateScreen_name();
+
+        // sprintf('%s %s', '', 'Solo') => ' Solo', then trim => 'Solo'
+        $this->assertSame('Solo', $this->user->getScreenName());
+    }
+
+    public function testGenerateScreenNameWithOnlyFirstname(): void
+    {
+        $this->user->setFirstname('Han');
+        $this->user->setLastname('');
+        $this->user->generateScreen_name();
+
+        $this->assertSame('Han', $this->user->getScreenName());
+    }
+
+    // -------------------------------------------------------------------------
+    // setLang
+    // -------------------------------------------------------------------------
+
+    public function testSetLangStoresValue(): void
+    {
+        // setLang() writes to private $_lang; only observable via getLangueid()
+        // We verify it doesn't throw
+        $this->user->setLang('fr');
+        $this->addToAssertionCount(1); // ensure assertion count is met
+    }
+
+    // -------------------------------------------------------------------------
+    // toArray
+    // -------------------------------------------------------------------------
+
+    public function testToArrayContainsExpectedKeys(): void
+    {
+        $this->user->setId(1);
+        $this->user->setEmail('tmp@example.com');
+        $this->user->setFirstname('Alice');
+        $this->user->setLastname('Smith');
+        $this->user->setStatus('active');
+        $this->user->generateScreen_name();
+
+        $result = $this->user->toArray();
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertArrayHasKey('email', $result);
+        $this->assertArrayHasKey('firstname', $result);
+        $this->assertArrayHasKey('lastname', $result);
+        $this->assertArrayHasKey('fullname', $result);
+        $this->assertArrayHasKey('screen_name', $result);
+        $this->assertArrayHasKey('status', $result);
+    }
+
+    public function testToArrayValuesMatchSetters(): void
+    {
+        $this->user->setId(7);
+        $this->user->setEmail('test@test.com');
+        $this->user->setFirstname('Bob');
+        $this->user->setLastname('Doe');
+        $this->user->setStatus('pending');
+        $this->user->generateScreen_name();
+
+        $result = $this->user->toArray();
+
+        $this->assertSame(7, $result['id']);
+        $this->assertSame('test@test.com', $result['email']);
+        $this->assertSame('Bob', $result['firstname']);
+        $this->assertSame('Doe', $result['lastname']);
+        $this->assertSame('pending', $result['status']);
+        $this->assertSame('Bob Doe', $result['screen_name']);
+    }
+
+    public function testToArrayUsernameKey(): void
+    {
+        $result = $this->user->toArray();
+        $this->assertArrayHasKey('username', $result);
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_TokenTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_TokenTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_Token;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_Token
+ *
+ * Tests token generation, uid/email/token validation, constants.
+ * DB-related operations are not tested here.
+ *
+ * @covers Episciences_User_Token
+ */
+class Episciences_User_TokenTest extends TestCase
+{
+    private Episciences_User_Token $token;
+
+    protected function setUp(): void
+    {
+        $this->token = new Episciences_User_Token();
+    }
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    public function testTokenStringLengthIs40(): void
+    {
+        $this->assertSame(40, Episciences_User_Token::TOKEN_STRING_LENGTH);
+    }
+
+    public function testUsageConstant(): void
+    {
+        $this->assertSame('REVIEWER_INVITATION', Episciences_User_Token::USAGE_REVIEWER_INVITATION);
+    }
+
+    // -------------------------------------------------------------------------
+    // generateUserToken
+    // -------------------------------------------------------------------------
+
+    public function testGenerateUserTokenProduces40CharString(): void
+    {
+        $this->token->generateUserToken();
+        $this->assertSame(40, strlen($this->token->getToken()));
+    }
+
+    public function testGenerateUserTokenProducesHexString(): void
+    {
+        $this->token->generateUserToken();
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{40}$/', $this->token->getToken());
+    }
+
+    public function testGenerateUserTokenProducesUniqueValues(): void
+    {
+        $token1 = new Episciences_User_Token();
+        $token2 = new Episciences_User_Token();
+        $token1->generateUserToken();
+        // Sleep 1ms between calls to maximize uniqueness chance
+        usleep(1000);
+        $token2->generateUserToken();
+
+        // Not guaranteed unique but extremely unlikely to collide
+        $this->assertSame(40, strlen($token1->getToken()));
+        $this->assertSame(40, strlen($token2->getToken()));
+    }
+
+    // -------------------------------------------------------------------------
+    // setToken / getToken
+    // -------------------------------------------------------------------------
+
+    public function testSetValidToken(): void
+    {
+        $validToken = str_repeat('a', 40);
+        $this->token->setToken($validToken);
+        $this->assertSame($validToken, $this->token->getToken());
+    }
+
+    public function testSetTokenWith40CharHexString(): void
+    {
+        $sha1Token = sha1('test_value');
+        $this->token->setToken($sha1Token);
+        $this->assertSame($sha1Token, $this->token->getToken());
+    }
+
+    public function testSetTokenWithTooShortValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->token->setToken('short');
+    }
+
+    public function testSetTokenWithTooLongValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->token->setToken(str_repeat('a', 41));
+    }
+
+    public function testSetTokenWithEmptyStringThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->token->setToken('');
+    }
+
+    public function testSetTokenReturnsFluent(): void
+    {
+        $result = $this->token->setToken(sha1('fluent'));
+        $this->assertInstanceOf(Episciences_User_Token::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setUid / getUid
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUidWithValidPositiveInt(): void
+    {
+        $this->token->setUid(42);
+        $this->assertSame(42, (int) $this->token->getUid());
+    }
+
+    public function testSetUidWithEmptyStringSetsNull(): void
+    {
+        $this->token->setUid('');
+        $this->assertNull($this->token->getUid());
+    }
+
+    public function testSetUidWithZeroThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->token->setUid(0);
+    }
+
+    public function testSetUidWithNegativeValueThrowsException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->token->setUid(-5);
+    }
+
+    public function testSetUidReturnsFluent(): void
+    {
+        $result = $this->token->setUid(1);
+        $this->assertInstanceOf(Episciences_User_Token::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // setEmail / getEmail
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetEmail(): void
+    {
+        $this->token->setEmail('user@example.com');
+        $this->assertSame('user@example.com', $this->token->getEmail());
+    }
+
+    public function testSetEmailSanitizes(): void
+    {
+        // FILTER_SANITIZE_EMAIL removes characters not allowed in email addresses
+        $this->token->setEmail('user+tag@example.com');
+        $this->assertSame('user+tag@example.com', $this->token->getEmail());
+    }
+
+    public function testSetEmailReturnsFluent(): void
+    {
+        $result = $this->token->setEmail('a@b.com');
+        $this->assertInstanceOf(Episciences_User_Token::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // usage
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetUsage(): void
+    {
+        $this->token->setUsage(Episciences_User_Token::USAGE_REVIEWER_INVITATION);
+        $this->assertSame(Episciences_User_Token::USAGE_REVIEWER_INVITATION, $this->token->getUsage());
+    }
+
+    public function testSetUsageReturnsFluent(): void
+    {
+        $result = $this->token->setUsage('SOME_USAGE');
+        $this->assertInstanceOf(Episciences_User_Token::class, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // time_modified
+    // -------------------------------------------------------------------------
+
+    public function testSetAndGetTimeModified(): void
+    {
+        $this->token->setTime_modified('2024-05-01 12:00:00');
+        $this->assertSame('2024-05-01 12:00:00', $this->token->getTime_modified());
+    }
+
+    // -------------------------------------------------------------------------
+    // Constructor with options
+    // -------------------------------------------------------------------------
+
+    public function testConstructorWithOptions(): void
+    {
+        $token = new Episciences_User_Token([
+            'uid'   => 10,
+            'email' => 'test@example.com',
+            'usage' => Episciences_User_Token::USAGE_REVIEWER_INVITATION,
+        ]);
+
+        $this->assertSame(10, (int) $token->getUid());
+        $this->assertSame('test@example.com', $token->getEmail());
+        $this->assertSame(Episciences_User_Token::USAGE_REVIEWER_INVITATION, $token->getUsage());
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_User_UserMapperTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_User_UserMapperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User_UserMapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_User_UserMapper
+ *
+ * @covers Episciences_User_UserMapper
+ */
+class Episciences_User_UserMapperTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // getUserCountAfterDate (static)
+    // -------------------------------------------------------------------------
+
+    public function testGetUserCountAfterDateReturnsNonNegativeInteger(): void
+    {
+        $count = Episciences_User_UserMapper::getUserCountAfterDate('2000-01-01 00:00:00');
+        $this->assertIsInt($count);
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    public function testGetUserCountAfterDateWithDefaultParameterReturnsInt(): void
+    {
+        // Empty string triggers "current year" logic
+        $count = Episciences_User_UserMapper::getUserCountAfterDate('');
+        $this->assertIsInt($count);
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    public function testGetUserCountAfterFutureDateReturnsZeroOrPositive(): void
+    {
+        // A date far in the future should return 0 (no registrations yet)
+        $count = Episciences_User_UserMapper::getUserCountAfterDate('2099-12-31 23:59:59');
+        $this->assertIsInt($count);
+        $this->assertSame(0, $count);
+    }
+
+    public function testGetUserCountAfterVeryOldDateReturnsPositive(): void
+    {
+        // All users were registered after 1970, so count should be >= 0
+        $count = Episciences_User_UserMapper::getUserCountAfterDate('1970-01-01 00:00:00');
+        $this->assertIsInt($count);
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    // -------------------------------------------------------------------------
+    // findUserByFirstNameAndName (instance method)
+    // -------------------------------------------------------------------------
+
+    public function testFindUserByFirstNameAndNameWithNonExistentNameReturnsNull(): void
+    {
+        // This test requires the Zend_Db_Table metadata cache to be writable.
+        // In some CI/test environments the cache directory may be unavailable.
+        try {
+            $mapper = new Episciences_User_UserMapper();
+            // A name extremely unlikely to exist
+            $result = $mapper->findUserByFirstNameAndName('ZZZZNONEXISTENTUSER99999');
+            $this->assertNull($result);
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), 'metadataCache')) {
+                $this->markTestSkipped('Zend_Db_Table metadata cache not available: ' . $e->getMessage());
+            }
+            throw $e;
+        }
+    }
+
+    public function testFindUserByFirstNameAndNameWithBothParamsAndNonExistentReturnsNull(): void
+    {
+        try {
+            $mapper = new Episciences_User_UserMapper();
+            $result = $mapper->findUserByFirstNameAndName('NONEXISTENTLASTNAME', 'NONEXISTENTFIRST');
+            $this->assertNull($result);
+        } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), 'metadataCache')) {
+                $this->markTestSkipped('Zend_Db_Table metadata cache not available: ' . $e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/tests/unit/library/Episciences/user/Episciences_UsersManagerTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_UsersManagerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace unit\library\Episciences\user;
+
+use Episciences_User;
+use Episciences_UsersManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_UsersManager
+ *
+ * Covers pure logic methods that do not require a database connection.
+ *
+ * @covers Episciences_UsersManager
+ */
+class Episciences_UsersManagerTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // sortByName
+    // -------------------------------------------------------------------------
+
+    public function testSortByNameSortsAlphabeticallyByLastname(): void
+    {
+        $userZ = $this->makeUser('Zola', 'Emile');
+        $userA = $this->makeUser('Balzac', 'Honoré');
+        $userM = $this->makeUser('Maupassant', 'Guy');
+
+        $sorted = Episciences_UsersManager::sortByName([$userZ, $userM, $userA]);
+
+        $this->assertSame('Balzac', $sorted[0]->getLastname());
+        $this->assertSame('Maupassant', $sorted[1]->getLastname());
+        $this->assertSame('Zola', $sorted[2]->getLastname());
+    }
+
+    public function testSortByNameWithSameLastnameSortsByFirstname(): void
+    {
+        $userB = $this->makeUser('Curie', 'Pierre');
+        $userA = $this->makeUser('Curie', 'Marie');
+
+        $sorted = Episciences_UsersManager::sortByName([$userB, $userA]);
+
+        // sortByName comparison returns -1 when firstname a > b (descending for firstname)
+        // Pierre > Marie, so Pierre comes first (returns -1 → stays first)
+        $this->assertSame('Pierre', $sorted[0]->getFirstname());
+        $this->assertSame('Marie', $sorted[1]->getFirstname());
+    }
+
+    public function testSortByNameWithIdenticalNamesReturnsZero(): void
+    {
+        $user1 = $this->makeUser('Dupont', 'Jean');
+        $user2 = $this->makeUser('Dupont', 'Jean');
+
+        $sorted = Episciences_UsersManager::sortByName([$user1, $user2]);
+
+        $this->assertCount(2, $sorted);
+        $this->assertSame('Dupont', $sorted[0]->getLastname());
+        $this->assertSame('Dupont', $sorted[1]->getLastname());
+    }
+
+    public function testSortByNameWithSingleElement(): void
+    {
+        $user = $this->makeUser('Solo', 'Han');
+        $sorted = Episciences_UsersManager::sortByName([$user]);
+
+        $this->assertCount(1, $sorted);
+        $this->assertSame('Solo', $sorted[0]->getLastname());
+    }
+
+    public function testSortByNameWithEmptyArray(): void
+    {
+        $sorted = Episciences_UsersManager::sortByName([]);
+        $this->assertSame([], $sorted);
+    }
+
+    public function testSortByNamePreservesAllUsers(): void
+    {
+        $users = [
+            $this->makeUser('Zola', 'Emile'),
+            $this->makeUser('Balzac', 'Honoré'),
+            $this->makeUser('Flaubert', 'Gustave'),
+        ];
+
+        $sorted = Episciences_UsersManager::sortByName($users);
+        $this->assertCount(3, $sorted);
+    }
+
+    // -------------------------------------------------------------------------
+    // skipRootFullName
+    // -------------------------------------------------------------------------
+
+    public function testSkipRootFullNameExcludesUserWithUid1(): void
+    {
+        $root    = $this->makeUser('Root', 'Admin', 1);
+        $regular = $this->makeUser('Doe', 'Jane', 2);
+
+        $result = Episciences_UsersManager::skipRootFullName([$root, $regular]);
+
+        $this->assertArrayNotHasKey(1, $result);
+        $this->assertArrayHasKey(2, $result);
+    }
+
+    public function testSkipRootFullNameReturnsFullNameValues(): void
+    {
+        $user = $this->makeUser('Doe', 'Jane', 42);
+        $result = Episciences_UsersManager::skipRootFullName([$user]);
+
+        $this->assertArrayHasKey(42, $result);
+        $this->assertSame($user->getFullName(), $result[42]);
+    }
+
+    public function testSkipRootFullNameWithNoRootUser(): void
+    {
+        $user1 = $this->makeUser('Smith', 'Alice', 10);
+        $user2 = $this->makeUser('Jones', 'Bob', 20);
+
+        $result = Episciences_UsersManager::skipRootFullName([$user1, $user2]);
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey(10, $result);
+        $this->assertArrayHasKey(20, $result);
+    }
+
+    public function testSkipRootFullNameWithOnlyRootUser(): void
+    {
+        $root = $this->makeUser('Root', 'Admin', 1);
+        $result = Episciences_UsersManager::skipRootFullName([$root]);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testSkipRootFullNameWithEmptyArray(): void
+    {
+        $result = Episciences_UsersManager::skipRootFullName([]);
+        $this->assertSame([], $result);
+    }
+
+    public function testSkipRootFullNameKeysAreUserIds(): void
+    {
+        $user1 = $this->makeUser('Alpha', 'A', 5);
+        $user2 = $this->makeUser('Beta', 'B', 99);
+
+        $result = Episciences_UsersManager::skipRootFullName([$user1, $user2]);
+
+        $this->assertSame([5, 99], array_keys($result));
+    }
+
+    // -------------------------------------------------------------------------
+    // VALID_USER constant
+    // -------------------------------------------------------------------------
+
+    public function testValidUserConstantEqualsOne(): void
+    {
+        $this->assertSame(1, Episciences_UsersManager::VALID_USER);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a minimal Episciences_User with lastname, firstname, and optionally uid.
+     */
+    private function makeUser(string $lastname, string $firstname, int $uid = 0): Episciences_User
+    {
+        $user = new Episciences_User();
+        $user->setLastname($lastname);
+        $user->setFirstname($firstname);
+        if ($uid > 0) {
+            $user->setUid($uid);
+        }
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary

- Add **89 unit tests** for `Episciences/User`, `Ccsd/User` and `Ccsd/Auth` classes (pure logic, no DB/network required)
- Fix security bug in `Ccsd\Auth\Adapter\Idp::filterEmail()`
- Document existing bugs found during test writing

## Bug fix — `filterEmail()` (`Ccsd\Auth\Adapter\Idp`)

Two vulnerabilities in the email domain filter:

| # | Issue | Example bypass |
|---|---|---|
| 1 | Unescaped `.` in regex matched any character | `user@inraXfr` passed the filter |
| 2 | No trailing `$` anchor allowed subdomain injection | `attacker@inra.fr.evil.com` passed the filter |

**Fix:** use `preg_quote()` + `$` anchor — `preg_match('/'.preg_quote($emailFilter, '/').'$/', $email)`

## Bugs documented (not fixed — separate PRs needed)

- `Ccsd\Auth\Asso::valid()` always returns `true` (hardcoded), ignoring `setValid(false)` → the guard in `save()` is unreachable
- `Ccsd\Auth\Asso::toArray()` hardcodes `'valid' => 0` → DB insertions always store `valid=0` regardless of constructor argument
- `Ccsd\Auth\AdapterFactory::getTypedAdapter()` silently falls back to CAS for unknown adapter types

## Unused code flagged (no tests written)

- `Ccsd_Auth_Check` — zero references in codebase
- `Ccsd\Auth\Asso\Ext` — zero references in codebase
- `Ccsd_User_Merge` — zero references in codebase

## Test plan

- [x] `make test-php` passes: 908 tests, 0 failures, 8 skipped (DB/CAS env-specific)