### PR TITLE
refactor: Rector automated PHP 8.1+ type declaration updates

### DIFF
--- a/application/Bootstrap.php
+++ b/application/Bootstrap.php
@@ -8,8 +8,6 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
 
     /**
      * Chargement automatique des différents modèles
-     *
-     * @return Zend_Loader_Autoloader
      */
     protected function _initAutoload(): \Zend_Loader_Autoloader
     {
@@ -127,8 +125,6 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
 
     /**
      * Ajout des Helpers de vue
-     *
-     * @return Zend_View
      */
     protected function _initView(): \Zend_View
     {
@@ -164,15 +160,14 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
     }
 
     /**
-     * @return Episciences_Acl|void
      * @throws Zend_Config_Exception
      * @throws Zend_Exception
      * @throws Zend_Navigation_Exception
      */
-    protected function _initAcl()
+    protected function _initAcl(): ?\Episciences_Acl
     {
         if (APPLICATION_MODULE === 'oai') {
-            return;
+            return null;
         }
         //Chargement des Acl et de la navigation
         $acl = new Episciences_Acl();

--- a/application/modules/oai/controllers/ErrorController.php
+++ b/application/modules/oai/controllers/ErrorController.php
@@ -3,16 +3,16 @@
 
 class ErrorController  extends Zend_Controller_Action
 {
-    public function init()
+    public function init(): void
     {
         $this->_helper->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
     }
-    public function indexAction()
+    public function indexAction(): void
     {
         $this->errorAction();
     }
-    public function errorAction()
+    public function errorAction(): void
     {
        $this->redirect(SERVER_PROTOCOL . '://' . DOMAIN);
     }

--- a/application/modules/oai/controllers/IndexController.php
+++ b/application/modules/oai/controllers/IndexController.php
@@ -3,7 +3,7 @@
 class IndexController extends Zend_Controller_Action
 {
 
-    public function init()
+    public function init(): void
     {
         $this->_helper->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
@@ -14,7 +14,7 @@ class IndexController extends Zend_Controller_Action
         return new Episciences_Oai_Server($this->getRequest());
     }
 
-    public function xslAction()
+    public function xslAction(): void
     {
         header('Content-Type: text/xml; charset=UTF-8');
         ob_clean();

--- a/application/modules/oai/controllers/OaiController.php
+++ b/application/modules/oai/controllers/OaiController.php
@@ -3,12 +3,12 @@
 
 class OaiController  extends Zend_Controller_Action
 {
-    public function init()
+    public function init(): void
     {
         $this->_helper->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
     }
-    public function xslAction()
+    public function xslAction(): void
     {
         $this->forward('xsl', 'index');
     }

--- a/library/Episciences/Paper/Authors.php
+++ b/library/Episciences/Paper/Authors.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 class Episciences_Paper_Authors
 {
@@ -37,7 +37,6 @@ class Episciences_Paper_Authors
 
     /**
      * set paper options
-     * @param array $options
      */
     public function setOptions(array $options): void
     {
@@ -52,9 +51,6 @@ class Episciences_Paper_Authors
     }
 
 
-    /**
-     * @return array
-     */
     public function toArray(): array
     {
         return [
@@ -74,7 +70,6 @@ class Episciences_Paper_Authors
     }
 
     /**
-     * @param int $idAuthors
      * @return $this
      */
     public function setAuthorsId(int $idAuthors): self
@@ -91,9 +86,6 @@ class Episciences_Paper_Authors
         return $this->_authors;
     }
 
-    /**
-     * @param string $authors
-     */
     public function setAuthors(string $authors): void
     {
         $this->_authors = $authors;
@@ -107,10 +99,8 @@ class Episciences_Paper_Authors
     }
 
     /**
-     * @param int $paperId
      * @return $this
      */
-
     public function setPaperId(int $paperId): self
     {
         $this->_paperId = $paperId;
@@ -118,9 +108,6 @@ class Episciences_Paper_Authors
     }
 
 
-    /**
-     * @return DateTime
-     */
     public function getDateUpdated(): DateTime
     {
         return $this->_dateUpdated;

--- a/library/Episciences/Paper/Authors/AffiliationHelper.php
+++ b/library/Episciences/Paper/Authors/AffiliationHelper.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 class Episciences_Paper_Authors_AffiliationHelper
 {
     public const ID_TYPE_ROR = 'ROR';
@@ -70,7 +70,6 @@ class Episciences_Paper_Authors_AffiliationHelper
      * Check whether an affiliation already has a ROR identifier
      *
      * @param array $authorAffiliation single affiliation entry from the DB
-     * @return bool
      */
     public static function hasRor(array $authorAffiliation): bool
     {
@@ -91,7 +90,6 @@ class Episciences_Paper_Authors_AffiliationHelper
      * Check whether an affiliation has an acronym attached
      *
      * @param array $authorAffiliation single affiliation entry from the DB
-     * @return bool
      */
     public static function hasAcronym(array $authorAffiliation): bool
     {
@@ -113,7 +111,6 @@ class Episciences_Paper_Authors_AffiliationHelper
      *
      * @param array $affiliationIdentifiers identifier array (e.g. from $affiliation['id'])
      * @param string $acronym acronym to check
-     * @return bool
      */
     public static function isAcronymDuplicate(array $affiliationIdentifiers, string $acronym): bool
     {
@@ -148,7 +145,7 @@ class Episciences_Paper_Authors_AffiliationHelper
             }
         }
 
-        if (empty($uniqueAcronyms)) {
+        if ($uniqueAcronyms === []) {
             return '';
         }
 
@@ -162,7 +159,6 @@ class Episciences_Paper_Authors_AffiliationHelper
      * Join acronym entries with the "||" separator
      *
      * @param array $acronymList list of formatted acronym strings
-     * @return string
      */
     public static function formatAcronymList(array $acronymList): string
     {
@@ -181,7 +177,7 @@ class Episciences_Paper_Authors_AffiliationHelper
         $matchedAcronym = '';
 
         foreach ($acronyms as $acronym) {
-            if ($acronym !== '' && str_contains($haystack, $acronym)) {
+            if ($acronym !== '' && str_contains($haystack, (string) $acronym)) {
                 $matchedAcronym = $acronym;
                 break;
             }

--- a/library/Episciences/Paper/Authors/EnrichmentService.php
+++ b/library/Episciences/Paper/Authors/EnrichmentService.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
@@ -238,12 +238,11 @@ class Episciences_Paper_Authors_EnrichmentService
     }
 
     /**
-     * @return Logger
      * @throws Exception
      */
     private static function getLogger(): Logger
     {
-        if (self::$logger === null) {
+        if (!self::$logger instanceof \Monolog\Logger) {
             $logFile = EPISCIENCES_LOG_PATH . self::LOG_FILE_PREFIX . date('Y-m-d') . '.log';
             self::$logger = new Logger(self::LOGGER_CHANNEL);
             self::$logger->pushHandler(new StreamHandler($logFile, Logger::INFO));

--- a/library/Episciences/Paper/Authors/HalTeiParser.php
+++ b/library/Episciences/Paper/Authors/HalTeiParser.php
@@ -1,5 +1,10 @@
 <?php
+declare(strict_types=1);
 
+/**
+ * Warning: rector will mess with this file converting isset to !property_exists
+ * Run tests immediately after if you apply Rector changes
+ */
 class Episciences_Paper_Authors_HalTeiParser
 {
     private const IDNO_TYPE_ORCID = 'ORCID';
@@ -78,7 +83,7 @@ class Episciences_Paper_Authors_HalTeiParser
         $lastAuthorIndex = array_key_last($parsedAuthors);
 
         foreach ($authorNode->affiliation as $affiliationNode) {
-            $structRef = (string)str_replace('#', '', $affiliationNode->attributes()->ref);
+            $structRef = str_replace('#', '', (string)$affiliationNode->attributes()->ref);
             $parsedAuthors[$lastAuthorIndex][self::KEY_AFFILIATIONS][] = $structRef;
         }
 
@@ -107,16 +112,13 @@ class Episciences_Paper_Authors_HalTeiParser
 
     /**
      * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
-     *
-     * @param string $orcid
-     * @return string
      */
     public static function normalizeOrcid(string $orcid): string
     {
         $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
 
-        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', $orcid)) {
-            $orcid = substr($orcid, 0, -1) . 'X';
+        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', (string) $orcid)) {
+            $orcid = substr((string) $orcid, 0, -1) . 'X';
         }
 
         return $orcid;
@@ -151,9 +153,6 @@ class Episciences_Paper_Authors_HalTeiParser
     }
 
     /**
-     * @param SimpleXMLElement $orgNode
-     * @param array &$organizationsByStructId
-     * @param string $structId
      * @return bool true if ROR was found
      */
     private static function extractRorFromOrg(SimpleXMLElement $orgNode, array &$organizationsByStructId, string $structId): bool
@@ -173,11 +172,6 @@ class Episciences_Paper_Authors_HalTeiParser
         return false;
     }
 
-    /**
-     * @param SimpleXMLElement $orgNode
-     * @param array &$organizationsByStructId
-     * @param string $structId
-     */
     private static function extractAcronymFromOrg(SimpleXMLElement $orgNode, array &$organizationsByStructId, string $structId): void
     {
         foreach ($orgNode->orgName as $orgNameNode) {

--- a/library/Episciences/Paper/AuthorsManager.php
+++ b/library/Episciences/Paper/AuthorsManager.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 class Episciences_Paper_AuthorsManager
 {
     /** @deprecated Use Episciences_Hal_TeiCacheManager::ONE_MONTH */
@@ -8,12 +8,9 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // ORCID normalization (stays here, used cross-module)
     // ────────────────────────────────────────────
-
     /**
      * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
      *
-     * @param string $orcid
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::normalizeOrcid()
      */
     public static function normalizeOrcid(string $orcid): string
@@ -22,8 +19,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $orcid
-     * @return string
      * @deprecated Use normalizeOrcid() instead
      */
     public static function cleanLowerCaseOrcid(string $orcid): string
@@ -34,9 +29,7 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Orchestration methods (delegate to new classes)
     // ────────────────────────────────────────────
-
     /**
-     * @param int $paperId
      * @return array|mixed
      * @throws JsonException
      */
@@ -46,8 +39,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param int $paperId
-     * @param int $idAuthorInJson
      * @return mixed|string
      * @throws JsonException
      */
@@ -59,11 +50,7 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — HAL TEI cache
     // ────────────────────────────────────────────
-
     /**
-     * @param string $identifier
-     * @param int $version
-     * @return bool
      * @throws \Psr\Cache\InvalidArgumentException
      * @deprecated Use Episciences_Hal_TeiCacheManager::fetchAndCache()
      */
@@ -73,9 +60,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $identifier
-     * @param int $version
-     * @return string
      * @deprecated Use Episciences_Hal_TeiCacheManager
      */
     public static function getTeiHalByIdentifier(string $identifier, int $version = 0): string
@@ -84,9 +68,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $identifier
-     * @param int $version
-     * @return string
      * @throws \Psr\Cache\InvalidArgumentException
      * @deprecated Use Episciences_Hal_TeiCacheManager::getFromCache()
      */
@@ -98,10 +79,7 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — HAL TEI parser
     // ────────────────────────────────────────────
-
     /**
-     * @param SimpleXMLElement $xmlString
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorsFromHalTei()
      */
     public static function getAuthorsFromHalTei(SimpleXMLElement $xmlString): array
@@ -110,9 +88,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param SimpleXMLElement|null $infoName
-     * @param array $globalAuthorArray
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorInfoFromXmlTei()
      */
     public static function getAuthorInfoFromXmlTei(?SimpleXMLElement $infoName, array $globalAuthorArray): array
@@ -121,9 +96,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param SimpleXMLElement|null $author
-     * @param array $globalAuthorArray
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAuthorStructureFromXmlTei()
      */
     public static function getAuthorStructureFromXmlTei(?SimpleXMLElement $author, array $globalAuthorArray): array
@@ -132,9 +104,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param SimpleXMLElement|null $author
-     * @param array $globalAuthorArray
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getOrcidAuthorFromXmlTei()
      */
     public static function getOrcidAuthorFromXmlTei(?SimpleXMLElement $author, array $globalAuthorArray): array
@@ -143,8 +112,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param SimpleXMLElement $xmlString
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::getAffiFromHalTei()
      */
     public static function getAffiFromHalTei(SimpleXMLElement $xmlString): array
@@ -153,9 +120,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $authorTei
-     * @param array $affiliationTei
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_HalTeiParser::mergeAuthorInfoAndAffiTei()
      */
     public static function mergeAuthorInfoAndAffiTei(array $authorTei, array $affiliationTei): array
@@ -166,10 +130,8 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — Repository
     // ────────────────────────────────────────────
-
     /**
      * @param int|string $paperId
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_Repository::getAuthorByPaperId()
      */
     public static function getAuthorByPaperId($paperId): array
@@ -178,8 +140,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $authors
-     * @return int
      * @deprecated Use Episciences_Paper_Authors_Repository::insert()
      */
     public static function insert(array $authors): int
@@ -188,8 +148,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param Episciences_Paper_Authors $authors
-     * @return int
      * @deprecated Use Episciences_Paper_Authors_Repository::update()
      */
     public static function update(Episciences_Paper_Authors $authors): int
@@ -198,7 +156,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param int $paperId
      * @return bool
      * @deprecated Use Episciences_Paper_Authors_Repository::deleteAuthorsByPaperId()
      */
@@ -208,8 +165,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param Episciences_Paper $paper
-     * @return int
      * @deprecated Use Episciences_Paper_Authors_Repository::insertFromPaper()
      */
     public static function InsertAuthorsFromPapers(Episciences_Paper $paper): int
@@ -218,9 +173,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param int $docId
-     * @param int $paperId
-     * @return void
      * @throws Zend_Db_Statement_Exception
      * @deprecated Use Episciences_Paper_Authors_Repository::verifyExistOrInsert()
      */
@@ -232,13 +184,7 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — Enrichment
     // ────────────────────────────────────────────
-
     /**
-     * @param int $repoId
-     * @param int $paperId
-     * @param string $identifier
-     * @param int $version
-     * @return int
      * @throws JsonException
      * @throws \Psr\Cache\InvalidArgumentException
      * @deprecated Use Episciences_Paper_Authors_EnrichmentService::enrichAffiOrcidFromTeiHalInDB()
@@ -249,9 +195,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $authorDb
-     * @param array $authorTei
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_EnrichmentService::mergeInfoDbAndInfoTei()
      */
     public static function mergeInfoDbAndInfoTei(array $authorDb, array $authorTei): array
@@ -260,8 +203,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $msg
-     * @return void
      * @throws Exception
      * @deprecated Use Episciences_Paper_Authors_EnrichmentService::logInfoMessage()
      */
@@ -273,10 +214,8 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — View formatter
     // ────────────────────────────────────────────
-
     /**
      * @param int|string $paperId
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_ViewFormatter::formatAuthorEnrichmentForViewByPaper()
      */
     public static function formatAuthorEnrichmentForViewByPaper($paperId): array
@@ -285,7 +224,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param int $paperId
      * @return array
      * @throws JsonException
      * @deprecated Use Episciences_Paper_Authors_ViewFormatter::filterAuthorsAndAffiNumeric()
@@ -298,10 +236,7 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     // Backward-compatible proxies — Affiliation helper
     // ────────────────────────────────────────────
-
     /**
-     * @param array $affiliation
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildWithRor()
      */
     public static function putAffiliationWithRORinArray(array $affiliation): array
@@ -310,8 +245,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $name
-     * @return array
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildNameOnly()
      */
     public static function putOnlyNameAffiliation(string $name): array
@@ -320,8 +253,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $ror
-     * @param string|null $acronym
      * @return array[]
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::buildRorOnly()
      */
@@ -331,9 +262,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $arrayAffi
-     * @param string $acronym
-     * @return bool
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::isAcronymDuplicate()
      */
     public static function acronymAlreadyExist(array $arrayAffi, string $acronym): bool
@@ -343,7 +271,6 @@ class Episciences_Paper_AuthorsManager
 
     /**
      * Format for the ROR input in paper View
-     * @param array $affiliation
      * @return array
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::formatAffiliationForInputRor()
      */
@@ -353,9 +280,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $acronyms
-     * @param string $haystack
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::setOrUpdateRorAcronym()
      */
     public static function setOrUpdateRorAcronym(array $acronyms, string $haystack): string
@@ -364,9 +288,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $name
-     * @param string $acronym
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::eraseAcronymInName()
      */
     public static function eraseAcronymInName(string $name, string $acronym): string
@@ -375,8 +296,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param string $acronym
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::cleanAcronym()
      */
     public static function cleanAcronym(string $acronym): string
@@ -385,8 +304,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $affiliationOfAuthor
-     * @return bool
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::hasAcronym()
      */
     public static function AcronymExist(array $affiliationOfAuthor): bool
@@ -395,8 +312,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $affiliationDb
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::getExistingAcronyms()
      */
     public static function getAcronymExisting(array $affiliationDb): string
@@ -405,8 +320,6 @@ class Episciences_Paper_AuthorsManager
     }
 
     /**
-     * @param array $acronymList
-     * @return string
      * @deprecated Use Episciences_Paper_Authors_AffiliationHelper::formatAcronymList()
      */
     public static function formatAcronymList(array $acronymList): string


### PR DESCRIPTION
## Summary

Rector-generated changes adding missing return type declarations for PHP 8.1+ compatibility:

- `Bootstrap`: return types on `_initAutoload()`, `_initView()`, `_initAcl()`; bare `return` → `return null`
- OAI controllers (`ErrorController`, `IndexController`, `OaiController`): `void` return types on `init()` and action methods
- `Paper/Authors*` and `AuthorsManager`: return types added, redundant annotations and dead code removed

## Test plan

- [ ] `make test-php` passes
- [ ] `make phpstan` reports no new errors
- [ ] OAI endpoint responds correctly