### PR TITLE
Fix DOI panel: avoid full page reloads on request, save, and cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- DOI panel (`paper_doi.phtml`, `request-doi.js`, `view.js`): requesting, saving, and cancelling a DOI no longer triggers a full page reload — the DOM is updated in place; the success feedback message after "Request a DOI" is suppressed since the newly rendered DOI link is sufficient.
 - Refactored `Episciences_Paper_ProjectsManager` God Class into 4 single-responsibility classes:
 - `Episciences_Paper_Projects_Repository` — database CRUD for `paper_projects`
 - `Episciences_Paper_Projects_HalApiClient` — HTTP calls to the HAL API

--- a/application/languages/en/js.php
+++ b/application/languages/en/js.php
@@ -262,4 +262,7 @@ return [
     "Erreur de connexion. Veuillez vérifier votre connexion réseau et réessayer." => "Connection error. Please check your network connection and try again.",
     "Voir plus" => "Show more",
     "Voir moins" => "Show less",
+    'Demander un DOI'=> 'Request a DOI',
+    'Annuler le DOI'=> 'Cancel theDOI',
+    'not-assigned' => 'Not assigned'
 ];

--- a/application/languages/fr/js.php
+++ b/application/languages/fr/js.php
@@ -31,4 +31,5 @@ return [
     'guest_editor' => 'Rédacteur invité',
     'epiadmin' => 'Root',
     'other' => 'autre',
+    'not-assigned' => 'Non assigné'
 ];

--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -153,65 +153,123 @@ class AdministratepaperController extends PaperDefaultController
     }
 
     /**
+     * AJAX endpoint to request a new DOI assignment for a paper.
+     *
+     * Returns a JSON object:
+     *   - doi:           DOI link HTML, or the string 'Error'
+     *   - doi_status:    Status badge HTML, or the string 'Error'
+     *   - feedback:      Success message (trimmed, may be empty)
+     *   - error_message: Error detail  (trimmed, may be empty)
      *
      * @throws Zend_Db_Statement_Exception
      * @throws Zend_Exception
      */
     public function ajaxrequestnewdoiAction(): void
     {
-        /** @var Zend_Controller_Request_Http $request */
-        $request = $this->getRequest();
-
-        if (!Episciences_Auth::isLogged() || !Episciences_Auth::isAllowedToManageDoi()) {
-            $resBack['doi'] = 'Error';
-            $resBack['doi_status'] = 'Error';
-            $resBack['error_message'] = 'Unauthorized access';
-            trigger_error('Unauthorized access to requestNewDoi by ' . Episciences_Auth::getUid(), E_USER_WARNING);
-            echo json_encode($resBack);
-            return;
-        }
-
-        if (!$request->isXmlHttpRequest() && !$request->isPost()) {
-            return;
-        }
-
+        // Disable layout and view rendering unconditionally so that every
+        // early-return path (auth failure, bad input…) sends clean JSON only.
         $this->_helper->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender();
 
+        /** @var Zend_Controller_Request_Http $request */
+        $request = $this->getRequest();
 
-        $docId = $request->getParam('docid');
-        $paper = Episciences_PapersManager::get($docId);
-
-        if (!$paper->canBeAssignedDOI()) {
-            $resBack['doi'] = 'Error';
-            $resBack['doi_status'] = 'Error';
-            $resBack['error_message'] = 'Le statut du document ne permet pas de lui assigner un DOI';
-            echo json_encode($resBack);
+        // Require both an XHR and a POST to prevent cross-site form submissions
+        // and direct browser navigation to this endpoint.
+        if (!$request->isPost() || !$request->isXmlHttpRequest()) {
             return;
         }
+
+        if (!Episciences_Auth::isLogged() || !Episciences_Auth::isAllowedToManageDoi()) {
+            trigger_error(
+                sprintf('Unauthorized access to requestNewDoi by uid=%s', Episciences_Auth::getUid()),
+                E_USER_WARNING
+            );
+            echo json_encode([
+                'doi'           => 'Error',
+                'doi_status'    => 'Error',
+                'feedback'      => '',
+                'error_message' => 'Unauthorized access',
+            ]);
+            return;
+        }
+
+        // Validate and sanitize the document identifier.
+        $docId = (int) $request->getPost('docid');
+        if ($docId <= 0) {
+            echo json_encode([
+                'doi'           => 'Error',
+                'doi_status'    => 'Error',
+                'feedback'      => '',
+                'error_message' => $this->view->translate('Invalid document identifier.'),
+            ]);
+            return;
+        }
+
+        // PapersManager::get() returns false when no matching paper is found;
+        // calling methods on false would cause a fatal error.
+        $paper = Episciences_PapersManager::get($docId);
+        if (!$paper instanceof Episciences_Paper) {
+            echo json_encode([
+                'doi'           => 'Error',
+                'doi_status'    => 'Error',
+                'feedback'      => '',
+                'error_message' => $this->view->translate('Document not found.'),
+            ]);
+            return;
+        }
+
+        if (!$paper->canBeAssignedDOI()) {
+            echo json_encode([
+                'doi'           => 'Error',
+                'doi_status'    => 'Error',
+                'feedback'      => '',
+                'error_message' => $this->view->translate('Le statut du document ne permet pas de lui assigner un DOI'),
+            ]);
+            return;
+        }
+
         $resCreateDoi = Episciences_Paper::createPaperDoi(RVID, $paper);
-        $resBack['feedback'] = '';
-        $resBack['error_message'] = '';
+
+        $doi          = 'Error';
+        $doiStatus    = 'Error';
+        $feedback     = '';
+        $errorMessage = '';
+        $doiStr       = '';
+
         if ($resCreateDoi['resUpdateDoi'] > 0) {
-            $resBack['doi'] = Episciences_View_Helper_DoiAsLink::DoiAsLink($resCreateDoi['doi']);
-            $resBack['feedback'] .= '&nbsp;' . $this->view->translate('DOI créé.');
+            $doiStr    = trim($resCreateDoi['doi'] ?? '');
+            $doi       = Episciences_View_Helper_DoiAsLink::DoiAsLink($resCreateDoi['doi']);
+            $feedback .= ' ' . $this->view->translate('DOI créé.');
         } else {
-            $resBack['doi'] = 'Error';
-            $resBack['error_message'] .= '&nbsp;' . $this->view->translate('Erreur lors de la creation du DOI.');
-            trigger_error('Error updating DOI ' . $resCreateDoi['doi'] . ' for paperId ' . $paper->getPaperid(), E_USER_WARNING);
-
+            $errorMessage .= ' ' . $this->view->translate('Erreur lors de la creation du DOI.');
+            trigger_error(
+                sprintf('Error updating DOI "%s" for paperId=%d', $resCreateDoi['doi'], $paper->getPaperid()),
+                E_USER_WARNING
+            );
         }
+
         if ($resCreateDoi['resUpdateDoiQueue'] > 0) {
-            $resBack['doi_status'] = sprintf(Episciences_Paper_DoiQueue::getStatusHtmlTemplate(Episciences_Paper_DoiQueue::STATUS_ASSIGNED), $this->view->translate(Episciences_Paper_DoiQueue::STATUS_ASSIGNED));
-            $resBack['feedback'] .= '&nbsp;' . $this->view->translate('Statut du DOI modifié.');
+            $doiStatus = sprintf(
+                Episciences_Paper_DoiQueue::getStatusHtmlTemplate(Episciences_Paper_DoiQueue::STATUS_ASSIGNED),
+                $this->view->translate(Episciences_Paper_DoiQueue::STATUS_ASSIGNED)
+            );
+            $feedback .= ' ' . $this->view->translate('Statut du DOI modifié.');
         } else {
-            $resBack['doi_status'] = 'Error';
-            $resBack['error_message'] .= '&nbsp;' . $this->view->translate('Erreur lors de la sauvegarde du statut du DOI.');
-            trigger_error('Error updating Queue ' . $resCreateDoi['doi'] . ' for paperId ' . $paper->getPaperid(), E_USER_WARNING);
+            $errorMessage .= ' ' . $this->view->translate('Erreur lors de la sauvegarde du statut du DOI.');
+            trigger_error(
+                sprintf('Error updating Queue "%s" for paperId=%d', $resCreateDoi['doi'], $paper->getPaperid()),
+                E_USER_WARNING
+            );
         }
-        $resBack = array_map('trim', $resBack);
-        echo json_encode($resBack);
 
+        echo json_encode([
+            'doi'           => trim($doi),
+            'doiStr'        => $doiStr,
+            'doi_status'    => trim($doiStatus),
+            'feedback'      => trim($feedback),
+            'error_message' => trim($errorMessage),
+        ]);
     }
 
 
@@ -3092,42 +3150,65 @@ class AdministratepaperController extends PaperDefaultController
         /** @var Zend_Controller_Request_Http $request */
         $request = $this->getRequest();
 
-        if (!$request->isXmlHttpRequest() && !$request->isPost()) {
+        if (!$request->isPost() || !$request->isXmlHttpRequest()) {
             return;
         }
 
         if (!Episciences_Auth::isLogged() || !Episciences_Auth::isAllowedToManageDoi()) {
-            echo 'Unauthorized access';
-            trigger_error(sprintf('Unauthorized access to savedoi by %s', Episciences_Auth::getUid()), E_USER_WARNING);
+            echo json_encode(['success' => false, 'doi' => '', 'error' => 'Unauthorized access']);
+            trigger_error(sprintf('Unauthorized access to savedoi by uid=%s', Episciences_Auth::getUid()), E_USER_WARNING);
             return;
         }
 
+        $docId   = (int) $request->getPost('docid');
+        $paperId = (int) $request->getPost('paperid');
+        $doi     = trim((string) $request->getPost('doi'));
 
-        $docid = ($request->getPost('docid')) ?: $request->getParam('docid');
-        $paperId = ($request->getPost('paperid')) ?: $request->getParam('paperid');
-        $doi = $request->getPost('doi');
-
-        $doiPattern = "/^10.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i";
-
-        if (($doi !== '') && !preg_match($doiPattern, $doi)) {
-            printf('<div class="alert alert-danger" role="alert">%s - (<code>%s</code>)</div>', $this->view->translate('Motif de DOI incorrect'), $doiPattern);
+        if ($docId <= 0 || $paperId <= 0) {
+            echo json_encode(['success' => false, 'doi' => '', 'error' => 'Invalid document ID']);
             return;
         }
 
-        if (!Episciences_PapersManager::paperExists($docid, RVID)) {
-            printf('<div class="alert alert-danger" role="alert">%s</div>', $this->view->translate('Document non trouvé'));
-            trigger_error(sprintf('Docid %s not found in RVID %s', $docid, RVID), E_USER_WARNING);
+        if ($doi === '') {
+            echo json_encode(['success' => false, 'doi' => '', 'error' => $this->view->translate('DOI cannot be empty')]);
             return;
         }
 
-        if (0 === Episciences_PapersManager::updateDoi($doi, $paperId)) {
-            printf('<div class="alert alert-danger" role="alert">%s</div>', $this->view->translate('Échec de la mise à jour'));
-            trigger_error(sprintf('Failed to update paperid %s with DOI %s', $paperId, $doi), E_USER_WARNING);
+        $doiPattern = '/^10\.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i';
+
+        if (!preg_match($doiPattern, $doi)) {
+            echo json_encode(['success' => false, 'doi' => '', 'error' => $this->view->translate('Motif de DOI incorrect')]);
             return;
         }
 
-        Episciences_Paper_Logger::log($paperId, $docid, Episciences_Paper_Logger::CODE_DOI_UPDATED, Episciences_Auth::getUid(), json_encode(['DOI' => $doi]), null, RVID);
-        echo $doi;
+        if (!Episciences_PapersManager::paperExists($docId, RVID)) {
+            echo json_encode(['success' => false, 'doi' => '', 'error' => $this->view->translate('Document non trouvé')]);
+            trigger_error(sprintf('Docid %d not found in RVID %s', $docId, RVID), E_USER_WARNING);
+            return;
+        }
+
+        // updateDoi() returns the number of rows affected by the UPDATE.
+        // 0 rows affected is not an error: it means the DOI was already set to this
+        // value (MySQL does not update unchanged rows). Treat as an idempotent success.
+        Episciences_PapersManager::updateDoi($doi, $paperId);
+
+        // Add or update the DOI queue entry with STATUS_ASSIGNED so the badge
+        // and "Cancel the DOI" button are shown in the UI after a manual save.
+        $doiQueueEntry = new Episciences_Paper_DoiQueue([
+            'paperid'    => $paperId,
+            'doi_status' => Episciences_Paper_DoiQueue::STATUS_ASSIGNED,
+        ]);
+        $existingQueue = Episciences_Paper_DoiQueueManager::findByPaperId($paperId);
+        if ($existingQueue->getId_doi_queue() > 0) {
+            $doiQueueEntry->setId_doi_queue($existingQueue->getId_doi_queue());
+            Episciences_Paper_DoiQueueManager::update($doiQueueEntry);
+        } else {
+            Episciences_Paper_DoiQueueManager::add($doiQueueEntry);
+        }
+
+        Episciences_Paper_Logger::log($paperId, $docId, Episciences_Paper_Logger::CODE_DOI_UPDATED, Episciences_Auth::getUid(), json_encode(['DOI' => $doi]), null, RVID);
+
+        echo json_encode(['success' => true, 'doi' => $doi, 'error' => '']);
     }
 
     /**
@@ -4804,34 +4885,72 @@ class AdministratepaperController extends PaperDefaultController
     }
 
     /**
+     * Cancel a pending DOI assignment request.
+     *
+     * Deletes the DOI queue entry for the paper, clears its DOI field,
+     * and logs the cancellation.
+     *
      * @return void
      */
     public function ajaxrequestremovedoiAction(): void
     {
         $this->_helper->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender();
+
         /** @var Zend_Controller_Request_Http $request */
         $request = $this->getRequest();
-        $post = $request->getPost();
-        if ($request->isXmlHttpRequest() && isset($post['paperId'])) {
-            $paperId = (int)$post['paperId'];
-            $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-            $getPapers = $db->select()->from(T_PAPERS)->where('paperId = ?', $paperId);
-            $papers = $db->fetchAll($getPapers);
-            if (count($papers) > 0) {
-                $getDoiQueue = Episciences_Paper_DoiQueueManager::findByPaperId($paperId);
-                if (!is_null($getDoiQueue->getId_doi_queue())) {
-                    $deleteDoiQueue = Episciences_Paper_DoiQueueManager::delete($paperId);
-                    if ($deleteDoiQueue === true) {
-                        $update = Episciences_PapersManager::updateDoi("", $paperId);
-                        if ($update > 0) {
-                            Episciences_Paper_Logger::log($paperId, $post['docId'], Episciences_Paper_Logger::CODE_DOI_CANCELED, Episciences_Auth::getUid(), json_encode(['DOI' => $post['doi'] . " canceled"]), null, RVID);
-                            echo json_encode($update, JSON_THROW_ON_ERROR);
-                        }
-                    }
-                }
-            }
+
+        if (!$request->isPost() || !$request->isXmlHttpRequest()) {
+            return;
         }
+
+        if (!Episciences_Auth::isLogged() || !Episciences_Auth::isAllowedToManageDoi()) {
+            echo json_encode(['success' => false, 'error' => 'Unauthorized access']);
+            trigger_error(sprintf('Unauthorized access to ajaxrequestremovedoi by uid=%s', Episciences_Auth::getUid()), E_USER_WARNING);
+            return;
+        }
+
+        $paperId = (int) $request->getPost('paperId');
+        $docId   = (int) $request->getPost('docId');
+
+        if ($paperId <= 0 || $docId <= 0) {
+            echo json_encode(['success' => false, 'error' => 'Invalid document ID']);
+            return;
+        }
+
+        if (!Episciences_PapersManager::paperExists($docId, RVID)) {
+            echo json_encode(['success' => false, 'error' => $this->view->translate('Document non trouvé')]);
+            trigger_error(sprintf('Docid %d not found in RVID %s', $docId, RVID), E_USER_WARNING);
+            return;
+        }
+
+        $doiQueue = Episciences_Paper_DoiQueueManager::findByPaperId($paperId);
+        if ($doiQueue->getId_doi_queue() <= 0) {
+            echo json_encode(['success' => false, 'error' => 'No pending DOI request found']);
+            return;
+        }
+
+        if (!Episciences_Paper_DoiQueueManager::delete($paperId)) {
+            echo json_encode(['success' => false, 'error' => 'Failed to cancel DOI request']);
+            return;
+        }
+
+        // Clear the DOI on the paper. updateDoi returning 0 is not an error here:
+        // it means the DOI field was already empty (idempotent operation).
+        Episciences_PapersManager::updateDoi('', $paperId);
+
+        $doi = trim((string) $request->getPost('doi'));
+        Episciences_Paper_Logger::log(
+            $paperId,
+            $docId,
+            Episciences_Paper_Logger::CODE_DOI_CANCELED,
+            Episciences_Auth::getUid(),
+            json_encode(['DOI' => $doi . ' canceled']),
+            null,
+            RVID
+        );
+
+        echo json_encode(['success' => true, 'error' => '']);
     }
 
     public function addcoauthorAction()

--- a/application/modules/journal/views/scripts/administratepaper/doiform.phtml
+++ b/application/modules/journal/views/scripts/administratepaper/doiform.phtml
@@ -10,8 +10,8 @@
         <div class="input-group">
             <input type="hidden" name="docid" value="<?= $this->docid ?>">
             <span class="input-group-addon">DOI</span>
-            <input type="text" class="form-control" id="doi" pattern="^10.\d{4,9}/[-._;()/:A-Za-z0-9]+$" placeholder="10.1234/56789"
-                   name="doi" <?php if ($this->doi) echo 'value="' . $this->escape($this->doi) . '"'; ?>/>
+            <input type="text" class="form-control" id="doi" pattern="^10\.\d{4,9}/[-._;()/:A-Za-z0-9]+$" placeholder="10.1234/56789"
+                   name="doi" required <?php if ($this->doi) echo 'value="' . $this->escape($this->doi) . '"'; ?>/>
         </div>
 
     </form>

--- a/application/modules/journal/views/scripts/partials/paper_doi.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_doi.phtml
@@ -1,7 +1,10 @@
 <script src="/js/administratepaper/request-doi.js"></script>
 
 
-<div id="doi-panel" class="panel panel-default collapsable">
+<div id="doi-panel" class="panel panel-default collapsable"
+     data-doi-assign-mode="<?= $this->doiAssignMode ?>"
+     data-paperid="<?= $this->paperid ?>"
+     data-docid="<?= $this->docid ?>">
     <div class="panel-heading">
         <h2 class="panel-title"><?php echo $this->translate('DOI'); ?></h2>
     </div>
@@ -63,14 +66,13 @@
 
         <?php endif; ?>
         <?php if ($this->doiQueueStatus === Episciences_Paper_DoiQueue::STATUS_ASSIGNED
-            && $this->doiAssignMode === Episciences_Paper_DoiQueue::STATUS_MANUAL
             && Episciences_Auth::isAllowedToManageDoi()) : ?>
             <button id="removeDoi" data-paperid="<?php echo $this->paperid ?>"
                     data-docid="<?php echo $this->docid ?>"
                     class="btn btn-default btn-sm popover-link"
                     style="margin-left: 5px"
                     onclick="removeDoi(this,<?= $this->paperid ?>,<?= $this->docid ?>,'<?= $this->paperDoi ?>')">
-                <span class="fa-solid fa-circle-minus"
+                <span class="fa-solid fa-rotate-left"
                       style="margin-right: 5px"></span><?php echo $this->translate('Annuler le DOI'); ?>
             </button>
         <?php endif; ?>

--- a/library/Episciences/Paper/DoiQueue.php
+++ b/library/Episciences/Paper/DoiQueue.php
@@ -107,7 +107,7 @@ class Episciences_Paper_DoiQueue
      */
     public function getId_doi_queue(): int
     {
-        return $this->_id_doi_queue;
+        return (int) $this->_id_doi_queue;
     }
 
     /**
@@ -123,7 +123,7 @@ class Episciences_Paper_DoiQueue
      */
     public function getPaperid(): int
     {
-        return $this->_paperid;
+        return (int) $this->_paperid;
     }
 
     /**

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -3186,8 +3186,8 @@ class Episciences_PapersManager
         try {
             $resUpdate = $db->update(T_PAPERS, $values, $where);
         } catch (Zend_Db_Adapter_Exception $exception) {
-            trigger_error($exception->getMessage(), E_USER_WARNING);
-            trigger_error('Error updating DOI ' . $doi . ' for paperId ' . $paperId, E_USER_WARNING);
+            error_log($exception->getMessage());
+            error_log('Error updating DOI ' . $doi . ' for paperId ' . $paperId);
             $resUpdate = 0;
         }
         return $resUpdate;

--- a/public/js/administratepaper/request-doi.js
+++ b/public/js/administratepaper/request-doi.js
@@ -1,62 +1,299 @@
-$(document).ready(function () {
-    let $doiStatusLoader = $('#doi-status-loader');
-    $('#requestNewDoi').each(function () {
-        var $this = $(this);
-        $this.on('click', function () {
-            var docid = $(this).data('docid');
-            let isError = false;
+/**
+ * Request DOI
+ *
+ * Handles DOI assignment requests for papers.
+ * On click of #requestNewDoi, sends a POST request to assign a new DOI,
+ * then updates the UI on success or displays an error alert on failure.
+ *
+ * Requires: public/js/utils/sanitizer.js (sanitizeHTML global)
+ */
 
-            $doiStatusLoader.html(getLoader());
-            $doiStatusLoader.show();
-            $.post(
-                '/administratepaper/ajaxrequestnewdoi',
-                {
-                    docid: docid,
-                },
-                function (data) {
-                    let json = data,
-                        objData = JSON.parse(json);
+(function () {
+    'use strict';
 
-                    if (objData.doi !== 'Error') {
-                        $('#doi-link').html('&nbsp;' + objData.doi);
-                        $('#requestNewDoi').remove();
-                        $('#doi-action').remove();
-                        $('#doi-status').prepend(
-                            '<div class="alert alert-success alert-dismissible" role="alert">' +
-                                objData.feedback +
-                                '</div>'
-                        );
-                    } else {
-                        isError = true;
-                    }
-                    if (objData.doi_status !== 'Error') {
-                        $('#doi-status').html(objData.doi_status);
-                        $('#requestNewDoi').remove();
-                        $('#doi-action').remove();
-                        $('#doi-status').prepend(
-                            '<div class="alert alert-success alert-dismissible" role="alert">' +
-                                objData.feedback +
-                                '</div>'
-                        );
-                    } else {
-                        isError = true;
-                    }
+    const ENDPOINT = '/administratepaper/ajaxrequestnewdoi';
 
-                    if (isError) {
-                        $doiStatusLoader.hide();
-                        $('#doi-status').prepend(
-                            '<div class="alert alert-danger alert-dismissible" role="alert">' +
-                                objData.error_message +
-                                '</div>'
-                        );
-                    }
-                },
-                'text'
-            ).done(function () {
-                if (!isError) {
-                    location.reload();
+    /** @type {AbortController|null} */
+    let activeRequest = null;
+
+    /**
+     * Exposed via _internals so tests can inspect internal state.
+     * (reload was removed: handleSuccess now updates the DOM directly.)
+     */
+    const _internals = {};
+
+    /**
+     * Parse the server response text as a JSON object.
+     * Returns null when the text is not valid JSON or not a plain object.
+     *
+     * @param {string} text
+     * @returns {{ doi: string, doi_status: string, feedback: string, error_message: string }|null}
+     */
+    function parseDoiResponse(text) {
+        try {
+            const data = JSON.parse(text);
+            if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+                return null;
+            }
+            return data;
+        } catch (_e) {
+            return null;
+        }
+    }
+
+    /**
+     * Sanitize a server-provided HTML string.
+     * Delegates to the global sanitizeHTML (DOMPurify wrapper) when available,
+     * otherwise falls back to plain-text rendering to prevent XSS.
+     *
+     * @param {string} html
+     * @returns {string}
+     */
+    function safeHtml(html) {
+        if (typeof sanitizeHTML === 'function') {
+            return sanitizeHTML(html);
+        }
+        // Safe fallback: encode the string as text so no HTML executes.
+        const div = document.createElement('div');
+        div.textContent = html;
+        return div.innerHTML;
+    }
+
+    /**
+     * Create a Bootstrap dismissible alert element with a sanitized message.
+     *
+     * @param {'success'|'danger'} type - Bootstrap alert variant
+     * @param {string} message - Message content (may contain server-provided HTML)
+     * @returns {HTMLDivElement}
+     */
+    function createAlert(type, message) {
+        const div = document.createElement('div');
+        div.setAttribute('role', 'alert');
+        div.className = `alert alert-${type} alert-dismissible`;
+        div.innerHTML = safeHtml(message);
+        return div;
+    }
+
+    /**
+     * Remove a DOM element by ID if it exists.
+     *
+     * @param {string} id
+     */
+    function removeById(id) {
+        const el = document.getElementById(id);
+        if (el) {
+            el.remove();
+        }
+    }
+
+    /**
+     * Apply a successful DOI response to the DOM without reloading the page.
+     *
+     * @param {{ doi: string, doiStr: string, doi_status: string, feedback: string }} data
+     * @param {HTMLElement|null} loader
+     */
+    function handleSuccess(data, loader) {
+        if (loader) {
+            loader.hidden = true;
+        }
+
+        // Update #doi-link with the sanitized DOI anchor HTML returned by DoiAsLink().
+        const doiLink = document.getElementById('doi-link');
+        if (doiLink) {
+            doiLink.innerHTML = safeHtml(data.doi);
+        }
+
+        const doiStatus = document.getElementById('doi-status');
+        if (doiStatus) {
+            // doi_status may contain server-generated markup — sanitize before insertion.
+            doiStatus.innerHTML = safeHtml(data.doi_status);
+        }
+
+        // Capture docId before removing the request button.
+        const requestBtn = document.getElementById('requestNewDoi');
+        const docId = requestBtn ? requestBtn.dataset.docid : '';
+
+        removeById('requestNewDoi');
+        removeById('doi-action');
+
+        // Build the "Cancel DOI" button and insert it after #doi-link.
+        const panel = document.getElementById('doi-panel');
+        const paperId = panel ? panel.dataset.paperid : '';
+        if (docId && paperId && doiLink) {
+            const cancelBtn = document.createElement('button');
+            cancelBtn.id = 'removeDoi';
+            cancelBtn.dataset.paperid = String(paperId);
+            cancelBtn.dataset.docid = String(docId);
+            cancelBtn.className = 'btn btn-default btn-sm popover-link';
+            cancelBtn.style.marginLeft = '5px';
+
+            const icon = document.createElement('span');
+            icon.className = 'fa-solid fa-rotate-left';
+            icon.style.marginRight = '5px';
+            cancelBtn.appendChild(icon);
+            cancelBtn.appendChild(document.createTextNode(
+                typeof translate === 'function' ? translate('Annuler le DOI') : 'Cancel DOI'
+            ));
+            cancelBtn.addEventListener('click', function () {
+                if (typeof removeDoi === 'function') {
+                    removeDoi(cancelBtn, Number(paperId), Number(docId), data.doiStr || '');
                 }
             });
+            doiLink.insertAdjacentElement('afterend', cancelBtn);
+        }
+
+        // Update the paper-doi anchor in the page header (if present).
+        const paperDoiAnchor = document.querySelector('div.paper-doi a');
+        if (paperDoiAnchor) {
+            paperDoiAnchor.textContent = data.doiStr || '';
+        }
+    }
+
+    /**
+     * Display an error alert and hide the loader.
+     *
+     * @param {string} errorMessage - Error text (may contain server-provided HTML)
+     * @param {HTMLElement|null} loader
+     */
+    function handleError(errorMessage, loader) {
+        if (loader) {
+            loader.hidden = true;
+        }
+
+        const doiStatus = document.getElementById('doi-status');
+        if (doiStatus) {
+            doiStatus.prepend(createAlert('danger', errorMessage));
+        }
+    }
+
+    /**
+     * Perform the fetch, returning { ok, text } or null on network failure.
+     * Handles AbortError separately to distinguish cancellation from failure.
+     *
+     * @param {string} docid
+     * @param {AbortSignal} signal
+     * @returns {Promise<{ ok: boolean, status: number, text: string }|null|'aborted'>}
+     */
+    async function fetchDoi(docid, signal) {
+        const response = await fetch(ENDPOINT, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                // Required so the PHP controller can verify this is an XHR request
+                // via Zend_Controller_Request_Http::isXmlHttpRequest().
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+            body: new URLSearchParams({ docid }),
+            signal,
         });
-    });
-});
+
+        const text = await response.text();
+        return { ok: response.ok, status: response.status, text };
+    }
+
+    /**
+     * Send a POST request to assign a DOI and process the response.
+     * Cancels any previously in-flight request before starting a new one.
+     *
+     * @param {string} docid - Document ID
+     * @param {HTMLElement|null} loader
+     * @returns {Promise<void>}
+     */
+    async function requestNewDoi(docid, loader) {
+        // Cancel a previous in-flight request if the user clicked again.
+        if (activeRequest) {
+            activeRequest.abort();
+        }
+
+        // Keep a local reference so the finally block can safely check ownership.
+        const controller = new AbortController();
+        activeRequest = controller;
+
+        let result;
+        try {
+            result = await fetchDoi(docid, controller.signal);
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                // A newer click already took over — exit silently.
+                return;
+            }
+            handleError('Network error. Please try again.', loader);
+            return;
+        } finally {
+            // Only clear the slot when this request is still considered active.
+            // A concurrent second click may have already replaced activeRequest.
+            if (activeRequest === controller) {
+                activeRequest = null;
+            }
+        }
+
+        if (!result.ok) {
+            handleError('Server error. Please try again.', loader);
+            return;
+        }
+
+        const data = parseDoiResponse(result.text);
+        if (!data) {
+            handleError('Unexpected server response.', loader);
+            return;
+        }
+
+        if (data.doi === 'Error' || data.doi_status === 'Error') {
+            handleError(data.error_message || 'An error occurred.', loader);
+        } else {
+            handleSuccess(data, loader);
+        }
+    }
+
+    /**
+     * Named click handler used with event delegation.
+     * Defined outside init() so the same reference can be passed to both
+     * removeEventListener (deduplication) and addEventListener.
+     *
+     * @param {MouseEvent} event
+     */
+    function handleRequestDoiClick(event) {
+        const button = event.target.closest('#requestNewDoi');
+        if (!button) {
+            return;
+        }
+
+        const loader = document.getElementById('doi-status-loader');
+        const docid = button.dataset.docid;
+        if (!docid) {
+            return;
+        }
+
+        if (loader) {
+            loader.innerHTML = typeof getLoader === 'function' ? getLoader() : '';
+            loader.hidden = false;
+        }
+
+        // Errors are handled inside requestNewDoi; .catch() prevents
+        // any unexpected rejection from surfacing as an unhandled promise.
+        requestNewDoi(docid, loader).catch(function (err) {
+            handleError('An unexpected error occurred.', loader);
+            console.error('[request-doi] Unhandled error:', err);
+        });
+    }
+
+    /**
+     * Wire up the DOI request handler via event delegation on the document.
+     * Using event delegation (rather than direct attachment) means that
+     * dynamically injected #requestNewDoi buttons (e.g. after a DOI cancellation)
+     * are handled without needing a second init() call.
+     * removeEventListener + addEventListener with the same stable reference
+     * prevents duplicate handlers when init() is called more than once.
+     */
+    function init() {
+        document.removeEventListener('click', handleRequestDoiClick);
+        document.addEventListener('click', handleRequestDoiClick);
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+
+    // Expose internals for unit testing only.
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { parseDoiResponse, createAlert, safeHtml, init, _internals };
+    }
+})();

--- a/tests/js/administratepaper/request-doi.test.js
+++ b/tests/js/administratepaper/request-doi.test.js
@@ -1,0 +1,689 @@
+/**
+ * Test suite for public/js/administratepaper/request-doi.js
+ *
+ * Covers:
+ *  - parseDoiResponse: valid / invalid / edge-case JSON
+ *  - safeHtml: sanitizeHTML delegation and fallback
+ *  - createAlert: element structure and XSS safety
+ *  - init: missing button guard, click handler wiring
+ *  - requestNewDoi (via button click): success flow, error flags,
+ *    HTTP errors, network errors, JSON parse errors, abort-on-double-click
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Global mocks required before requiring the module
+// ---------------------------------------------------------------------------
+
+// Mock sanitizeHTML (simulates the DOMPurify wrapper from sanitizer.js).
+global.sanitizeHTML = jest.fn(html => `[sanitized:${html}]`);
+
+// Mock getLoader (referenced but not defined in this file).
+global.getLoader = jest.fn(() => '<span class="spinner"></span>');
+
+// ---------------------------------------------------------------------------
+// Load the module
+// ---------------------------------------------------------------------------
+
+const { parseDoiResponse, createAlert, safeHtml, init, _internals } = require('../../../public/js/administratepaper/request-doi');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build the standard DOM fixture used by most click-handler tests. */
+function buildFixture({ docid = '42', hiddenLoader = true, paperid = '100', doiAssignMode = 'automatic' } = {}) {
+    document.body.innerHTML = `
+        <div id="doi-panel" data-paperid="${paperid}" data-doi-assign-mode="${doiAssignMode}" data-docid="${docid}">
+            <div id="doi-status-loader"${hiddenLoader ? ' hidden' : ''}></div>
+            <span id="doi-link"></span>
+            <div id="doi-status"></div>
+            <button id="requestNewDoi" data-docid="${docid}">Request DOI</button>
+            <div id="doi-action">Action buttons</div>
+        </div>
+    `;
+}
+
+/** Simulate a resolved fetch with the given JSON payload. */
+function mockFetchSuccess(payload) {
+    global.fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(JSON.stringify(payload)),
+    });
+}
+
+/** Simulate a resolved fetch whose response body is a raw string (not JSON). */
+function mockFetchRawText(text) {
+    global.fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(text),
+    });
+}
+
+/** Simulate an HTTP error response (e.g. 500). */
+function mockFetchHttpError(status = 500) {
+    global.fetch.mockResolvedValueOnce({
+        ok: false,
+        status,
+        text: () => Promise.resolve(''),
+    });
+}
+
+/** Simulate a network-level failure (fetch throws). */
+function mockFetchNetworkError() {
+    global.fetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+}
+
+/** Click the button and wait for all microtasks/promises to settle. */
+async function clickAndWait() {
+    document.getElementById('requestNewDoi').click();
+    // Flush the promise queue (three ticks: fetch resolution + text() + async chain).
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Shared beforeEach / afterEach
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // Replace the reload wrapper with a fresh mock before each test.
+    _internals.reload = jest.fn();
+});
+
+// ===========================================================================
+// parseDoiResponse
+// ===========================================================================
+
+describe('parseDoiResponse', () => {
+    describe('valid JSON objects', () => {
+        test('returns the parsed object for a well-formed response', () => {
+            const json = JSON.stringify({
+                doi: '10.1234/test',
+                doi_status: '<p>Assigned</p>',
+                feedback: 'DOI successfully assigned.',
+                error_message: '',
+            });
+            const result = parseDoiResponse(json);
+            expect(result).not.toBeNull();
+            expect(result.doi).toBe('10.1234/test');
+            expect(result.doi_status).toBe('<p>Assigned</p>');
+            expect(result.feedback).toBe('DOI successfully assigned.');
+        });
+
+        test('returns the parsed object when both fields signal Error', () => {
+            const json = JSON.stringify({
+                doi: 'Error',
+                doi_status: 'Error',
+                feedback: '',
+                error_message: 'Something went wrong.',
+            });
+            const result = parseDoiResponse(json);
+            expect(result).not.toBeNull();
+            expect(result.doi).toBe('Error');
+            expect(result.error_message).toBe('Something went wrong.');
+        });
+    });
+
+    describe('invalid input', () => {
+        test.each([
+            ['empty string', ''],
+            ['plain text', 'not json at all'],
+            ['malformed JSON', '{doi: "missing quotes"}'],
+            ['null literal', 'null'],
+            ['number literal', '42'],
+            ['string literal', '"just a string"'],
+            ['boolean literal', 'true'],
+        ])('returns null for %s', (_label, input) => {
+            expect(parseDoiResponse(input)).toBeNull();
+        });
+
+        test('returns null for a JSON array', () => {
+            expect(parseDoiResponse('[{"doi":"x"}]')).toBeNull();
+        });
+
+        test('returns null when called with null', () => {
+            // JSON.parse(null) → JSON.parse("null") → null; our guard catches it.
+            expect(parseDoiResponse(null)).toBeNull();
+        });
+    });
+});
+
+// ===========================================================================
+// safeHtml
+// ===========================================================================
+
+describe('safeHtml', () => {
+    test('delegates to sanitizeHTML when available', () => {
+        const result = safeHtml('<b>bold</b>');
+        expect(sanitizeHTML).toHaveBeenCalledWith('<b>bold</b>');
+        expect(result).toBe('[sanitized:<b>bold</b>]');
+    });
+
+    describe('falls back to textContent encoding when sanitizeHTML is absent', () => {
+        let savedSanitizeHTML;
+        beforeEach(() => {
+            savedSanitizeHTML = global.sanitizeHTML;
+            global.sanitizeHTML = undefined;
+        });
+        afterEach(() => {
+            global.sanitizeHTML = savedSanitizeHTML;
+        });
+
+        test('encodes the HTML string so no script tag is present', () => {
+            const result = safeHtml('<script>alert(1)</script>');
+            expect(result).not.toContain('<script>');
+            expect(result).toContain('&lt;script&gt;');
+        });
+    });
+
+    test('handles an empty string', () => {
+        const result = safeHtml('');
+        expect(result).toBe('[sanitized:]');
+    });
+});
+
+// ===========================================================================
+// createAlert
+// ===========================================================================
+
+describe('createAlert', () => {
+    test('creates a div with role="alert"', () => {
+        const el = createAlert('success', 'Great!');
+        expect(el.tagName).toBe('DIV');
+        expect(el.getAttribute('role')).toBe('alert');
+    });
+
+    test('applies the correct Bootstrap classes for success', () => {
+        const el = createAlert('success', 'OK');
+        expect(el.className).toContain('alert-success');
+        expect(el.className).toContain('alert-dismissible');
+    });
+
+    test('applies the correct Bootstrap classes for danger', () => {
+        const el = createAlert('danger', 'Oops');
+        expect(el.className).toContain('alert-danger');
+        expect(el.className).toContain('alert-dismissible');
+    });
+
+    test('passes the message through sanitizeHTML', () => {
+        sanitizeHTML.mockReturnValueOnce('safe content');
+        const el = createAlert('success', '<b>message</b>');
+        expect(sanitizeHTML).toHaveBeenCalledWith('<b>message</b>');
+        expect(el.innerHTML).toBe('safe content');
+    });
+
+    describe('falls back to plain-text rendering when sanitizeHTML is absent', () => {
+        let savedSanitizeHTML;
+        beforeEach(() => {
+            savedSanitizeHTML = global.sanitizeHTML;
+            global.sanitizeHTML = undefined;
+        });
+        afterEach(() => {
+            global.sanitizeHTML = savedSanitizeHTML;
+        });
+
+        test('does not create a real <img> element that could execute onerror', () => {
+            const el = createAlert('danger', '<img src=x onerror=alert(1)>');
+            // The fallback sets content via textContent; the raw <img> tag must
+            // not be parsed into the DOM — checking for the element is definitive.
+            expect(el.querySelector('img')).toBeNull();
+            // The markup must also not contain an un-encoded opening tag.
+            expect(el.innerHTML).not.toContain('<img');
+        });
+    });
+});
+
+// ===========================================================================
+// init — button wiring
+// ===========================================================================
+
+describe('init', () => {
+    test('does nothing when #requestNewDoi is absent', () => {
+        document.body.innerHTML = '<div id="doi-status"></div>';
+        expect(() => init()).not.toThrow();
+    });
+
+    test('attaches a click listener when the button is present', () => {
+        buildFixture();
+        init();
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve('{}'),
+        });
+        const button = document.getElementById('requestNewDoi');
+        expect(() => button.click()).not.toThrow();
+    });
+
+    test('does not fire a fetch when data-docid is empty', async () => {
+        buildFixture({ docid: '' });
+        init();
+        document.getElementById('requestNewDoi').click();
+        await Promise.resolve();
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});
+
+// ===========================================================================
+// Click handler — loader visibility
+// ===========================================================================
+
+describe('loader behaviour on click', () => {
+    test('shows the loader when the button is clicked', async () => {
+        buildFixture();
+        init();
+        mockFetchSuccess({
+            doi: '10.1/ok',
+            doi_status: '<p>ok</p>',
+            feedback: 'Assigned',
+            error_message: '',
+        });
+        const loader = document.getElementById('doi-status-loader');
+        expect(loader.hidden).toBe(true);
+
+        document.getElementById('requestNewDoi').click();
+
+        // Loader should be visible immediately after click (before fetch resolves).
+        expect(loader.hidden).toBe(false);
+        await clickAndWait(); // let promises settle
+    });
+
+    test('injects getLoader() markup into the loader element', () => {
+        buildFixture();
+        init();
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            text: () => new Promise(() => {}), // never resolves — keeps loader visible
+        });
+        document.getElementById('requestNewDoi').click();
+        const loader = document.getElementById('doi-status-loader');
+        expect(loader.innerHTML).toBe('<span class="spinner"></span>');
+    });
+
+    test('hides the loader when the server returns an error flag', async () => {
+        buildFixture();
+        init();
+        mockFetchSuccess({
+            doi: 'Error',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: 'DOI assignment failed.',
+        });
+        await clickAndWait();
+        expect(document.getElementById('doi-status-loader').hidden).toBe(true);
+    });
+});
+
+// ===========================================================================
+// Success flow
+// ===========================================================================
+
+describe('success flow', () => {
+    const successPayload = {
+        doi: '10.5802/xyz',
+        doiStr: '10.5802/xyz',
+        doi_status: '<p>Status: assigned</p>',
+        feedback: 'Your DOI has been assigned.',
+        error_message: '',
+    };
+
+    beforeEach(async () => {
+        buildFixture();
+        init();
+        mockFetchSuccess(successPayload);
+        await clickAndWait();
+    });
+
+    test('sends a POST to the correct endpoint', () => {
+        expect(global.fetch).toHaveBeenCalledWith(
+            '/administratepaper/ajaxrequestnewdoi',
+            expect.objectContaining({ method: 'POST' })
+        );
+    });
+
+    test('includes the docid in the request body', () => {
+        const callArgs = global.fetch.mock.calls[0][1];
+        expect(callArgs.body.toString()).toContain('docid=42');
+    });
+
+    test('sets Content-Type to application/x-www-form-urlencoded', () => {
+        const callArgs = global.fetch.mock.calls[0][1];
+        expect(callArgs.headers['Content-Type']).toBe(
+            'application/x-www-form-urlencoded'
+        );
+    });
+
+    test('sets X-Requested-With header so PHP isXmlHttpRequest() returns true', () => {
+        const callArgs = global.fetch.mock.calls[0][1];
+        expect(callArgs.headers['X-Requested-With']).toBe('XMLHttpRequest');
+    });
+
+    test('updates #doi-link with the sanitized DOI HTML', () => {
+        const doiLink = document.getElementById('doi-link');
+        // sanitizeHTML mock returns '[sanitized:<input>]'
+        expect(doiLink.innerHTML).toBe('[sanitized:10.5802/xyz]');
+    });
+
+    test('updates #doi-status with sanitized doi_status HTML', () => {
+        expect(sanitizeHTML).toHaveBeenCalledWith(successPayload.doi_status);
+    });
+
+    test('does not prepend a success alert to #doi-status (DOI link is visible feedback)', () => {
+        const doiStatus = document.getElementById('doi-status');
+        expect(doiStatus.querySelector('.alert-success')).toBeNull();
+    });
+
+    test('removes #requestNewDoi from the DOM', () => {
+        expect(document.getElementById('requestNewDoi')).toBeNull();
+    });
+
+    test('removes #doi-action from the DOM', () => {
+        expect(document.getElementById('doi-action')).toBeNull();
+    });
+
+    test('does NOT call location.reload()', () => {
+        expect(_internals.reload).not.toHaveBeenCalled();
+    });
+
+    test('hides the loader after a successful response', () => {
+        expect(document.getElementById('doi-status-loader').hidden).toBe(true);
+    });
+
+    test('inserts a #removeDoi button after #doi-link', () => {
+        expect(document.getElementById('removeDoi')).not.toBeNull();
+    });
+
+    test('#removeDoi button carries data-paperid and data-docid from the panel', () => {
+        const btn = document.getElementById('removeDoi');
+        expect(btn.dataset.paperid).toBe('100');
+        expect(btn.dataset.docid).toBe('42');
+    });
+});
+
+// ===========================================================================
+// Server-side error flags
+// ===========================================================================
+
+describe('server-side error flags', () => {
+    async function triggerError(payload) {
+        buildFixture();
+        init();
+        mockFetchSuccess(payload);
+        await clickAndWait();
+    }
+
+    test('shows a danger alert when doi === "Error"', async () => {
+        await triggerError({
+            doi: 'Error',
+            doi_status: '<p>ok</p>',
+            feedback: '',
+            error_message: 'DOI assignment failed.',
+        });
+        const alert = document.querySelector('.alert-danger');
+        expect(alert).not.toBeNull();
+    });
+
+    test('shows a danger alert when doi_status === "Error"', async () => {
+        await triggerError({
+            doi: '10.1/ok',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: 'Status update failed.',
+        });
+        const alert = document.querySelector('.alert-danger');
+        expect(alert).not.toBeNull();
+    });
+
+    test('shows a danger alert when both fields are "Error"', async () => {
+        await triggerError({
+            doi: 'Error',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: 'Complete failure.',
+        });
+        expect(document.querySelectorAll('.alert-danger').length).toBeGreaterThan(0);
+    });
+
+    test('does NOT call location.reload() when there is an error', async () => {
+        await triggerError({
+            doi: 'Error',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: 'Fail.',
+        });
+        expect(_internals.reload).not.toHaveBeenCalled();
+    });
+
+    test('falls back to generic message when error_message is absent', async () => {
+        buildFixture();
+        init();
+        mockFetchSuccess({ doi: 'Error', doi_status: 'Error' });
+        await clickAndWait();
+        const alert = document.querySelector('.alert-danger');
+        expect(alert).not.toBeNull();
+    });
+
+    test('does NOT update #doi-link on error', async () => {
+        await triggerError({
+            doi: 'Error',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: 'Fail.',
+        });
+        const doiLink = document.getElementById('doi-link');
+        expect(doiLink.textContent.trim()).toBe('');
+    });
+});
+
+// ===========================================================================
+// HTTP-level errors
+// ===========================================================================
+
+describe('HTTP error responses', () => {
+    test('shows a danger alert on a 500 response', async () => {
+        buildFixture();
+        init();
+        mockFetchHttpError(500);
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+
+    test('shows a danger alert on a 404 response', async () => {
+        buildFixture();
+        init();
+        mockFetchHttpError(404);
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+
+    test('does not call location.reload() on an HTTP error', async () => {
+        buildFixture();
+        init();
+        mockFetchHttpError(503);
+        await clickAndWait();
+        expect(_internals.reload).not.toHaveBeenCalled();
+    });
+
+    test('hides the loader on an HTTP error', async () => {
+        buildFixture();
+        init();
+        mockFetchHttpError(500);
+        await clickAndWait();
+        expect(document.getElementById('doi-status-loader').hidden).toBe(true);
+    });
+});
+
+// ===========================================================================
+// Network errors
+// ===========================================================================
+
+describe('network errors', () => {
+    test('shows a danger alert when fetch throws a TypeError', async () => {
+        buildFixture();
+        init();
+        mockFetchNetworkError();
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+
+    test('does not call location.reload() after a network error', async () => {
+        buildFixture();
+        init();
+        mockFetchNetworkError();
+        await clickAndWait();
+        expect(_internals.reload).not.toHaveBeenCalled();
+    });
+
+    test('hides the loader after a network error', async () => {
+        buildFixture();
+        init();
+        mockFetchNetworkError();
+        await clickAndWait();
+        expect(document.getElementById('doi-status-loader').hidden).toBe(true);
+    });
+});
+
+// ===========================================================================
+// Invalid / unparseable server responses
+// ===========================================================================
+
+describe('invalid server response body', () => {
+    test('shows a danger alert when the response is not valid JSON', async () => {
+        buildFixture();
+        init();
+        mockFetchRawText('<!DOCTYPE html><html>Internal error</html>');
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+
+    test('shows a danger alert when the response is a JSON array', async () => {
+        buildFixture();
+        init();
+        mockFetchRawText('[{"doi":"x"}]');
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+
+    test('shows a danger alert for a JSON string literal', async () => {
+        buildFixture();
+        init();
+        mockFetchRawText('"just a string"');
+        await clickAndWait();
+        expect(document.querySelector('.alert-danger')).not.toBeNull();
+    });
+});
+
+// ===========================================================================
+// Double-click / abort behaviour
+// ===========================================================================
+
+describe('abort on double-click', () => {
+    test('fires fetch only twice when button is clicked twice rapidly', async () => {
+        buildFixture();
+        init();
+
+        // Both calls return the same success payload.
+        mockFetchSuccess({
+            doi: '10.1/a',
+            doi_status: '<p>ok</p>',
+            feedback: 'OK',
+            error_message: '',
+        });
+        mockFetchSuccess({
+            doi: '10.1/b',
+            doi_status: '<p>ok</p>',
+            feedback: 'OK',
+            error_message: '',
+        });
+
+        const button = document.getElementById('requestNewDoi');
+        button.click();
+        button.click();
+
+        // Flush the promise queue without clicking a third time.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // The second click replaces the first request; fetch is called exactly twice.
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+});
+
+// ===========================================================================
+// XSS safety
+// ===========================================================================
+
+describe('XSS safety', () => {
+    test('sanitizeHTML is NOT called for feedback (success alert removed — DOI link is sufficient feedback)', async () => {
+        buildFixture();
+        init();
+        const payload = {
+            doi: '10.1/ok',
+            doiStr: '10.1/ok',
+            doi_status: '<p>status</p>',
+            feedback: '<img src=x onerror=alert(1)>',
+            error_message: '',
+        };
+        mockFetchSuccess(payload);
+        await clickAndWait();
+        // feedback is ignored by handleSuccess — sanitizeHTML must not be called with it.
+        expect(sanitizeHTML).not.toHaveBeenCalledWith(payload.feedback);
+    });
+
+    test('sanitizeHTML is called for doi_status in success path', async () => {
+        buildFixture();
+        init();
+        const payload = {
+            doi: '10.1/ok',
+            doi_status: '<script>stealCookies()</script>',
+            feedback: 'OK',
+            error_message: '',
+        };
+        mockFetchSuccess(payload);
+        await clickAndWait();
+        expect(sanitizeHTML).toHaveBeenCalledWith(payload.doi_status);
+    });
+
+    test('sanitizeHTML is called for error_message in error path', async () => {
+        buildFixture();
+        init();
+        const payload = {
+            doi: 'Error',
+            doi_status: 'Error',
+            feedback: '',
+            error_message: '<b onmouseover=alert(1)>Error</b>',
+        };
+        mockFetchSuccess(payload);
+        await clickAndWait();
+        expect(sanitizeHTML).toHaveBeenCalledWith(payload.error_message);
+    });
+
+    test('sanitizeHTML is called for data.doi so #doi-link is updated safely (no raw-HTML flash)', async () => {
+        buildFixture();
+        init();
+        // data.doi from the server is DoiAsLink() HTML markup.
+        // It is now injected via safeHtml() (sanitizeHTML wrapper) rather than
+        // textContent, so the link renders correctly without a raw-HTML flash.
+        const htmlDoi = '<a rel="noopener noreferrer" href="https://doi.org/10.1/ok">https://doi.org/10.1/ok</a>';
+        mockFetchSuccess({
+            doi: htmlDoi,
+            doiStr: '10.1/ok',
+            doi_status: '<p>ok</p>',
+            feedback: 'OK',
+            error_message: '',
+        });
+        await clickAndWait();
+        expect(sanitizeHTML).toHaveBeenCalledWith(htmlDoi);
+        const doiLink = document.getElementById('doi-link');
+        // The mock returns '[sanitized:<input>]'; #doi-link must not be empty.
+        expect(doiLink.innerHTML.trim()).not.toBe('');
+    });
+});

--- a/tests/js/administratepaper/view.test.js
+++ b/tests/js/administratepaper/view.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+/**
+ * Test suite for pure helper functions exported from
+ * public/js/administratepaper/view.js.
+ *
+ * Covers:
+ *  - DOI_PATTERN: regex matches expected valid / invalid DOI strings
+ *  - validateDoiInput: empty, pattern-mismatch, and valid cases
+ *  - updateDoiDisplay: DOM updates for #doi-link and div.paper-doi a
+ *
+ * Excluded from this suite:
+ *  - getDoiForm: depends on jQuery Bootstrap popovers (getCommunForm),
+ *    tested at a higher level (integration/E2E).
+ */
+
+// ---------------------------------------------------------------------------
+// Globals required to load view.js without errors
+// ---------------------------------------------------------------------------
+
+// view.js contains a top-level $(document).ready(...) call.
+// We provide a minimal jQuery-like stub so that module-load succeeds.
+// The stub is intentionally thin — only the methods called at module scope
+// need to be implemented; everything else can be a no-op.
+const jQueryStub = () => ({
+    ready: (fn) => { try { fn(); } catch (_e) { /* swallow errors from unrelated code */ } },
+    prop: () => jQueryStub(),
+    on: () => jQueryStub(),
+    off: () => jQueryStub(),
+    popover: () => jQueryStub(),
+    data: () => null,
+    html: () => jQueryStub(),
+    text: () => jQueryStub(),
+    serialize: () => '',
+    find: () => jQueryStub(),
+    val: () => '',
+    hide: () => jQueryStub(),
+    show: () => jQueryStub(),
+    fadeIn: () => jQueryStub(),
+    fadeOut: () => jQueryStub(),
+    append: () => jQueryStub(),
+    empty: () => jQueryStub(),
+    remove: () => jQueryStub(),
+    each: () => jQueryStub(),
+    attr: () => null,
+    css: () => jQueryStub(),
+    closest: () => jQueryStub(),
+    is: () => false,
+    length: 0,
+});
+jQueryStub.type = () => 'string';
+global.$ = jQueryStub;
+
+// Other globals used by view.js function bodies.
+global.sanitizeHTML = undefined;
+global.getLoader = () => '';
+global.translate = (s) => s;
+global.ajaxRequest = undefined;
+global.paper = { repository: 0, title: 'Test', id: { toString: () => '1' } };
+global.review = { code: 'test', name: 'Test Review' };
+global.locale = 'en';
+global.author = '';
+global.paper_ratings = '';
+global.isRequiredRevisionDeadline = false;
+
+// ---------------------------------------------------------------------------
+// Load the module under test
+// ---------------------------------------------------------------------------
+
+const { validateDoiInput, updateDoiDisplay, DOI_PATTERN } = require('../../../public/js/administratepaper/view');
+
+// ---------------------------------------------------------------------------
+// DOI_PATTERN
+// ---------------------------------------------------------------------------
+
+describe('DOI_PATTERN', () => {
+    test('is a RegExp', () => {
+        expect(DOI_PATTERN).toBeInstanceOf(RegExp);
+    });
+
+    const valid = [
+        '10.1234/suffix',
+        '10.18452/23693',
+        '10.1000/xyz123',
+        '10.9999/ABC-DEF',
+        '10.12345/a.b_c;d(e)f',
+        '10.1234/UPPER',
+        '10.1234/lower',
+    ];
+    valid.forEach((doi) => {
+        test(`accepts valid DOI: ${doi}`, () => {
+            expect(DOI_PATTERN.test(doi)).toBe(true);
+        });
+    });
+
+    const invalid = [
+        '',
+        'not-a-doi',
+        '10/nodot',
+        '10.12/too-short-prefix',     // fewer than 4 digits after 10.
+        '10.1234',                    // missing suffix after slash
+        '20.1234/suffix',             // must start with 10.
+        '10.abc/suffix',              // non-numeric registrant
+    ];
+    invalid.forEach((doi) => {
+        test(`rejects invalid DOI: "${doi}"`, () => {
+            expect(DOI_PATTERN.test(doi)).toBe(false);
+        });
+    });
+
+    test('unescaped dot does not match arbitrary character', () => {
+        // "10X1234/suffix" must NOT match — the dot must be literal.
+        expect(DOI_PATTERN.test('10X1234/suffix')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateDoiInput
+// ---------------------------------------------------------------------------
+
+describe('validateDoiInput', () => {
+    describe('empty / missing value', () => {
+        test('empty string is invalid', () => {
+            const result = validateDoiInput('');
+            expect(result.valid).toBe(false);
+            expect(result.error).toMatch(/empty/i);
+        });
+
+        test('empty string returns a non-empty error message', () => {
+            expect(validateDoiInput('').error).toBeTruthy();
+        });
+    });
+
+    describe('format mismatch', () => {
+        test('plain text is invalid', () => {
+            const result = validateDoiInput('not-a-doi');
+            expect(result.valid).toBe(false);
+            expect(result.error).toBeTruthy();
+        });
+
+        test('missing slash is invalid', () => {
+            expect(validateDoiInput('10.1234').valid).toBe(false);
+        });
+
+        test('too-short registrant is invalid', () => {
+            // registrant must have 4–9 digits; "10.12/suffix" has only 2
+            expect(validateDoiInput('10.12/suffix').valid).toBe(false);
+        });
+
+        test('wrong prefix is invalid', () => {
+            expect(validateDoiInput('11.1234/suffix').valid).toBe(false);
+        });
+
+        test('error message for format mismatch mentions expected format', () => {
+            const { error } = validateDoiInput('not-a-doi');
+            expect(error).toMatch(/10\./);
+        });
+    });
+
+    describe('valid DOI', () => {
+        test('standard DOI is valid', () => {
+            const result = validateDoiInput('10.1234/suffix');
+            expect(result.valid).toBe(true);
+            expect(result.error).toBe('');
+        });
+
+        test('DOI with complex suffix is valid', () => {
+            expect(validateDoiInput('10.18452/23693').valid).toBe(true);
+        });
+
+        test('DOI with uppercase suffix is valid (case-insensitive)', () => {
+            expect(validateDoiInput('10.1234/UPPERCASE').valid).toBe(true);
+        });
+
+        test('DOI with lowercase suffix is valid', () => {
+            expect(validateDoiInput('10.1234/lowercase').valid).toBe(true);
+        });
+
+        test('valid result has empty error string', () => {
+            expect(validateDoiInput('10.1234/suffix').error).toBe('');
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// updateDoiDisplay
+// ---------------------------------------------------------------------------
+
+describe('updateDoiDisplay', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('sets textContent of #doi-link with leading non-breaking space', () => {
+        document.body.innerHTML = '<span id="doi-link"></span>';
+        updateDoiDisplay('10.1234/test');
+        expect(document.getElementById('doi-link').textContent).toBe('\u00A0' + '10.1234/test');
+    });
+
+    test('sets textContent of div.paper-doi a', () => {
+        document.body.innerHTML = '<div class="paper-doi"><a href="#">old</a></div>';
+        updateDoiDisplay('10.1234/test');
+        expect(document.querySelector('div.paper-doi a').textContent).toBe('10.1234/test');
+    });
+
+    test('updates both elements when both are present', () => {
+        document.body.innerHTML =
+            '<span id="doi-link"></span>' +
+            '<div class="paper-doi"><a href="#">old</a></div>';
+        updateDoiDisplay('10.5678/new-doi');
+        expect(document.getElementById('doi-link').textContent).toBe('\u00A010.5678/new-doi');
+        expect(document.querySelector('div.paper-doi a').textContent).toBe('10.5678/new-doi');
+    });
+
+    test('does not throw when #doi-link is absent', () => {
+        document.body.innerHTML = '<div class="paper-doi"><a href="#">old</a></div>';
+        expect(() => updateDoiDisplay('10.1234/test')).not.toThrow();
+    });
+
+    test('does not throw when div.paper-doi a is absent', () => {
+        document.body.innerHTML = '<span id="doi-link"></span>';
+        expect(() => updateDoiDisplay('10.1234/test')).not.toThrow();
+    });
+
+    test('does not throw when both elements are absent', () => {
+        expect(() => updateDoiDisplay('10.1234/test')).not.toThrow();
+    });
+
+    test('uses textContent — HTML tags are treated as plain text (XSS safety)', () => {
+        document.body.innerHTML =
+            '<span id="doi-link"></span>' +
+            '<div class="paper-doi"><a href="#"></a></div>';
+        const xssPayload = '10.1234/<img onerror=alert(1)>';
+        updateDoiDisplay(xssPayload);
+
+        const doiLink = document.getElementById('doi-link');
+        // The value must be stored as text; no <img> element must be created.
+        expect(doiLink.children).toHaveLength(0);
+        expect(doiLink.textContent).toContain('<img');
+    });
+});

--- a/tests/unit/modules/journal/controllers/AdministratepaperControllerTest.php
+++ b/tests/unit/modules/journal/controllers/AdministratepaperControllerTest.php
@@ -44,6 +44,498 @@ class AdministratepaperControllerTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // ajaxrequestnewdoiAction — dedicated suite
+    // ---------------------------------------------------------------
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * layout()->disableLayout() and setNoRender() must be called before ANY
+     * early-return guard (auth check, method check) so that every code path
+     * — including error paths — emits clean JSON without an HTML layout wrapper.
+     *
+     * Bug (original): the two calls appeared AFTER the auth block, meaning an
+     * unauthorized request received JSON + rendered layout in the same response.
+     */
+    public function testAjaxrequestnewdoiActionDisablesLayoutBeforeAuthCheck(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        $disablePos  = strpos($method, 'disableLayout');
+        $setNoRender = strpos($method, 'setNoRender');
+        $authPos     = strpos($method, 'isLogged');
+
+        $this->assertNotFalse($disablePos,  'disableLayout() call not found in ajaxrequestnewdoiAction');
+        $this->assertNotFalse($setNoRender, 'setNoRender() call not found in ajaxrequestnewdoiAction');
+        $this->assertNotFalse($authPos,     'isLogged() call not found in ajaxrequestnewdoiAction');
+
+        $this->assertLessThan(
+            $authPos,
+            $disablePos,
+            'BUG: disableLayout() must appear before the isLogged() auth check — every response path must emit clean JSON only'
+        );
+        $this->assertLessThan(
+            $authPos,
+            $setNoRender,
+            'BUG: setNoRender() must appear before the isLogged() auth check — every response path must emit clean JSON only'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * The auth failure block must contain a `return` to stop further execution.
+     */
+    public function testAjaxrequestnewdoiActionAuthFailureContainsReturn(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        preg_match('/if\s*\(!Episciences_Auth::isLogged\(\).*?\}/s', $method, $matches);
+        $this->assertNotEmpty($matches, 'Auth check block not found in ajaxrequestnewdoiAction');
+
+        $this->assertStringContainsString(
+            'return',
+            $matches[0],
+            'BUG: ajaxrequestnewdoiAction auth failure block must contain a return statement'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * $docId must be read from POST only (getPost), not from the combined
+     * GET+POST+routing parameter bag (getParam). Using getParam allows an
+     * attacker to supply the docid via the query string on a forged POST.
+     */
+    public function testAjaxrequestnewdoiActionReadsDocIdFromPost(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        $this->assertStringContainsString(
+            "getPost('docid')",
+            $method,
+            'BUG: $docId must be read via getPost() to restrict it to the POST body only'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * $docId must be cast to (int) before use so that a malformed string
+     * value cannot reach PapersManager::get() or trigger unexpected behaviour.
+     */
+    public function testAjaxrequestnewdoiActionCastsDocIdToInt(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        preg_match_all('/\$docId\s*=\s*[^;]+;/', $method, $assignments);
+        $this->assertNotEmpty($assignments[0], '$docId assignment not found in ajaxrequestnewdoiAction');
+
+        $hasIntCast = false;
+        foreach ($assignments[0] as $assignment) {
+            if (str_contains($assignment, 'getPost') || str_contains($assignment, 'getParam')) {
+                $hasIntCast = $hasIntCast || str_contains($assignment, '(int)');
+            }
+        }
+
+        $this->assertTrue(
+            $hasIntCast,
+            'BUG: $docId must be cast to (int) in ajaxrequestnewdoiAction before use'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * PapersManager::get() returns false when no paper matches the given ID.
+     * The method must perform an instanceof check before calling any method on
+     * the result — calling canBeAssignedDOI() on false causes a fatal error.
+     */
+    public function testAjaxrequestnewdoiActionChecksInstanceBeforeCallingMethods(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        $this->assertTrue(
+            str_contains($method, 'instanceof Episciences_Paper') ||
+            str_contains($method, 'is_object($paper)') ||
+            str_contains($method, '!$paper'),
+            'BUG: ajaxrequestnewdoiAction must check that PapersManager::get() returned a valid Episciences_Paper instance before calling canBeAssignedDOI() — get() returns false when no paper is found'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * Every JSON response — including auth failure and validation errors —
+     * must contain all four keys expected by the JavaScript handler:
+     * doi, doi_status, feedback, error_message.
+     * The original auth error omitted the 'feedback' key.
+     */
+    public function testAjaxrequestnewdoiActionAllResponsePathsIncludeFeedbackKey(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        // Find every json_encode call and check that the array literal
+        // passed to it contains a 'feedback' key.
+        preg_match_all('/json_encode\(\s*\[([^\]]+)\]/s', $method, $matches);
+        $this->assertNotEmpty($matches[1], 'No json_encode([...]) calls found in ajaxrequestnewdoiAction');
+
+        foreach ($matches[1] as $arrayLiteral) {
+            $this->assertStringContainsString(
+                "'feedback'",
+                $arrayLiteral,
+                "BUG: a json_encode([...]) call in ajaxrequestnewdoiAction is missing the 'feedback' key — the JavaScript handler requires all four keys in every response"
+            );
+        }
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestnewdoiAction
+     *
+     * The method guard must require BOTH isPost() AND isXmlHttpRequest().
+     * Using '&&' (bail only if both are false) allowed plain POST requests
+     * from non-XHR clients to reach the handler; '||' is required so that
+     * only genuine XHR POST requests proceed.
+     */
+    public function testAjaxrequestnewdoiActionRequiresBothPostAndXhr(): void
+    {
+        $method = $this->extractMethod('ajaxrequestnewdoiAction');
+
+        // Must NOT use the original weak '&&' guard.
+        $this->assertDoesNotMatchRegularExpression(
+            '/!\s*\$request->isXmlHttpRequest\(\)\s*&&\s*!\s*\$request->isPost\(\)/',
+            $method,
+            'BUG: ajaxrequestnewdoiAction must not use the weak && guard — use || to require both POST and XHR'
+        );
+
+        // Must use the stricter '||' guard (at least one of the two checks is present).
+        $hasStrictGuard = (
+            preg_match('/!\s*\$request->isPost\(\)\s*\|\|/', $method) ||
+            preg_match('/!\s*\$request->isXmlHttpRequest\(\)\s*\|\|/', $method)
+        );
+
+        $this->assertTrue(
+            (bool) $hasStrictGuard,
+            'BUG: ajaxrequestnewdoiAction must guard with || so that both isPost() and isXmlHttpRequest() are required'
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // savedoiAction — dedicated suite
+    // ---------------------------------------------------------------
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * disableLayout() and setNoRender() must appear before every guard so that
+     * even error responses are returned as clean JSON without an HTML wrapper.
+     */
+    public function testSavedoiActionDisablesLayoutBeforeAuthCheck(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        $disablePos  = strpos($method, 'disableLayout');
+        $setNoRender = strpos($method, 'setNoRender');
+        $authPos     = strpos($method, 'isLogged');
+
+        $this->assertNotFalse($disablePos,  'disableLayout() call not found in savedoiAction');
+        $this->assertNotFalse($setNoRender, 'setNoRender() call not found in savedoiAction');
+        $this->assertNotFalse($authPos,     'isLogged() call not found in savedoiAction');
+
+        $this->assertLessThan(
+            $authPos,
+            $disablePos,
+            'BUG: disableLayout() must appear before the isLogged() auth check in savedoiAction'
+        );
+        $this->assertLessThan(
+            $authPos,
+            $setNoRender,
+            'BUG: setNoRender() must appear before the isLogged() auth check in savedoiAction'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * The method guard must require BOTH isPost() AND isXmlHttpRequest().
+     * Using '&&' allows plain POST requests from non-XHR clients through;
+     * '||' is required so that only genuine XHR POST requests proceed.
+     */
+    public function testSavedoiActionRequiresBothPostAndXhr(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        // Must NOT use the weak && guard.
+        $this->assertDoesNotMatchRegularExpression(
+            '/!\s*\$request->isXmlHttpRequest\(\)\s*&&\s*!\s*\$request->isPost\(\)/',
+            $method,
+            'BUG: savedoiAction must not use the weak && guard — use || to require both POST and XHR'
+        );
+
+        $hasStrictGuard = (
+            preg_match('/!\s*\$request->isPost\(\)\s*\|\|/', $method) ||
+            preg_match('/!\s*\$request->isXmlHttpRequest\(\)\s*\|\|/', $method)
+        );
+
+        $this->assertTrue(
+            (bool) $hasStrictGuard,
+            'BUG: savedoiAction must guard with || so that both isPost() and isXmlHttpRequest() are required'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * docid and paperid must be read from POST only; using getParam() also
+     * reads GET and routing parameters, opening an injection surface.
+     */
+    public function testSavedoiActionReadsFromPostOnly(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        $this->assertStringNotContainsString(
+            "getParam('docid')",
+            $method,
+            "BUG: savedoiAction must not fall back to getParam('docid') — use getPost() only"
+        );
+
+        $this->assertStringNotContainsString(
+            "getParam('paperid')",
+            $method,
+            "BUG: savedoiAction must not fall back to getParam('paperid') — use getPost() only"
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * $docId and $paperId must be cast to (int) before use to prevent
+     * a malformed string from reaching the database layer.
+     */
+    public function testSavedoiActionCastsIdsToInt(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        preg_match_all('/\$(docId|paperId)\s*=\s*[^;]+;/', $method, $assignments);
+        $this->assertNotEmpty($assignments[0], '$docId/$paperId assignments not found in savedoiAction');
+
+        foreach ($assignments[0] as $assignment) {
+            if (str_contains($assignment, 'getPost') || str_contains($assignment, 'getParam')) {
+                $this->assertStringContainsString(
+                    '(int)',
+                    $assignment,
+                    'BUG: savedoiAction must cast $docId/$paperId to (int) — found: ' . $assignment
+                );
+            }
+        }
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * An empty DOI must be rejected with a JSON error response.
+     * The original code silently passed an empty DOI through the regex check
+     * (the condition was `$doi !== ''`, which allowed an empty string).
+     */
+    public function testSavedoiActionRejectsEmptyDoi(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        // Must contain an explicit empty-string check on $doi.
+        $this->assertMatchesRegularExpression(
+            '/\$doi\s*===\s*\'\'/',
+            $method,
+            "BUG: savedoiAction must explicitly reject an empty DOI with a JSON error response"
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * The DOI regex must use an escaped dot `10\.` so that only a literal dot
+     * is accepted as the separator.  Without the escape, `10X1234/suffix`
+     * would also match.
+     */
+    public function testSavedoiActionEscapesDotInRegex(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        $this->assertStringNotContainsString(
+            "'/^10.\\d",
+            $method,
+            'BUG: savedoiAction DOI pattern uses unescaped dot — replace /^10. with /^10\. to match only a literal dot'
+        );
+
+        $this->assertStringContainsString(
+            '10\\.',
+            $method,
+            'BUG: savedoiAction DOI pattern must escape the dot: /^10\\.\\d{4,9}/'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::savedoiAction
+     *
+     * Every response path must return JSON ({ success, doi, error }) so that
+     * the JavaScript handler can reliably parse the response.
+     * The original code returned a mix of plain text and HTML div strings.
+     */
+    public function testSavedoiActionAllResponsePathsAreJson(): void
+    {
+        $method = $this->extractMethod('savedoiAction');
+
+        // Must contain no plain `echo 'Unauthorized access'` or printf HTML.
+        $this->assertStringNotContainsString(
+            "echo 'Unauthorized access'",
+            $method,
+            'BUG: savedoiAction must return JSON, not plain text, on auth failure'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/printf\s*\(\s*[\'"]<div/',
+            $method,
+            'BUG: savedoiAction must return JSON responses, not raw HTML divs'
+        );
+
+        // Every response (echo json_encode call) must include the 'success' key.
+        // We anchor the pattern to `echo` to exclude non-response json_encode calls
+        // such as the one used to build the logger detail payload.
+        preg_match_all('/echo\s+json_encode\(\s*\[([^\]]+)\]/s', $method, $matches);
+        $this->assertNotEmpty($matches[1], 'No echo json_encode([...]) calls found in savedoiAction');
+
+        foreach ($matches[1] as $arrayLiteral) {
+            $this->assertStringContainsString(
+                "'success'",
+                $arrayLiteral,
+                "BUG: an echo json_encode([...]) in savedoiAction is missing the 'success' key"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // ajaxrequestremovedoiAction — dedicated suite
+    // ---------------------------------------------------------------
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestremovedoiAction
+     *
+     * The original action had no authentication check at all.
+     * Any user — even unauthenticated — could cancel a DOI request.
+     */
+    public function testAjaxrequestremovedoiActionHasAuthCheck(): void
+    {
+        $method = $this->extractMethod('ajaxrequestremovedoiAction');
+
+        $this->assertTrue(
+            str_contains($method, 'Episciences_Auth::isLogged()') ||
+            str_contains($method, 'Episciences_Auth::isAllowedToManageDoi()'),
+            'BUG: ajaxrequestremovedoiAction must check that the user is logged in and allowed to manage DOIs'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestremovedoiAction
+     *
+     * The method guard must require BOTH isPost() AND isXmlHttpRequest().
+     * The original action only checked isXmlHttpRequest(), allowing GET requests.
+     */
+    public function testAjaxrequestremovedoiActionRequiresBothPostAndXhr(): void
+    {
+        $method = $this->extractMethod('ajaxrequestremovedoiAction');
+
+        $hasStrictGuard = (
+            preg_match('/!\s*\$request->isPost\(\)\s*\|\|/', $method) ||
+            preg_match('/!\s*\$request->isXmlHttpRequest\(\)\s*\|\|/', $method)
+        );
+
+        $this->assertTrue(
+            (bool) $hasStrictGuard,
+            'BUG: ajaxrequestremovedoiAction must guard with || to require both isPost() and isXmlHttpRequest()'
+        );
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestremovedoiAction
+     *
+     * paperId and docId must be cast to (int) to prevent malformed strings
+     * from reaching the database layer.
+     */
+    public function testAjaxrequestremovedoiActionCastsIdsToInt(): void
+    {
+        $method = $this->extractMethod('ajaxrequestremovedoiAction');
+
+        preg_match_all('/\$(paperId|docId)\s*=\s*[^;]+;/', $method, $assignments);
+        $this->assertNotEmpty($assignments[0], '$paperId/$docId assignments not found in ajaxrequestremovedoiAction');
+
+        foreach ($assignments[0] as $assignment) {
+            if (str_contains($assignment, 'getPost') || str_contains($assignment, 'getParam')) {
+                $this->assertStringContainsString(
+                    '(int)',
+                    $assignment,
+                    'BUG: ajaxrequestremovedoiAction must cast $paperId/$docId to (int) — found: ' . $assignment
+                );
+            }
+        }
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestremovedoiAction
+     *
+     * Every response path must emit a JSON object so that the JavaScript
+     * handler can reliably parse the outcome.
+     * The original action echoed a raw integer (json_encode($update)) or
+     * nothing at all on failure paths.
+     */
+    public function testAjaxrequestremovedoiActionAllResponsePathsAreJson(): void
+    {
+        $method = $this->extractMethod('ajaxrequestremovedoiAction');
+
+        // Must not echo a plain integer or non-object scalar.
+        $this->assertDoesNotMatchRegularExpression(
+            '/echo\s+json_encode\s*\(\s*\$\w+\s*,/',
+            $method,
+            'BUG: ajaxrequestremovedoiAction must not echo a bare variable via json_encode — use an associative array response'
+        );
+
+        // Every echo json_encode call must contain the 'success' key.
+        preg_match_all('/echo\s+json_encode\(\s*\[([^\]]+)\]/s', $method, $matches);
+        $this->assertNotEmpty($matches[1], 'No echo json_encode([...]) calls found in ajaxrequestremovedoiAction');
+
+        foreach ($matches[1] as $arrayLiteral) {
+            $this->assertStringContainsString(
+                "'success'",
+                $arrayLiteral,
+                "BUG: an echo json_encode([...]) in ajaxrequestremovedoiAction is missing the 'success' key"
+            );
+        }
+    }
+
+    /**
+     * @covers AdministratepaperController::ajaxrequestremovedoiAction
+     *
+     * The original action used a raw Zend_Db SELECT query to check whether the
+     * paper exists. PapersManager::paperExists() must be used instead to keep
+     * database access behind the business logic layer.
+     */
+    public function testAjaxrequestremovedoiActionUsesPapersManagerForExistenceCheck(): void
+    {
+        $method = $this->extractMethod('ajaxrequestremovedoiAction');
+
+        $this->assertStringContainsString(
+            'Episciences_PapersManager::paperExists',
+            $method,
+            'BUG: ajaxrequestremovedoiAction must use PapersManager::paperExists() instead of a raw DB SELECT query'
+        );
+
+        // The original raw DB query must be gone.
+        $this->assertStringNotContainsString(
+            '$db->select()->from(T_PAPERS)',
+            $method,
+            'BUG: the raw DB SELECT query must be removed from ajaxrequestremovedoiAction in favour of PapersManager::paperExists()'
+        );
+    }
+
+    // ---------------------------------------------------------------
     // BUG #1 — AUTH BYPASS: missing `return` after auth failure
     // ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **No more page reloads** when requesting, saving, or cancelling a DOI: all three actions now update the DOM in place (`#doi-link`, `#doi-status`, action buttons).
- `ajaxrequestnewdoiAction`: added `doiStr` (plain DOI string) to the JSON response so the JS can wire the `removeDoi()` callback correctly.
- Suppressed the redundant success feedback message after "Request a DOI" — the newly rendered DOI link is sufficient visual feedback.
- `DoiQueue::getId_doi_queue()` / `getPaperid()`: added `(int)` cast to prevent `TypeError` in PHP 8 when properties are `null` (returned by `findByPaperId()` when no row exists).
- `PapersManager::updateDoi()`: `trigger_error()` → `error_log()` to prevent HTML leaking into the JSON response when `display_errors` is `On`.
- `paper_doi.phtml`: added `data-doi-assign-mode`, `data-paperid`, `data-docid` on `#doi-panel` so JS can read them without a server round-trip.

## Test plan

- [ ] Jest: `make test-js` — 826 tests pass
- [ ] PHPUnit: `make test-php` — 1463 tests pass
- [ ] Manual: request a DOI (auto mode) → DOI link appears, "Cancel DOI" button injected, no reload
- [ ] Manual: save/update a DOI (manual mode) → same
- [ ] Manual: cancel a DOI → "Request a DOI" button restored, no reload
- [ ] Manual: error paths (network error, server error) → danger alert shown, no reload