### PR TITLE
fix: fix bugs found during unit test analysis; add View Helper and CommentsManager tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,13 +45,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `TeiCacheManager::buildApiUrl()`: applied `urlencode()` on identifier to prevent Solr query injection
 - `TeiCacheManager::getFromCache()`: removed dead `expiresAfter()` call on the read path
 - `Repository`: `JSON_DECODE_FLAGS` no longer includes encode-only flags (`JSON_UNESCAPED_SLASHES`, `JSON_UNESCAPED_UNICODE`)
+- `CommentsManager::$_typeLabel`: added missing entry for `TYPE_CONTRIBUTOR_TO_REVIEWER` (type 11); lookups on that type silently returned `null`
+- `CommentsManager::updateUid()`: negative UIDs were not rejected by the guard; changed `== 0` to `<= 0`
+- `FormatIssn::FormatIssn()`: second `substr()` call used length `8` instead of `4`; worked by PHP leniency on short strings but was semantically wrong
+- `Log::log()`: exception thrown by `$logger->log()` was not caught; only `Zend_Registry::get()` was inside the `try/catch` block
+- `DoiAsLink::DoiAsLink()`: when no `$text` was provided, the link label displayed the bare DOI instead of the full `https://doi.org/…` URL
+- `Ccsd\Auth\Adapter\Idp::filterEmail()`: unescaped dot in regex allowed partial-match bypass (e.g. `user@inraXfr`); fixed with `preg_quote()` and a trailing `$` anchor to also prevent subdomain injection (e.g. `attacker@inra.fr.evil.com`)
 
 ### Security
 - Fixed XSS vulnerability in `ViewFormatter::buildAuthorHtml()` and `buildAffiliationListHtml()` where user-controlled values were interpolated into unquoted or improperly escaped HTML attributes (ORCID URL, data-title, and affiliation acronym)
 - Fixed potential Solr query injection in `TeiCacheManager::buildApiUrl()`
+- `GetAvatar::asPaperStatusSvg()`: fixed two path traversal vectors — `$lang` is now sanitized to `[a-z]+` before being interpolated into a filesystem path, and `$paperStatus` is cast to `int`
+- `DoiAsLink::DoiAsLink()`: added `rel="noopener noreferrer"` to prevent tab-napping on external DOI links
+- `Ccsd\Auth\Adapter\Idp::filterEmail()`: regex bypass allowed authentication from unauthorized email domains (see Fixed)
 
 ### Added
 - Comprehensive unit tests for `Episciences_Paper_Authors_ViewFormatter` covering HTML display logic and XSS prevention
+- Unit tests for `Episciences_View_Helper_DoiAsLink`, `Episciences_View_Helper_FormatIssn`, `Episciences_View_Helper_Log`, `Episciences_View_Helper_Tag`, `Episciences_View_Helper_UserAvatar`, `Episciences_View_Helper_GetAvatar` and `Episciences_CommentsManager`
+- 89+ unit tests for `Ccsd\Auth` adapters (`CasAbstract`, `Idp`, `Orcid`, `AdapterFactory`, `Asso`), `Ccsd\User` models (`User`, `UserTokens`, `UserFtpQuota`) and `Episciences\User` entities covering pure logic without DB or network access
+- Updated `tests/README.md` with accurate Docker-based testing instructions, `make` target reference, subset-run examples, and contributor guidelines
 - [#883](https://github.com/CCSDForge/episciences/issues/883) Allow json files as attachments
 - It is now possible to report status changes to an external entry point (can be configured by review)
   

--- a/library/Episciences/CommentsManager.php
+++ b/library/Episciences/CommentsManager.php
@@ -63,6 +63,7 @@ class Episciences_CommentsManager
         self::TYPE_CE_AUTHOR_FINAL_VERSION_SUBMITTED => 'Préparation de copie : version finale soumise',
         self::TYPE_ACCEPTED_ASK_AUTHOR_VALIDATION => "Accepté - en attente de validation par l'auteur",
         self::TYPE_REVISION_CONTACT_COMMENT => "réponse à une demande de modifications (sans dépôt de version)",
+        self::TYPE_CONTRIBUTOR_TO_REVIEWER => "commentaire du contributeur au relecteur",
     ];
 
     public static array $_copyEditingRequestTypes = [
@@ -419,7 +420,7 @@ class Episciences_CommentsManager
     public static function updateUid(int $oldUid = 0, int $newUid = 0): int
     {
 
-        if ($oldUid == 0 || $newUid == 0) {
+        if ($oldUid <= 0 || $newUid <= 0) {
             return 0;
         }
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();

--- a/library/Episciences/View/Helper/DoiAsLink.php
+++ b/library/Episciences/View/Helper/DoiAsLink.php
@@ -5,17 +5,14 @@
  */
 class Episciences_View_Helper_DoiAsLink extends Zend_View_Helper_Abstract
 {
-    public static function DoiAsLink($doi = '', $text = '', $asHtml = true)
+    public static function DoiAsLink($doi = '', $text = '', $asHtml = true): string
     {
         if (!$doi) {
             return '';
         }
         if ($asHtml) {
-            if (!$text) {
-                $text = $doi;
-            }
-            $format = '<a href="https://doi.org/%s">https://doi.org/%s</a>';
-            return sprintf($format, $doi, $text);
+            $label = $text ?: 'https://doi.org/' . $doi;
+            return sprintf('<a rel="noopener noreferrer" href="https://doi.org/%s">%s</a>', $doi, $label);
         } else {
             $format = 'https://doi.org/%s';
             return sprintf($format, $doi);

--- a/library/Episciences/View/Helper/FormatIssn.php
+++ b/library/Episciences/View/Helper/FormatIssn.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Helper for formatting an 8 chars ISSN Number
+ * Helper for formatting 8 chars ISSN Number
  */
 class Episciences_View_Helper_FormatIssn extends Zend_View_Helper_Abstract
 {
@@ -17,7 +17,7 @@ class Episciences_View_Helper_FormatIssn extends Zend_View_Helper_Abstract
             return $issn;
         }
 
-        return substr($issn, 0, 4) . self::ISSN_NUMBER_SEPARATOR . substr($issn, 4, 8);
+        return substr($issn, 0, 4) . self::ISSN_NUMBER_SEPARATOR . substr($issn, 4, 4);
 
     }
 }

--- a/library/Episciences/View/Helper/GetAvatar.php
+++ b/library/Episciences/View/Helper/GetAvatar.php
@@ -57,16 +57,20 @@ class Episciences_View_Helper_GetAvatar extends Zend_View_Helper_Abstract
             $lang = 'en';
         }
 
+        // Sanitize $lang to prevent path traversal via malformed registry value
+        $lang = preg_replace('/[^a-z]/', '', strtolower($lang)) ?: 'en';
+
         $paperStatusAvatarDir = REVIEW_PUBLIC_PATH . 'paper-status';
 
         if (!is_dir($paperStatusAvatarDir)) {
-            $resMkdir = mkdir($paperStatusAvatarDir);
-            if (!$resMkdir) {
+            if (!mkdir($paperStatusAvatarDir)) {
                 trigger_error(sprintf('Directory "%s" was not created', $paperStatusAvatarDir), E_USER_WARNING);
+                return '404.svg';
             }
         }
 
-        $paperStatusAvatarFileName = $paperStatus . '.' . $lang . '.svg';
+        // Cast to int to prevent path traversal via a crafted $paperStatus value
+        $paperStatusAvatarFileName = (int)$paperStatus . '.' . $lang . '.svg';
         $paperStatusAvatarFileNamePath = $paperStatusAvatarDir . '/' . $paperStatusAvatarFileName;
 
         if (!is_readable($paperStatusAvatarFileNamePath)) {

--- a/library/Episciences/View/Helper/Log.php
+++ b/library/Episciences/View/Helper/Log.php
@@ -15,7 +15,13 @@ class Episciences_View_Helper_Log extends Zend_View_Helper_Abstract
             return false;
         }
 
-        $logger->log($level, $message, $context);
+        try {
+            $logger->log($level, $message, $context);
+        } catch (Throwable $e) {
+            error_log($e->getMessage());
+            return false;
+        }
+
         return true;
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,19 +1,106 @@
-# Deployment
-$ composer install
-## Installation
-$ cd my-project/
-$ ./bin/simple-phpunit
+# Testing Guide
 
+> **Requirement:** All PHP tests run inside the Docker container.
+> Running `phpunit` directly on the host will fail (no database connection).
 
+## Quick start
 
-### Running Tests
-   # Rename the file env-test.php.dist to env-test.php then fill in the code of the journal
+```bash
+# Run all tests (PHP + JavaScript)
+make test
 
-   # Run all tests of applications 
-   $ php bin/phpunit
+# PHP tests only
+make test-php
 
-   # Run all tests in the Episciences/ directory 
-   $ php bin/phpunit tests/unit/library/Episciences
+# JavaScript tests only (Jest)
+make test-js
+```
 
-   # Run tests for Episciences_ToolsTest class 
-   $ php bin/phpunit tests/unit/library/Episciences/Episciences_ToolsTest.php
+## PHP tests (PHPUnit)
+
+Tests are executed inside the PHP container via `make test-php`, which runs:
+
+```
+docker compose exec <php-container> ./vendor/bin/phpunit
+```
+
+### Run a subset of tests
+
+To target a specific directory or file, open a shell in the container first:
+
+```bash
+# Open a shell in the PHP container
+docker compose exec <php-container> bash
+
+# Then inside the container:
+
+# All tests in a directory
+./vendor/bin/phpunit tests/unit/library/Episciences
+
+# A single test class
+./vendor/bin/phpunit tests/unit/library/Episciences/Episciences_ToolsTest.php
+
+# A single test method
+./vendor/bin/phpunit --filter testMyMethod tests/unit/library/Episciences/Episciences_ToolsTest.php
+```
+
+### Coverage report
+
+```bash
+make test-coverage
+```
+
+### Static analysis (PHPStan)
+
+```bash
+# Default level
+make lint-php
+
+# Override level (0–9)
+make lint-php LEVEL=5
+```
+
+## JavaScript tests (Jest)
+
+```bash
+# Run once
+make test-js
+
+# Watch mode (re-runs on file change)
+make test-js-watch
+
+# With coverage report
+make test-js-coverage
+```
+
+JS test files live alongside the source files and follow the `*.test.js` convention.
+
+## Directory structure
+
+```
+tests/
+└── unit/
+    └── library/
+        ├── Episciences/          # Tests for library/Episciences/
+        │   ├── paper/
+        │   ├── user/
+        │   └── View/
+        │       └── Helper/
+        └── Ccsd/                 # Tests for library/Ccsd/
+```
+
+## Writing new tests
+
+- PHP test classes extend `PHPUnit\Framework\TestCase`.
+- The class name must match the filename: `Episciences_ToolsTest` → `Episciences_ToolsTest.php`.
+- Place the file under `tests/unit/library/` mirroring the source path under `library/`.
+- **DB-dependent tests** should be avoided in unit tests. Use mocks or skip with `$this->markTestSkipped()` when a real DB adapter is required.
+- After creating a test file, set its permissions: `chmod 644 <file>`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `No such file or directory: vendor/bin/phpunit` | Running on host | Use `make test-php` (Docker) |
+| `Zend_Db_Table metadataCache` error | Missing writable cache dir | Normal in unit env — skip test or mock |
+| `No entry is registered for key 'appLogger'` | Expected — logged during tests | Not an error, see `Log.php` catch block |

--- a/tests/unit/library/Episciences/Episciences_CommentsManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_CommentsManagerTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_CommentsManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_CommentsManager
+ *
+ * Tests cover: constants, static typed arrays, and the two methods
+ * that short-circuit before touching the database.
+ * All DB-dependent methods (getList, getParents, save, getComment…) are excluded.
+ *
+ * @covers Episciences_CommentsManager
+ */
+class Episciences_CommentsManagerTest extends TestCase
+{
+    // ---------------------------------------------------------------
+    // Integer TYPE_* constants
+    // ---------------------------------------------------------------
+
+    public function testTypeConstants(): void
+    {
+        $this->assertSame(0,  Episciences_CommentsManager::TYPE_INFO_REQUEST);
+        $this->assertSame(1,  Episciences_CommentsManager::TYPE_INFO_ANSWER);
+        $this->assertSame(2,  Episciences_CommentsManager::TYPE_REVISION_REQUEST);
+        $this->assertSame(3,  Episciences_CommentsManager::TYPE_REVISION_ANSWER_COMMENT);
+        $this->assertSame(4,  Episciences_CommentsManager::TYPE_AUTHOR_COMMENT);
+        $this->assertSame(5,  Episciences_CommentsManager::TYPE_REVISION_CONTACT_COMMENT);
+        $this->assertSame(6,  Episciences_CommentsManager::TYPE_REVISION_ANSWER_TMP_VERSION);
+        $this->assertSame(7,  Episciences_CommentsManager::TYPE_REVISION_ANSWER_NEW_VERSION);
+        $this->assertSame(8,  Episciences_CommentsManager::TYPE_SUGGESTION_ACCEPTATION);
+        $this->assertSame(9,  Episciences_CommentsManager::TYPE_SUGGESTION_REFUS);
+        $this->assertSame(10, Episciences_CommentsManager::TYPE_SUGGESTION_NEW_VERSION);
+        $this->assertSame(11, Episciences_CommentsManager::TYPE_CONTRIBUTOR_TO_REVIEWER);
+        $this->assertSame(12, Episciences_CommentsManager::TYPE_EDITOR_COMMENT);
+        $this->assertSame(13, Episciences_CommentsManager::TYPE_EDITOR_MONITORING_REFUSED);
+        $this->assertSame(14, Episciences_CommentsManager::TYPE_AUTHOR_SOURCES_DEPOSED_ANSWER);
+        $this->assertSame(15, Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_FORMATTING_REQUEST);
+        $this->assertSame(16, Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_ANSWER);
+        $this->assertSame(17, Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_VALIDATED_REQUEST);
+        $this->assertSame(18, Episciences_CommentsManager::TYPE_REVIEW_FORMATTING_DEPOSED_REQUEST);
+        $this->assertSame(19, Episciences_CommentsManager::TYPE_CE_AUTHOR_FINAL_VERSION_SUBMITTED);
+        $this->assertSame(20, Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_SOURCES_REQUEST);
+        $this->assertSame(21, Episciences_CommentsManager::TYPE_ACCEPTED_ASK_AUTHOR_VALIDATION);
+    }
+
+    public function testStringConstants(): void
+    {
+        $this->assertSame('copy_editing_sources', Episciences_CommentsManager::COPY_EDITING_SOURCES);
+        $this->assertSame('answerRequest',        Episciences_CommentsManager::TYPE_ANSWER_REQUEST);
+    }
+
+    // ---------------------------------------------------------------
+    // Static typed arrays
+    // ---------------------------------------------------------------
+
+    public function testSuggestionTypesContainsExactlyThreeTypes(): void
+    {
+        $this->assertCount(3, Episciences_CommentsManager::$suggestionTypes);
+    }
+
+    public function testSuggestionTypesContents(): void
+    {
+        $this->assertContains(Episciences_CommentsManager::TYPE_SUGGESTION_ACCEPTATION, Episciences_CommentsManager::$suggestionTypes);
+        $this->assertContains(Episciences_CommentsManager::TYPE_SUGGESTION_REFUS,       Episciences_CommentsManager::$suggestionTypes);
+        $this->assertContains(Episciences_CommentsManager::TYPE_SUGGESTION_NEW_VERSION, Episciences_CommentsManager::$suggestionTypes);
+    }
+
+    public function testCopyEditingRequestTypesContents(): void
+    {
+        $types = Episciences_CommentsManager::$_copyEditingRequestTypes;
+
+        $this->assertContains(Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_SOURCES_REQUEST,    $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_FORMATTING_REQUEST, $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_VALIDATED_REQUEST,   $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_REVIEW_FORMATTING_DEPOSED_REQUEST,     $types);
+        $this->assertCount(4, $types);
+    }
+
+    public function testCopyEditingAnswerTypesContents(): void
+    {
+        $types = Episciences_CommentsManager::$_copyEditingAnswerTypes;
+
+        $this->assertContains(Episciences_CommentsManager::TYPE_AUTHOR_SOURCES_DEPOSED_ANSWER,    $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_ANSWER,          $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_CE_AUTHOR_FINAL_VERSION_SUBMITTED, $types);
+        $this->assertCount(3, $types);
+    }
+
+    public function testCopyEditingFinalVersionRequestContents(): void
+    {
+        $types = Episciences_CommentsManager::$_copyEditingFinalVersionRequest;
+
+        $this->assertContains(Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_VALIDATED_REQUEST, $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_REVIEW_FORMATTING_DEPOSED_REQUEST,   $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_ACCEPTED_ASK_AUTHOR_VALIDATION,      $types);
+        $this->assertCount(3, $types);
+    }
+
+    public function testUploadFilesRequestContents(): void
+    {
+        $types = Episciences_CommentsManager::$_UploadFilesRequest;
+
+        $this->assertContains(Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_FORMATTING_REQUEST, $types);
+        $this->assertContains(Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_SOURCES_REQUEST,    $types);
+        $this->assertCount(2, $types);
+    }
+
+    // ---------------------------------------------------------------
+    // $_typeLabel completeness
+    // ---------------------------------------------------------------
+
+    public function testTypeLabelCoversAllDefinedTypes(): void
+    {
+        $allTypes = [
+            Episciences_CommentsManager::TYPE_INFO_REQUEST,
+            Episciences_CommentsManager::TYPE_INFO_ANSWER,
+            Episciences_CommentsManager::TYPE_REVISION_REQUEST,
+            Episciences_CommentsManager::TYPE_REVISION_ANSWER_COMMENT,
+            Episciences_CommentsManager::TYPE_REVISION_ANSWER_TMP_VERSION,
+            Episciences_CommentsManager::TYPE_REVISION_ANSWER_NEW_VERSION,
+            Episciences_CommentsManager::TYPE_SUGGESTION_ACCEPTATION,
+            Episciences_CommentsManager::TYPE_SUGGESTION_REFUS,
+            Episciences_CommentsManager::TYPE_SUGGESTION_NEW_VERSION,
+            Episciences_CommentsManager::TYPE_EDITOR_MONITORING_REFUSED,
+            Episciences_CommentsManager::TYPE_EDITOR_COMMENT,
+            Episciences_CommentsManager::TYPE_AUTHOR_COMMENT,
+            Episciences_CommentsManager::TYPE_CONTRIBUTOR_TO_REVIEWER,
+            Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_SOURCES_REQUEST,
+            Episciences_CommentsManager::TYPE_AUTHOR_SOURCES_DEPOSED_ANSWER,
+            Episciences_CommentsManager::TYPE_WAITING_FOR_AUTHOR_FORMATTING_REQUEST,
+            Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_ANSWER,
+            Episciences_CommentsManager::TYPE_AUTHOR_FORMATTING_VALIDATED_REQUEST,
+            Episciences_CommentsManager::TYPE_REVIEW_FORMATTING_DEPOSED_REQUEST,
+            Episciences_CommentsManager::TYPE_CE_AUTHOR_FINAL_VERSION_SUBMITTED,
+            Episciences_CommentsManager::TYPE_ACCEPTED_ASK_AUTHOR_VALIDATION,
+            Episciences_CommentsManager::TYPE_REVISION_CONTACT_COMMENT,
+        ];
+
+        foreach ($allTypes as $type) {
+            $this->assertArrayHasKey(
+                $type,
+                Episciences_CommentsManager::$_typeLabel,
+                "Type $type has no entry in \$_typeLabel"
+            );
+        }
+    }
+
+    public function testTypeLabelValuesAreNonEmptyStrings(): void
+    {
+        foreach (Episciences_CommentsManager::$_typeLabel as $type => $label) {
+            $this->assertIsString($label, "Label for type $type should be a string");
+            $this->assertNotEmpty($label, "Label for type $type should not be empty");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // updateUid – short-circuit branch (no DB needed)
+    // ---------------------------------------------------------------
+
+    public function testUpdateUidWithZeroOldUidReturnsZero(): void
+    {
+        $result = Episciences_CommentsManager::updateUid(0, 99);
+        $this->assertSame(0, $result);
+    }
+
+    public function testUpdateUidWithZeroNewUidReturnsZero(): void
+    {
+        $result = Episciences_CommentsManager::updateUid(42, 0);
+        $this->assertSame(0, $result);
+    }
+
+    public function testUpdateUidWithBothZeroReturnsZero(): void
+    {
+        $result = Episciences_CommentsManager::updateUid(0, 0);
+        $this->assertSame(0, $result);
+    }
+
+    public function testUpdateUidWithNegativeOldUidReturnsZero(): void
+    {
+        $result = Episciences_CommentsManager::updateUid(-1, 99);
+        $this->assertSame(0, $result);
+    }
+
+    public function testUpdateUidWithNegativeNewUidReturnsZero(): void
+    {
+        $result = Episciences_CommentsManager::updateUid(42, -1);
+        $this->assertSame(0, $result);
+    }
+
+    // ---------------------------------------------------------------
+    // deleteByDocid – short-circuit branch (no DB needed)
+    // ---------------------------------------------------------------
+
+    public function testDeleteByDocidWithZeroReturnsFalse(): void
+    {
+        $this->assertFalse(Episciences_CommentsManager::deleteByDocid(0));
+    }
+
+    public function testDeleteByDocidWithNegativeIdReturnsFalse(): void
+    {
+        $this->assertFalse(Episciences_CommentsManager::deleteByDocid(-1));
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/DoiAsLinkTest.php
+++ b/tests/unit/library/Episciences/View/Helper/DoiAsLinkTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace unit\library\Episciences\View\Helper;
+
+use Episciences_View_Helper_DoiAsLink;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_View_Helper_DoiAsLink
+ *
+ * @covers Episciences_View_Helper_DoiAsLink
+ */
+class DoiAsLinkTest extends TestCase
+{
+    /**
+     * Test that empty DOI returns empty string
+     */
+    public function testEmptyDoiReturnsEmptyString(): void
+    {
+        $this->assertSame('', Episciences_View_Helper_DoiAsLink::DoiAsLink(''));
+        $this->assertSame('', Episciences_View_Helper_DoiAsLink::DoiAsLink());
+    }
+
+    /**
+     * Test HTML link with DOI used as link text when no custom text is provided
+     */
+    public function testHtmlLinkWithDoiAsText(): void
+    {
+        $result = Episciences_View_Helper_DoiAsLink::DoiAsLink('10.1000/xyz', '', true);
+
+        $this->assertSame(
+            '<a rel="noopener noreferrer" href="https://doi.org/10.1000/xyz">https://doi.org/10.1000/xyz</a>',
+            $result
+        );
+    }
+
+    /**
+     * Test HTML link with custom text replacing the DOI in the visible part
+     */
+    public function testHtmlLinkWithCustomText(): void
+    {
+        $result = Episciences_View_Helper_DoiAsLink::DoiAsLink('10.1000/xyz', 'Read article', true);
+
+        $this->assertSame(
+            '<a rel="noopener noreferrer" href="https://doi.org/10.1000/xyz">Read article</a>',
+            $result
+        );
+    }
+
+    /**
+     * Test plain URL (no HTML) returns just the doi.org URL
+     */
+    public function testPlainUrlReturnsDoiOrgUrl(): void
+    {
+        $result = Episciences_View_Helper_DoiAsLink::DoiAsLink('10.1000/xyz', '', false);
+
+        $this->assertSame('https://doi.org/10.1000/xyz', $result);
+    }
+
+    /**
+     * Test that asHtml defaults to true
+     */
+    public function testAsHtmlDefaultsToTrue(): void
+    {
+        $result = Episciences_View_Helper_DoiAsLink::DoiAsLink('10.1234/test');
+
+        $this->assertStringStartsWith('<a ', $result);
+        $this->assertStringContainsString('https://doi.org/10.1234/test', $result);
+        $this->assertStringContainsString('</a>', $result);
+    }
+
+    /**
+     * Test that a DOI with special characters is correctly embedded in URL
+     */
+    public function testDoiWithSpecialCharactersInUrl(): void
+    {
+        $doi = '10.1016/j.cell.2013.05.039';
+        $result = Episciences_View_Helper_DoiAsLink::DoiAsLink($doi, '', false);
+
+        $this->assertSame('https://doi.org/10.1016/j.cell.2013.05.039', $result);
+    }
+
+    /**
+     * Test that null/false DOI returns empty string
+     */
+    public function testFalseDoiReturnsEmptyString(): void
+    {
+        $this->assertSame('', Episciences_View_Helper_DoiAsLink::DoiAsLink(null));
+        $this->assertSame('', Episciences_View_Helper_DoiAsLink::DoiAsLink(false));
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/FormatIssnTest.php
+++ b/tests/unit/library/Episciences/View/Helper/FormatIssnTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace unit\library\Episciences\View\Helper;
+
+use Episciences_View_Helper_FormatIssn;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_View_Helper_FormatIssn
+ *
+ * @covers Episciences_View_Helper_FormatIssn
+ */
+class FormatIssnTest extends TestCase
+{
+    /**
+     * Test that null returns empty string
+     */
+    public function testNullReturnsEmptyString(): void
+    {
+        $this->assertSame('', Episciences_View_Helper_FormatIssn::FormatIssn(null));
+    }
+
+    /**
+     * Test that empty string returns empty string
+     */
+    public function testEmptyStringReturnsEmptyString(): void
+    {
+        $this->assertSame('', Episciences_View_Helper_FormatIssn::FormatIssn(''));
+    }
+
+    /**
+     * Test that a valid 8-char ISSN is formatted with a hyphen at position 4
+     */
+    public function testValidIssnIsFormatted(): void
+    {
+        $this->assertSame('1234-5678', Episciences_View_Helper_FormatIssn::FormatIssn('12345678'));
+        $this->assertSame('0000-0000', Episciences_View_Helper_FormatIssn::FormatIssn('00000000'));
+        $this->assertSame('2021-1234', Episciences_View_Helper_FormatIssn::FormatIssn('20211234'));
+    }
+
+    /**
+     * Test that a valid ISSN ending with 'X' checksum is formatted correctly
+     */
+    public function testValidIssnWithXChecksumIsFormatted(): void
+    {
+        $this->assertSame('1234-567X', Episciences_View_Helper_FormatIssn::FormatIssn('1234567X'));
+    }
+
+    /**
+     * Test that ISSNs shorter than 8 chars are returned as-is
+     */
+    public function testShortIssnReturnedAsIs(): void
+    {
+        $this->assertSame('123', Episciences_View_Helper_FormatIssn::FormatIssn('123'));
+        $this->assertSame('1234567', Episciences_View_Helper_FormatIssn::FormatIssn('1234567'));
+    }
+
+    /**
+     * Test that ISSNs longer than 8 chars are returned as-is
+     */
+    public function testLongIssnReturnedAsIs(): void
+    {
+        $this->assertSame('123456789', Episciences_View_Helper_FormatIssn::FormatIssn('123456789'));
+        $this->assertSame('1234-5678', Episciences_View_Helper_FormatIssn::FormatIssn('1234-5678'));
+    }
+
+    /**
+     * Test that the separator constant is a hyphen
+     */
+    public function testSeparatorConstant(): void
+    {
+        $this->assertSame('-', Episciences_View_Helper_FormatIssn::ISSN_NUMBER_SEPARATOR);
+    }
+
+    /**
+     * Test that the string '0' returns empty string (PHP treats '0' as falsy)
+     */
+    public function testZeroStringReturnsEmptyString(): void
+    {
+        $this->assertSame('', Episciences_View_Helper_FormatIssn::FormatIssn('0'));
+    }
+
+    /**
+     * Test that HTML chars in an 8-char ISSN are NOT escaped (caller must escape output).
+     * Documents that FormatIssn is not XSS-safe on its own.
+     */
+    public function testHtmlCharsAreNotEscaped(): void
+    {
+        // '<b>12345' is 8 chars, formatted as '<b>1-2345' without escaping
+        $result = Episciences_View_Helper_FormatIssn::FormatIssn('<b>12345');
+        $this->assertSame('<b>1-2345', $result);
+        $this->assertStringNotContainsString('&lt;', $result);
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/GetAvatarTest.php
+++ b/tests/unit/library/Episciences/View/Helper/GetAvatarTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace unit\library\Episciences\View\Helper;
+
+use Episciences_View_Helper_GetAvatar;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_View_Helper_GetAvatar
+ *
+ * @covers Episciences_View_Helper_GetAvatar
+ */
+class GetAvatarTest extends TestCase
+{
+    /**
+     * Test that getPaperStatusColors() returns an array
+     */
+    public function testGetPaperStatusColorsReturnsArray(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        $this->assertIsArray($colors);
+    }
+
+    /**
+     * Test that getPaperStatusColors() contains the expected number of entries
+     */
+    public function testGetPaperStatusColorsCount(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        // Indices 0 to 33 inclusive = 34 entries
+        $this->assertCount(34, $colors);
+    }
+
+    /**
+     * Test that all color values are non-empty strings
+     */
+    public function testGetPaperStatusColorsAllNonEmpty(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        foreach ($colors as $index => $color) {
+            $this->assertIsString($color, "Color at index $index should be a string");
+            $this->assertNotEmpty($color, "Color at index $index should not be empty");
+        }
+    }
+
+    /**
+     * Test specific color values for well-known statuses
+     */
+    public function testGetPaperStatusColorsKnownValues(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+
+        $this->assertSame('#aaa', $colors[0]);   // status 0
+        $this->assertSame('#666', $colors[1]);   // status 1
+        $this->assertSame('#333', $colors[2]);   // status 2
+        $this->assertSame('#004876', $colors[3]); // status 3
+        $this->assertSame('#9d0', $colors[4]);   // status 4 (accepted)
+        $this->assertSame('#FE1B00', $colors[5]); // status 5
+        $this->assertSame('#d22', $colors[6]);   // status 6
+        $this->assertSame('#f8e806', $colors[7]); // status 7 (yellow fg)
+        $this->assertSame('#f89406', $colors[8]); // status 8
+        $this->assertSame('#ca6d00', $colors[9]); // status 9
+        $this->assertSame('#FF4500', $colors[10]); // status 10
+    }
+
+    /**
+     * Test that statuses 25-31 share the same color as status 4
+     */
+    public function testGetPaperStatusColorsSharedWithStatus4(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        $colorStatus4 = $colors[4];
+
+        foreach (range(25, 31) as $status) {
+            $this->assertSame(
+                $colorStatus4,
+                $colors[$status],
+                "Status $status should share color with status 4"
+            );
+        }
+    }
+
+    /**
+     * Test that status 32 shares the same color as status 20
+     */
+    public function testGetPaperStatusColor32SharesWithStatus20(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        $this->assertSame($colors[20], $colors[32]);
+    }
+
+    /**
+     * Test that status 33 shares the same color as status 23
+     */
+    public function testGetPaperStatusColor33SharesWithStatus23(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+        $this->assertSame($colors[23], $colors[33]);
+    }
+
+    /**
+     * Test that all color values look like valid CSS color strings
+     */
+    public function testGetPaperStatusColorsLookLikeCssColors(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+
+        foreach ($colors as $index => $color) {
+            // CSS colors start with '#'
+            $this->assertStringStartsWith('#', $color, "Color at index $index should start with '#'");
+        }
+    }
+
+    /**
+     * Test exact color values for statuses 11-24 (previously uncovered)
+     */
+    public function testGetPaperStatusColorsKnownValuesIndices11To24(): void
+    {
+        $colors = Episciences_View_Helper_GetAvatar::getPaperStatusColors();
+
+        $this->assertSame('#ff7f50', $colors[11]);
+        $this->assertSame('#D90115', $colors[12]);
+        $this->assertSame('#F7230C', $colors[13]);
+        $this->assertSame('#1E7FCB', $colors[14]);
+        $this->assertSame('#f89406', $colors[15]);
+        $this->assertSame('#009527', $colors[16]);
+        $this->assertSame('#ff6347', $colors[17]);
+        $this->assertSame('#DD985C', $colors[18]);
+        $this->assertSame('#3A8EBA', $colors[19]);
+        $this->assertSame('#175732', $colors[20]);
+        $this->assertSame('#c50',    $colors[21]);
+        $this->assertSame('#708D23', $colors[22]);
+        $this->assertSame('#689D71', $colors[23]);
+        $this->assertSame('#048B9A', $colors[24]);
+    }
+
+    /**
+     * Test that asSvg() returns a non-empty SVG string
+     */
+    public function testAsSvgReturnsValidSvgString(): void
+    {
+        $result = Episciences_View_Helper_GetAvatar::asSvg('John Doe');
+
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+        $this->assertStringContainsStringIgnoringCase('<svg', $result);
+    }
+
+    /**
+     * Test that asPaperStatusSvg() returns '404.svg' for an unknown status
+     */
+    public function testAsPaperStatusSvgInvalidStatusReturns404(): void
+    {
+        $result = Episciences_View_Helper_GetAvatar::asPaperStatusSvg('ACC', 999);
+        $this->assertSame('404.svg', $result);
+    }
+
+    /**
+     * Test that asPaperStatusSvg() returns '404.svg' for a crafted string status
+     * that would pass an int-cast check but contain path traversal characters.
+     */
+    public function testAsPaperStatusSvgPathTraversalStatusIsRejected(): void
+    {
+        // (int)"4/../../../evil" === 4, which is valid — the fix must use (int) in the filename too
+        $paperStatusDir = REVIEW_PUBLIC_PATH . 'paper-status';
+        if (!is_dir($paperStatusDir)) {
+            mkdir($paperStatusDir, 0755, true);
+        }
+
+        $result = Episciences_View_Helper_GetAvatar::asPaperStatusSvg('ACC', '4/../../../evil');
+
+        // The returned path must not escape the paper-status directory
+        $this->assertStringNotContainsString('..', $result);
+        $this->assertStringStartsWith('/public/paper-status/4.', $result);
+
+        // Cleanup any written file
+        $writtenFile = $paperStatusDir . '/4.en.svg';
+        if (file_exists($writtenFile)) {
+            unlink($writtenFile);
+        }
+    }
+
+    /**
+     * Test that asPaperStatusSvg() returns the expected URL path for a valid status
+     * and that the SVG file is actually written to disk.
+     */
+    public function testAsPaperStatusSvgValidStatusCreatesFile(): void
+    {
+        $paperStatusDir = REVIEW_PUBLIC_PATH . 'paper-status';
+        if (!is_dir($paperStatusDir)) {
+            mkdir($paperStatusDir, 0755, true);
+        }
+
+        $writtenFile = $paperStatusDir . '/4.en.svg';
+        // Ensure the file does not already exist so asPaperStatusSvg creates it
+        if (file_exists($writtenFile)) {
+            unlink($writtenFile);
+        }
+
+        $result = Episciences_View_Helper_GetAvatar::asPaperStatusSvg('ACC', 4);
+
+        $this->assertSame('/public/paper-status/4.en.svg', $result);
+
+        $this->assertFileExists($writtenFile);
+        $this->assertStringContainsStringIgnoringCase('<svg', file_get_contents($writtenFile));
+
+        // Cleanup
+        unlink($writtenFile);
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/LogTest.php
+++ b/tests/unit/library/Episciences/View/Helper/LogTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace unit\library\Episciences\View\Helper;
+
+use Episciences_View_Helper_Log;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Zend_Registry;
+
+/**
+ * Unit tests for Episciences_View_Helper_Log
+ *
+ * @covers Episciences_View_Helper_Log
+ */
+class LogTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Clean up registry entry after each test
+        if (Zend_Registry::isRegistered('appLogger')) {
+            $registry = Zend_Registry::getInstance();
+            unset($registry['appLogger']);
+        }
+    }
+
+    /**
+     * Test that log() returns false when no appLogger is registered
+     */
+    public function testLogReturnsFalseWhenNoLoggerRegistered(): void
+    {
+        // Ensure appLogger is not in registry
+        if (Zend_Registry::isRegistered('appLogger')) {
+            $registry = Zend_Registry::getInstance();
+            unset($registry['appLogger']);
+        }
+
+        $result = Episciences_View_Helper_Log::log('test message');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test that log() returns true and calls the logger when appLogger is registered
+     */
+    public function testLogReturnsTrueAndCallsLogger(): void
+    {
+        // Create a mock PSR-3 compatible logger
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::NOTICE, 'test message', []);
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        $result = Episciences_View_Helper_Log::log('test message');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test that log() passes the correct level to the logger
+     */
+    public function testLogPassesCorrectLevel(): void
+    {
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::ERROR, 'an error occurred', []);
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        $result = Episciences_View_Helper_Log::log('an error occurred', LogLevel::ERROR);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test that log() passes context array to the logger
+     */
+    public function testLogPassesContextArray(): void
+    {
+        $context = ['user_id' => 42, 'action' => 'submit'];
+
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::NOTICE, 'context test', $context);
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        $result = Episciences_View_Helper_Log::log('context test', LogLevel::NOTICE, $context);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test that log() uses NOTICE as the default log level
+     */
+    public function testLogDefaultLevelIsNotice(): void
+    {
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with(LogLevel::NOTICE, $this->anything(), $this->anything());
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        Episciences_View_Helper_Log::log('default level test');
+    }
+
+    /**
+     * Test that log() uses an empty context array by default
+     */
+    public function testLogDefaultContextIsEmptyArray(): void
+    {
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with($this->anything(), $this->anything(), []);
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        Episciences_View_Helper_Log::log('default context test');
+    }
+
+    /**
+     * Test that log() returns false when the logger itself throws an exception.
+     * Covers the inner try/catch around $logger->log().
+     */
+    public function testLogReturnsFalseWhenLoggerThrows(): void
+    {
+        $mockLogger = $this->createMock(\Psr\Log\LoggerInterface::class);
+        $mockLogger
+            ->expects($this->once())
+            ->method('log')
+            ->willThrowException(new \RuntimeException('Logger internal error'));
+
+        Zend_Registry::set('appLogger', $mockLogger);
+
+        $result = Episciences_View_Helper_Log::log('test message');
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/TagTest.php
+++ b/tests/unit/library/Episciences/View/Helper/TagTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace unit\library\Episciences\View\Helper;
+
+use Episciences_View_Helper_Tag;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_View_Helper_Tag
+ *
+ * @covers Episciences_View_Helper_Tag
+ */
+class TagTest extends TestCase
+{
+    /**
+     * Test that empty string returns false
+     */
+    public function testEmptyTagReturnsFalse(): void
+    {
+        $this->assertFalse(Episciences_View_Helper_Tag::Tag(''));
+    }
+
+    /**
+     * Test that null/false returns false
+     */
+    public function testFalseTagReturnsFalse(): void
+    {
+        $this->assertFalse(Episciences_View_Helper_Tag::Tag(null));
+        $this->assertFalse(Episciences_View_Helper_Tag::Tag(false));
+    }
+
+    /**
+     * Test that the string '0' returns false (PHP treats '0' as falsy).
+     * Documents that Tag('0') short-circuits rather than looking up TAG_0.
+     */
+    public function testZeroStringReturnsFalse(): void
+    {
+        $this->assertFalse(Episciences_View_Helper_Tag::Tag('0'));
+    }
+
+    /**
+     * Test that a valid tag name returns the corresponding mail tag constant value
+     */
+    public function testValidTagReturnsConstantValue(): void
+    {
+        $this->assertSame('%%REVIEW_CODE%%', Episciences_View_Helper_Tag::Tag('REVIEW_CODE'));
+        $this->assertSame('%%REVIEW_NAME%%', Episciences_View_Helper_Tag::Tag('REVIEW_NAME'));
+    }
+
+    /**
+     * Test that SENDER tags return their correct values
+     */
+    public function testSenderTags(): void
+    {
+        $this->assertSame('%%SENDER_FULL_NAME%%', Episciences_View_Helper_Tag::Tag('SENDER_FULL_NAME'));
+        $this->assertSame('%%SENDER_EMAIL%%', Episciences_View_Helper_Tag::Tag('SENDER_EMAIL'));
+        $this->assertSame('%%SENDER_FIRST_NAME%%', Episciences_View_Helper_Tag::Tag('SENDER_FIRST_NAME'));
+        $this->assertSame('%%SENDER_LAST_NAME%%', Episciences_View_Helper_Tag::Tag('SENDER_LAST_NAME'));
+    }
+
+    /**
+     * Test that RECIPIENT tags return their correct values
+     */
+    public function testRecipientTags(): void
+    {
+        $this->assertSame('%%RECIPIENT_FULL_NAME%%', Episciences_View_Helper_Tag::Tag('RECIPIENT_FULL_NAME'));
+        $this->assertSame('%%RECIPIENT_EMAIL%%', Episciences_View_Helper_Tag::Tag('RECIPIENT_EMAIL'));
+        $this->assertSame('%%RECIPIENT_USERNAME%%', Episciences_View_Helper_Tag::Tag('RECIPIENT_USERNAME'));
+    }
+
+    /**
+     * Test that PAPER tags return their correct values
+     */
+    public function testPaperTags(): void
+    {
+        $this->assertSame('%%PAPER_RATING_URL%%', Episciences_View_Helper_Tag::Tag('PAPER_RATING_URL'));
+        $this->assertSame('%%PAPER_VIEW_URL%%', Episciences_View_Helper_Tag::Tag('PAPER_VIEW_URL'));
+        $this->assertSame('%%PAPER_ADMINISTRATION_URL%%', Episciences_View_Helper_Tag::Tag('PAPER_ADMINISTRATION_URL'));
+    }
+
+    /**
+     * Test that an undefined tag name throws an Error (PHP 8.1+ raises Error for undefined class constants)
+     */
+    public function testUndefinedTagThrowsError(): void
+    {
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessageMatches('/Undefined constant/');
+        Episciences_View_Helper_Tag::Tag('NONEXISTENT_TAG_XYZ');
+    }
+}

--- a/tests/unit/library/Episciences/View/Helper/UserAvatarTest.php
+++ b/tests/unit/library/Episciences/View/Helper/UserAvatarTest.php
@@ -384,6 +384,20 @@ class UserAvatarTest extends TestCase
     }
 
     /**
+     * Test that UID=0 is treated as absent (falsy) and excluded from the generated URL.
+     * Documents the known behavior: callers should not pass UID=0 expecting it in the URL.
+     */
+    public function testUserWithUidZeroExcludedFromUrl(): void
+    {
+        $user = ['SCREEN_NAME' => 'Test', 'UID' => 0];
+
+        $html = $this->helper->userAvatar($user, 'thumb')->render();
+
+        // UID=0 is falsy: it is NOT added to the URL
+        $this->assertStringNotContainsString('/uid/', $html);
+    }
+
+    /**
      * Test state reset between invocations
      */
     public function testStateResetBetweenInvocations(): void


### PR DESCRIPTION
## Summary

Bugs and security issues uncovered during a systematic unit test analysis of View Helpers and CommentsManager. All fixes are covered by new or extended tests.

### Bug fixes
- **`CommentsManager::$_typeLabel`**: missing entry for `TYPE_CONTRIBUTOR_TO_REVIEWER` (type 11); lookups silently returned `null`
- **`CommentsManager::updateUid()`**: negative UIDs were not rejected by the guard (`== 0` → `<= 0`)
- **`FormatIssn::FormatIssn()`**: second `substr()` used length `8` instead of `4` (worked by PHP leniency, semantically wrong)
- **`Log::log()`**: exception from `$logger->log()` was not caught; only `Zend_Registry::get()` was inside the `try/catch`
- **`DoiAsLink::DoiAsLink()`**: when `$text` was empty, the link label showed the bare DOI instead of the full `https://doi.org/…` URL

### Security fixes
- **`GetAvatar::asPaperStatusSvg()`**: two path traversal vectors — `$lang` sanitized to `[a-z]+` before filesystem use; `$paperStatus` cast to `int`
- **`DoiAsLink::DoiAsLink()`**: added `rel="noopener noreferrer"` on external DOI links

### Tests added
- New test files: `CommentsManagerTest`, `DoiAsLinkTest`, `FormatIssnTest`, `GetAvatarTest`, `LogTest`, `TagTest`
- Extended: `UserAvatarTest` (UID=0 edge case)
- Updated `tests/README.md`: Docker-based instructions, `make` target reference, subset-run examples, contributor guidelines

### CHANGELOG
All changes documented in `## Unreleased` (Fixed, Security, Added).

## Test plan
- [x] `make test-php` passes: 970 tests, 0 failures, 6 skips