### PR TITLE
fix(reviewer,rating): fix 15 bugs across Rating/* and Reviewer* classes

### DIFF
--- a/library/Episciences/Rating/Criterion.php
+++ b/library/Episciences/Rating/Criterion.php
@@ -187,7 +187,11 @@ class Episciences_Rating_Criterion
 
     public function getMaxNote()
     {
-        $max = max(array_keys($this->getOptions()));
+        $keys = array_keys($this->getOptions());
+        if (empty($keys)) {
+            return 1;
+        }
+        $max = max($keys);
         return $max > 0 ? $max : 1;
     }
 

--- a/library/Episciences/Rating/Grid.php
+++ b/library/Episciences/Rating/Grid.php
@@ -49,9 +49,6 @@ class Episciences_Rating_Grid
             $this->setId(filter_var($this->getFilename(), FILTER_SANITIZE_NUMBER_INT));
         }
 
-        $xml->getElementsByTagName('text');
-
-
         $items = $xml->getElementsByTagName('div');
         $criteria = [];
         foreach ($items as $i => $item) {
@@ -66,8 +63,11 @@ class Episciences_Rating_Grid
 
             // labels
             $labels = [];
-            foreach ($item->getElementsByTagName('head')->item(0)->getElementsByTagName('label') as $node) {
-                $labels[$node->getAttribute('xml:lang')] = $node->nodeValue;
+            $headElement = $item->getElementsByTagName('head')->item(0);
+            if ($headElement !== null) {
+                foreach ($headElement->getElementsByTagName('label') as $node) {
+                    $labels[$node->getAttribute('xml:lang')] = $node->nodeValue;
+                }
             }
             $criterion_values['labels'] = $labels;
 
@@ -107,7 +107,9 @@ class Episciences_Rating_Grid
 
             //coefficient & visibility
             foreach ($item->getElementsByTagName('f') as $node) {
-                $criterion_values[$node->getAttribute('name')] = $node->firstChild->getAttribute('value');
+                if ($node->firstChild !== null) {
+                    $criterion_values[$node->getAttribute('name')] = $node->firstChild->getAttribute('value');
+                }
             }
 
             $criteria[] = new Episciences_Rating_Criterion($criterion_values);
@@ -152,7 +154,10 @@ class Episciences_Rating_Grid
 
     public function getCriterion($id)
     {
-        return (array_key_exists($id, $this->_criteria)) ? $this->_criteria[$id] : null;
+        if (!is_array($this->_criteria)) {
+            return null;
+        }
+        return array_key_exists($id, $this->_criteria) ? $this->_criteria[$id] : null;
     }
 
     public function removeCriterion($item_id)

--- a/library/Episciences/Rating/Manager.php
+++ b/library/Episciences/Rating/Manager.php
@@ -11,14 +11,7 @@ class Episciences_Rating_Manager
      */
     public static function find($docid, $uid)
     {
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $sql = $db->select()
-            ->from(T_REVIEWER_REPORTS)
-            ->where('DOCID = ?', $docid)
-            ->where('UID = ?', $uid);
-
-        $row = $db->fetchRow($sql);
-        return ($row) ? new Episciences_Rating_Report($row) : false;
+        return Episciences_Rating_Report::find($docid, $uid);
     }
 
     /**
@@ -31,7 +24,7 @@ class Episciences_Rating_Manager
     public static function getList($docid = null, $uid = null, $status = null)
     {
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $sql = $db->select()->from(T_REVIEWER_REPORTS)->order('CREATION_DATE', 'DESC');
+        $sql = $db->select()->from(T_REVIEWER_REPORTS)->order('CREATION_DATE DESC');
 
         if ($docid) {
             $sql->where('DOCID = ?', $docid);
@@ -66,7 +59,7 @@ class Episciences_Rating_Manager
         $nbRatings = 0;
 
         foreach ($ratings as $rating) {
-            if ($rating->getStatus()) {
+            if ($rating->getStatus() !== Episciences_Rating_Report::STATUS_PENDING) {
                 $total += $rating->getScore();
                 $nbRatings++;
             }
@@ -108,7 +101,7 @@ class Episciences_Rating_Manager
             // separator
             if ($criterion->isSeparator()) {
                 $form->addElement('note', $id, [
-                    'value' => '<h2 class="separator">' . $criterion->getLabel() . '</h2>']);
+                    'value' => '<h2 class="separator">' . htmlspecialchars($criterion->getLabel(), ENT_QUOTES, 'UTF-8') . '</h2>']);
             }
 
             // note
@@ -173,12 +166,16 @@ class Episciences_Rating_Manager
                         '/cid/' . $criterion->getId() .
                         '/file/' . $criterion->getAttachment();
 
-                    $bloc_delete_file = "<div class=col-sm-2'>";
-                    $bloc_delete_file .= "<a class='btn btn-danger btn-xs pull-right' onclick=\"confirmDeleteAttachment('$file_delete_url')\">";
+                    $safeDeleteUrl    = htmlspecialchars($file_delete_url, ENT_QUOTES, 'UTF-8');
+                    $safeFilepath     = htmlspecialchars($filepath, ENT_QUOTES, 'UTF-8');
+                    $safeAttachment   = htmlspecialchars($criterion->getAttachment(), ENT_QUOTES, 'UTF-8');
+
+                    $bloc_delete_file = "<div class='col-sm-2'>";
+                    $bloc_delete_file .= "<a class='btn btn-danger btn-xs pull-right' onclick=\"confirmDeleteAttachment('$safeDeleteUrl')\">";
                     $bloc_delete_file .= '<span class="glyphicon glyphicon-trash" style="margin-right: 5px;"></span>';
                     $bloc_delete_file .= $translator->translate('Supprimer');
                     $bloc_delete_file .= '</a></div>';
-                    $description .= "<div class='col-sm-10'><p><a href='$filepath' target='_blank'>" . $criterion->getAttachment() . "</a></p></div>"
+                    $description .= "<div class='col-sm-10'><p><a href='$safeFilepath' target='_blank'>$safeAttachment</a></p></div>"
                         . $bloc_delete_file;
                     $description .= "<div class='row'></div>";
                 }

--- a/library/Episciences/Rating/Report.php
+++ b/library/Episciences/Rating/Report.php
@@ -372,7 +372,7 @@ class Episciences_Rating_Report extends Episciences_Rating_Grid
             }
         }
 
-        if ($score != 0 && $coefs != 0) {
+        if ($coefs != 0) {
             $score = round(($score / $coefs) * $this->getMax_score(), $precision);
         } else {
             $score = null;

--- a/library/Episciences/Rating/ReportManager.php
+++ b/library/Episciences/Rating/ReportManager.php
@@ -83,18 +83,18 @@ class Episciences_Rating_ReportManager
         $nameDir = $gridPath . $uid;
 
         if (!is_dir($nameDir)) {
-            error_log('The filename' . $nameDir . 'not exists or is not a directory');
+            error_log('The filename ' . $nameDir . ' does not exist or is not a directory');
             return false;
         }
 
         $newName = $gridPath . 'unassigned_reviewer_' . $uid . '_' . date("Y-m-d") . '_' . date("H:i:s") . '.save';
 
-        if ($result = !rename($nameDir, $newName)) {
+        if (!rename($nameDir, $newName)) {
             error_log('Failed to rename ' . $nameDir . ' to ' . $newName);
-            return $result;
+            return false;
         }
 
-        return !$result;
+        return true;
     }
 
     /**
@@ -109,25 +109,24 @@ class Episciences_Rating_ReportManager
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
         $where[$whereFiled . ' = ?'] = $merger;
 
-        $db->delete(self::TABLE, $where);
-
         $sql = 'INSERT IGNORE INTO ';
         $sql .= $db->quoteIdentifier(self::TABLE);
         $sql .= ' (ID, UID, ONBEHALF_UID, DOCID, STATUS, CREATION_DATE, UPDATE_DATE) VALUES ';
         $sql .= implode(',', $values);
 
-        $insert = $db->prepare($sql);
-
         try {
+            $db->beginTransaction();
+            $db->delete(self::TABLE, $where);
+            $insert = $db->prepare($sql);
             $insert->execute();
+            $db->commit();
         } catch (Exception $e) {
-            $insert = null;
-            trigger_error($e->getMessage(), E_USER_ERROR);
+            $db->rollBack();
+            error_log($e->getMessage());
+            return 0;
         }
 
-
-        return ($insert) ? $insert->rowCount() : 0;
-
+        return $insert->rowCount();
     }
 }
 

--- a/library/Episciences/Reviewer.php
+++ b/library/Episciences/Reviewer.php
@@ -128,7 +128,7 @@ class Episciences_Reviewer extends Episciences_User
 
     public function getAssignment($docId)
     {
-        return $this->_assignments[$docId];
+        return $this->_assignments[$docId] ?? null;
     }
 
 
@@ -218,7 +218,7 @@ class Episciences_Reviewer extends Episciences_User
     public function unassign($docId, $params = [])
     {
         $params = [
-            'rvid' => Ccsd_Tools::ifsetor($params['rvid'], RVID),
+            'rvid' => $params['rvid'] ?? RVID,
             'itemid' => $docId,
             'item' => Episciences_User_Assignment::ITEM_PAPER,
             'roleid' => Episciences_User_Assignment::ROLE_REVIEWER,
@@ -236,7 +236,7 @@ class Episciences_Reviewer extends Episciences_User
      * @return array
      * @throws Zend_Db_Select_Exception
      */
-    public function getAssignedPapers(array $settings = [], bool $loadInvitations = false, bool $isFilterInfos = false, $isLimit = true)
+    public function getAssignedPapers(array $settings = [], bool $loadInvitations = false, bool $isFilterInfos = false, bool $isLimit = true)
     {
         if ($isFilterInfos || empty($this->_assignedPapers)) {
             $this->loadAssignedPapers($settings, $loadInvitations, $isFilterInfos, $isLimit);
@@ -258,7 +258,7 @@ class Episciences_Reviewer extends Episciences_User
      * @return array|Episciences_Paper[]
      * @throws Zend_Db_Select_Exception
      */
-    public function loadAssignedPapers(array $settings = [], bool $loadInvitations = false, bool $isFilterInfos = false, $isLimit = true): array
+    public function loadAssignedPapers(array $settings = [], bool $loadInvitations = false, bool $isFilterInfos = false, bool $isLimit = true): array
     {
 
         // fetch paper reviewer active assignments
@@ -453,8 +453,9 @@ class Episciences_Reviewer extends Episciences_User
         // Met à jour le status
         $oReviewing->loadStatus();
 
+        $reviewings = $this->getReviewings();
         $reviewings[$docId] = $oReviewing;
-        $this->_reviewings = $reviewings;
+        $this->setReviewings($reviewings);
     }
 
     public function getReviewing($docId)
@@ -495,11 +496,11 @@ class Episciences_Reviewer extends Episciences_User
 
     public function getComments(int $docId): array
     {
-        if (empty($this->_comments)) {
-            $this->_comments = Episciences_CommentsManager::getList($docId, ['UID' => $this->getUid()]);
+        if (!array_key_exists($docId, $this->_comments)) {
+            $this->_comments[$docId] = Episciences_CommentsManager::getList($docId, ['UID' => $this->getUid()]);
         }
 
-        return $this->_comments;
+        return $this->_comments[$docId];
     }
 
     public function setRatings($ratings): \Episciences_Reviewer

--- a/library/Episciences/ReviewersManager.php
+++ b/library/Episciences/ReviewersManager.php
@@ -24,7 +24,7 @@ class Episciences_ReviewersManager
         $select = $db->select()
             ->from(T_PAPER_SETTINGS, 'value')
             ->where('DOCID = ?', $docid)
-            ->where('SETTING = \'suggestedReviewer\'');
+            ->where('SETTING = ?', 'suggestedReviewer');
 
         return $db->fetchCol($select);
     }
@@ -40,7 +40,7 @@ class Episciences_ReviewersManager
         $select = $db->select()
             ->from(T_PAPER_SETTINGS, 'value')
             ->where('DOCID = ?', $docid)
-            ->where('SETTING = \'unwantedReviewer\'');
+            ->where('SETTING = ?', 'unwantedReviewer');
 
         return $db->fetchCol($select);
     }
@@ -150,10 +150,15 @@ class Episciences_ReviewersManager
      * @return bool
      */
 
-    public static function addReviewerToPool($uid, $vid = 0, $rvid = RVID)
+    public static function addReviewerToPool($uid, $vid = 0, $rvid = RVID): bool
     {
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $db->query('INSERT IGNORE INTO ' . T_REVIEWER_POOL . ' (RVID, VID, UID) VALUES (?, ?, ?)', array($rvid, $vid, $uid));
+        try {
+            $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+            $db->query('INSERT IGNORE INTO ' . T_REVIEWER_POOL . ' (RVID, VID, UID) VALUES (?, ?, ?)', [$rvid, $vid, $uid]);
+        } catch (Exception $e) {
+            error_log($e->getMessage());
+            return false;
+        }
         return true;
     }
 

--- a/tests/unit/library/Episciences/Episciences_ReviewerTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewerTest.php
@@ -1,0 +1,394 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Reviewer;
+use Episciences_User_Invitation;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * Unit tests for Episciences_Reviewer.
+ *
+ * DB-dependent methods (loadAssignments, loadAssignedPapers, getReport,
+ * loadReviewing, loadInvitations) are covered via API-contract and
+ * source-inspection tests only.
+ * Pure-logic methods and entity state are tested with real objects.
+ *
+ * Bugs documented/fixed:
+ *   Rv1 — getAssignment($docId): direct array access → undefined index warning;
+ *          fixed with ?? null.
+ *   Rv2 — loadReviewingById(): created a fresh local $reviewings array that
+ *          overwrote $this->_reviewings, destroying previously loaded reviewings;
+ *          fixed to merge with getReviewings()/setReviewings().
+ *   Rv3 — getComments(int $docId): cache stored in $this->_comments (flat)
+ *          instead of $this->_comments[$docId]; second call for a different
+ *          docId returned stale results from the first call.
+ *   Rv4 — getAssignedPapers() / loadAssignedPapers(): $isLimit parameter missing
+ *          bool type hint.
+ *   Rv5 — unassign(): used legacy Ccsd_Tools::ifsetor() instead of ?? operator,
+ *          inconsistent with assign().
+ *
+ * @covers Episciences_Reviewer
+ */
+final class Episciences_ReviewerTest extends TestCase
+{
+    // =========================================================================
+    // Status constants
+    // =========================================================================
+
+    public function testStatusConstants(): void
+    {
+        self::assertSame('pending',    Episciences_Reviewer::STATUS_PENDING);
+        self::assertSame('active',     Episciences_Reviewer::STATUS_ACTIVE);
+        self::assertSame('declined',   Episciences_Reviewer::STATUS_DECLINED);
+        self::assertSame('cancelled',  Episciences_Reviewer::STATUS_CANCELLED);
+        self::assertSame('expired',    Episciences_Reviewer::STATUS_EXPIRED);
+        self::assertSame('uninvited',  Episciences_Reviewer::STATUS_UNINVITED);
+        self::assertSame('inactive',   Episciences_Reviewer::STATUS_INACTIVE);
+    }
+
+    // =========================================================================
+    // setStatus / getStatus / setWhen / getWhen
+    // =========================================================================
+
+    public function testSetAndGetStatus(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setStatus(Episciences_Reviewer::STATUS_ACTIVE);
+
+        self::assertSame(Episciences_Reviewer::STATUS_ACTIVE, $reviewer->getStatus());
+    }
+
+    public function testSetStatusReturnsFluentInterface(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertSame($reviewer, $reviewer->setStatus(Episciences_Reviewer::STATUS_PENDING));
+    }
+
+    public function testSetAndGetWhen(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setWhen('2024-06-15 10:00:00');
+
+        self::assertSame('2024-06-15 10:00:00', $reviewer->getWhen());
+    }
+
+    public function testSetWhenReturnsFluentInterface(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertSame($reviewer, $reviewer->setWhen('2024-01-01'));
+    }
+
+    // =========================================================================
+    // Assignments
+    // =========================================================================
+
+    public function testHasAssignmentsReturnsFalseWhenEmpty(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertFalse($reviewer->hasAssignments());
+    }
+
+    public function testHasAssignmentsReturnsTrueAfterSetAssignments(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setAssignments([42 => 'assignment_object']);
+
+        self::assertTrue($reviewer->hasAssignments());
+    }
+
+    public function testSetAssignmentsReturnsFluentInterface(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertSame($reviewer, $reviewer->setAssignments([]));
+    }
+
+    // =========================================================================
+    // Bug Rv1 — getAssignment() undefined index fix
+    // =========================================================================
+
+    /**
+     * Fix Rv1: accessing $this->_assignments[$docId] directly throws an
+     * "undefined index" notice (PHP 7.x) or returns null with deprecation (PHP 8.x)
+     * when $docId is not in the array.
+     * Fixed with ?? null.
+     */
+    public function testGetAssignmentReturnsNullForMissingDocId(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setAssignments([]);
+
+        self::assertNull($reviewer->getAssignment(999), 'Fix Rv1: must return null for missing docId, not undefined index');
+    }
+
+    public function testGetAssignmentReturnsValueWhenPresent(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setAssignments([42 => 'my_assignment']);
+
+        self::assertSame('my_assignment', $reviewer->getAssignment(42));
+    }
+
+    // =========================================================================
+    // Reviewings
+    // =========================================================================
+
+    public function testGetReviewingsReturnsEmptyArrayByDefault(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertIsArray($reviewer->getReviewings());
+        self::assertEmpty($reviewer->getReviewings());
+    }
+
+    public function testSetAndGetReviewings(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $reviewer->setReviewings([10 => 'reviewing_a', 20 => 'reviewing_b']);
+
+        self::assertCount(2, $reviewer->getReviewings());
+        self::assertSame('reviewing_a', $reviewer->getReviewings()[10]);
+    }
+
+    // =========================================================================
+    // Bug Rv2 — loadReviewingById() destroys existing reviewings
+    // =========================================================================
+
+    /**
+     * Fix Rv2: loadReviewingById() created a fresh uninitialized local variable
+     * $reviewings[$docId] = $oReviewing, then did $this->_reviewings = $reviewings,
+     * erasing all previously loaded reviewings.
+     *
+     * The fix mirrors loadReviewing(): load existing reviewings first, merge,
+     * then setReviewings().
+     */
+    public function testLoadReviewingByIdSourceMergesWithExistingReviewings(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Reviewer::class, 'loadReviewingById');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        // Old pattern: orphan local var assignment directly to $this->_reviewings
+        self::assertStringNotContainsString(
+            '$this->_reviewings = $reviewings',
+            $source,
+            'Fix Rv2: must not assign directly to $this->_reviewings — use setReviewings() after merging'
+        );
+
+        // New pattern: load existing, merge, set
+        self::assertStringContainsString(
+            'getReviewings()',
+            $source,
+            'Fix Rv2: must call getReviewings() to load existing reviewings before merging'
+        );
+        self::assertStringContainsString(
+            'setReviewings(',
+            $source,
+            'Fix Rv2: must call setReviewings() to persist the merged result'
+        );
+    }
+
+    // =========================================================================
+    // Bug Rv3 — getComments() cache not keyed by docId
+    // =========================================================================
+
+    /**
+     * Fix Rv3: $this->_comments was a flat array filled on the first call.
+     * Subsequent calls for a different $docId returned the first call's results.
+     *
+     * The fix uses $this->_comments[$docId] as cache key, so each docId has
+     * its own entry.
+     */
+    public function testGetCommentsSourceUsesDocIdAsCacheKey(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Reviewer::class, 'getComments');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        // Old pattern: if (empty($this->_comments)) — cache not keyed by docId
+        self::assertStringNotContainsString(
+            'empty($this->_comments)',
+            $source,
+            'Fix Rv3: empty() check on $this->_comments is not keyed by docId — returns stale data for different docIds'
+        );
+
+        // New pattern: array_key_exists keyed by docId
+        self::assertStringContainsString(
+            'array_key_exists($docId, $this->_comments)',
+            $source,
+            'Fix Rv3: cache must be indexed by $docId to prevent cross-docId contamination'
+        );
+
+        self::assertStringContainsString(
+            '$this->_comments[$docId]',
+            $source,
+            'Fix Rv3: comments must be stored and returned as $this->_comments[$docId]'
+        );
+    }
+
+    // =========================================================================
+    // Bug Rv4 — $isLimit missing bool type hint
+    // =========================================================================
+
+    /**
+     * Fix Rv4: getAssignedPapers() and loadAssignedPapers() declared $isLimit
+     * without a type hint while the other three parameters were typed bool.
+     */
+    public function testGetAssignedPapersIsLimitParameterIsTypedBool(): void
+    {
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'getAssignedPapers');
+        $param  = $method->getParameters()[3]; // 4th param: $isLimit
+
+        self::assertSame('isLimit', $param->getName());
+        self::assertNotNull($param->getType(), 'Fix Rv4: $isLimit must have a type hint');
+        self::assertSame('bool', $param->getType()->getName(), 'Fix Rv4: $isLimit must be typed bool');
+        self::assertTrue($param->getDefaultValue(), '$isLimit default must be true');
+    }
+
+    public function testLoadAssignedPapersIsLimitParameterIsTypedBool(): void
+    {
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'loadAssignedPapers');
+        $param  = $method->getParameters()[3]; // 4th param: $isLimit
+
+        self::assertSame('isLimit', $param->getName());
+        self::assertNotNull($param->getType(), 'Fix Rv4: $isLimit must have a type hint in loadAssignedPapers()');
+        self::assertSame('bool', $param->getType()->getName());
+    }
+
+    // =========================================================================
+    // Bug Rv5 — unassign() uses legacy ifsetor instead of ??
+    // =========================================================================
+
+    /**
+     * Fix Rv5: unassign() used Ccsd_Tools::ifsetor($params['rvid'], RVID)
+     * while assign() already uses $params['rvid'] ?? RVID.
+     * Standardized to the ?? operator for consistency.
+     */
+    public function testUnassignSourceUsesNullCoalescingNotIfsetor(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Reviewer::class, 'unassign');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        self::assertStringNotContainsString(
+            'ifsetor(',
+            $source,
+            'Fix Rv5: Ccsd_Tools::ifsetor() must be replaced with ?? operator (consistent with assign())'
+        );
+
+        self::assertStringContainsString(
+            "?? RVID",
+            $source,
+            'Fix Rv5: use $params[\'rvid\'] ?? RVID like assign() does'
+        );
+    }
+
+    // =========================================================================
+    // filterInvitations() — pure logic, no DB
+    // =========================================================================
+
+    public function testFilterInvitationsWithNoFiltersReturnsAll(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $inv1     = $this->makeInvitation(Episciences_User_Invitation::STATUS_PENDING);
+        $inv2     = $this->makeInvitation(Episciences_User_Invitation::STATUS_DECLINED);
+
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'filterInvitations');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($reviewer, [10 => $inv1, 20 => $inv2], []);
+
+        self::assertCount(2, $result);
+    }
+
+    public function testFilterInvitationsFiltersByStatusArray(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $pending  = $this->makeInvitation(Episciences_User_Invitation::STATUS_PENDING);
+        $declined = $this->makeInvitation(Episciences_User_Invitation::STATUS_DECLINED);
+        $accepted = $this->makeInvitation(Episciences_User_Invitation::STATUS_ACCEPTED);
+
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'filterInvitations');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($reviewer, [10 => $pending, 20 => $declined, 30 => $accepted], [
+            'status' => [Episciences_User_Invitation::STATUS_PENDING, Episciences_User_Invitation::STATUS_DECLINED]
+        ]);
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey(10, $result);
+        self::assertArrayHasKey(20, $result);
+        self::assertArrayNotHasKey(30, $result);
+    }
+
+    public function testFilterInvitationsFiltersByStatusScalar(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        $pending  = $this->makeInvitation(Episciences_User_Invitation::STATUS_PENDING);
+        $declined = $this->makeInvitation(Episciences_User_Invitation::STATUS_DECLINED);
+
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'filterInvitations');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($reviewer, [10 => $pending, 20 => $declined], [
+            'status' => Episciences_User_Invitation::STATUS_PENDING
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey(10, $result);
+    }
+
+    public function testFilterInvitationsEmptyInputReturnsEmpty(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        $method = new ReflectionMethod(Episciences_Reviewer::class, 'filterInvitations');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($reviewer, [], ['status' => Episciences_User_Invitation::STATUS_PENDING]);
+
+        self::assertSame([], $result);
+    }
+
+    // =========================================================================
+    // getReviewingsByRvid()
+    // =========================================================================
+
+    public function testGetReviewingsByRvidReturnsEmptyWhenNoReviewings(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+        // _reviewings = [] by default
+
+        self::assertSame([], $reviewer->getReviewingsByRvid(1));
+    }
+
+    // =========================================================================
+    // Ratings
+    // =========================================================================
+
+    public function testSetRatingsReturnsFluentInterface(): void
+    {
+        $reviewer = new Episciences_Reviewer();
+
+        self::assertSame($reviewer, $reviewer->setRatings([]));
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function makeInvitation(string $status): Episciences_User_Invitation
+    {
+        $inv = $this->createMock(Episciences_User_Invitation::class);
+        $inv->method('getStatus')->willReturn($status);
+        $inv->method('hasExpired')->willReturn(false);
+
+        return $inv;
+    }
+}

--- a/tests/unit/library/Episciences/Episciences_ReviewersManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewersManagerTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_ReviewersManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_ReviewersManager.
+ *
+ * DB-dependent methods (getList, getSuggestedReviewers, getUnwantedReviewers,
+ * addReviewerToPool) and Zend_Form-dependent methods (acceptInvitationForm,
+ * refuseInvitationForm, reviewer_answer_form) are covered via API-contract
+ * and source-inspection tests only.
+ *
+ * Bugs documented/fixed:
+ *   RM1 — getList(): $settings parameter is accepted but never used; the method
+ *          always delegates to Episciences_Review::getReviewers() without filters.
+ *          Documented only — changing would require a larger refactoring and
+ *          aligning with callers.
+ *   RM2 — addReviewerToPool(): DB exception was unhandled — the method always
+ *          returned true regardless of success or failure.
+ *          Fixed: wrapped in try/catch; returns false on exception.
+ *   RM3 — getSuggestedReviewers() / getUnwantedReviewers(): literal string values
+ *          were embedded in where() without parameterization
+ *          (e.g. ->where("SETTING = 'suggestedReviewer'")).
+ *          Fixed: use parameterized where('SETTING = ?', 'value').
+ *
+ * @covers Episciences_ReviewersManager
+ */
+final class Episciences_ReviewersManagerTest extends TestCase
+{
+    // =========================================================================
+    // API contract — method signatures
+    // =========================================================================
+
+    public function testGetListAcceptsSettingsArray(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'getList');
+        $params = $method->getParameters();
+
+        self::assertCount(1, $params);
+        self::assertSame('settings', $params[0]->getName());
+        self::assertTrue($params[0]->isOptional(), 'getList() $settings must be optional');
+        self::assertSame([], $params[0]->getDefaultValue(), 'getList() $settings must default to []');
+    }
+
+    public function testGetSuggestedReviewersAcceptsDocid(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'getSuggestedReviewers');
+        $params = $method->getParameters();
+
+        self::assertCount(1, $params);
+        self::assertSame('docid', $params[0]->getName());
+    }
+
+    public function testGetUnwantedReviewersAcceptsDocid(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'getUnwantedReviewers');
+        $params = $method->getParameters();
+
+        self::assertCount(1, $params);
+        self::assertSame('docid', $params[0]->getName());
+    }
+
+    public function testAddReviewerToPoolReturnTypeIsBool(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'addReviewerToPool');
+
+        self::assertNotNull($method->getReturnType());
+        self::assertSame('bool', $method->getReturnType()->getName());
+    }
+
+    public function testAddReviewerToPoolHasThreeParameters(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'addReviewerToPool');
+        $params = $method->getParameters();
+
+        self::assertCount(3, $params);
+        self::assertSame('uid',  $params[0]->getName());
+        self::assertSame('vid',  $params[1]->getName());
+        self::assertSame('rvid', $params[2]->getName());
+    }
+
+    public function testAddReviewerToPoolSecondParamDefaultsToZero(): void
+    {
+        $method = new ReflectionMethod(Episciences_ReviewersManager::class, 'addReviewerToPool');
+        $params = $method->getParameters();
+
+        self::assertTrue($params[1]->isOptional());
+        self::assertSame(0, $params[1]->getDefaultValue());
+    }
+
+    // =========================================================================
+    // Bug RM1 — getList() ignores $settings (documented, not fixed)
+    // =========================================================================
+
+    /**
+     * Design issue RM1 (documented, not fixed): getList() accepts a $settings
+     * parameter but passes it to nothing — it always delegates to
+     * Episciences_Review::getReviewers() with no filter arguments.
+     *
+     * Callers that pass filters (e.g. volume id, role) silently get the full
+     * reviewer list instead of the filtered one.
+     *
+     * This test documents the current behaviour by inspecting the source to
+     * confirm the dead parameter, without breaking the existing API.
+     */
+    public function testGetListSourceIgnoresSettingsParameter(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'getList');
+        $source     = $this->getMethodSource($reflection);
+
+        // The $settings variable is never used in the method body
+        self::assertStringNotContainsString(
+            '$settings',
+            // Remove the parameter declaration line so we only check the body
+            preg_replace('/function\s+getList[^{]*\{/', '', $source),
+            'Design issue RM1: $settings is declared but never used inside getList() — filters are silently ignored'
+        );
+
+        // Always delegates to getReviewers() with no arguments
+        self::assertStringContainsString(
+            'getReviewers()',
+            $source,
+            'getList() must delegate to Episciences_Review::getReviewers()'
+        );
+    }
+
+    // =========================================================================
+    // Bug RM2 — addReviewerToPool() exception handling
+    // =========================================================================
+
+    /**
+     * Fix RM2: the original method had no try/catch — any DB exception propagated
+     * uncaught and the declared ": bool" return type was never false.
+     * Fixed: wrapped in try/catch; logs the exception and returns false on failure.
+     */
+    public function testAddReviewerToPoolSourceHasTryCatch(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'addReviewerToPool');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            'try {',
+            $source,
+            'Fix RM2: addReviewerToPool() must have a try block to catch DB exceptions'
+        );
+
+        self::assertStringContainsString(
+            'catch (',
+            $source,
+            'Fix RM2: addReviewerToPool() must have a catch block'
+        );
+
+        self::assertStringContainsString(
+            'return false;',
+            $source,
+            'Fix RM2: addReviewerToPool() must return false when an exception is caught'
+        );
+
+        self::assertStringContainsString(
+            'return true;',
+            $source,
+            'Fix RM2: addReviewerToPool() must return true on success'
+        );
+    }
+
+    public function testAddReviewerToPoolSourceLogsException(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'addReviewerToPool');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            'error_log(',
+            $source,
+            'Fix RM2: addReviewerToPool() must log the exception message before returning false'
+        );
+    }
+
+    // =========================================================================
+    // Bug RM3 — getSuggestedReviewers() / getUnwantedReviewers() parameterization
+    // =========================================================================
+
+    /**
+     * Fix RM3: the original where() calls embedded the setting name as a raw
+     * string literal in the SQL fragment, bypassing Zend_Db quoting:
+     *   ->where("SETTING = 'suggestedReviewer'")
+     *   ->where("SETTING = 'unwantedReviewer'")
+     *
+     * Fixed: use the parameterized form:
+     *   ->where('SETTING = ?', 'suggestedReviewer')
+     *   ->where('SETTING = ?', 'unwantedReviewer')
+     */
+    public function testGetSuggestedReviewersSourceUsesParameterizedWhere(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'getSuggestedReviewers');
+        $source     = $this->getMethodSource($reflection);
+
+        // Old pattern: literal string embedded in the where clause
+        self::assertStringNotContainsString(
+            "'SETTING = \\'suggestedReviewer\\''",
+            $source,
+            'Fix RM3: where() must not embed the setting name as a raw string literal'
+        );
+
+        // New pattern: parameterized placeholder
+        self::assertStringContainsString(
+            "where('SETTING = ?', 'suggestedReviewer')",
+            $source,
+            'Fix RM3: getSuggestedReviewers() must use parameterized where() for SETTING'
+        );
+    }
+
+    public function testGetUnwantedReviewersSourceUsesParameterizedWhere(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'getUnwantedReviewers');
+        $source     = $this->getMethodSource($reflection);
+
+        // Old pattern: literal string embedded in the where clause
+        self::assertStringNotContainsString(
+            "'SETTING = \\'unwantedReviewer\\''",
+            $source,
+            'Fix RM3: where() must not embed the setting name as a raw string literal'
+        );
+
+        // New pattern: parameterized placeholder
+        self::assertStringContainsString(
+            "where('SETTING = ?', 'unwantedReviewer')",
+            $source,
+            'Fix RM3: getUnwantedReviewers() must use parameterized where() for SETTING'
+        );
+    }
+
+    public function testGetSuggestedReviewersAlsoParameterizesDocid(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'getSuggestedReviewers');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            "where('DOCID = ?', \$docid)",
+            $source,
+            'getSuggestedReviewers() must use parameterized where() for DOCID'
+        );
+    }
+
+    public function testGetUnwantedReviewersAlsoParameterizesDocid(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_ReviewersManager::class, 'getUnwantedReviewers');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            "where('DOCID = ?', \$docid)",
+            $source,
+            'getUnwantedReviewers() must use parameterized where() for DOCID'
+        );
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function getMethodSource(ReflectionMethod $method): string
+    {
+        $lines = file($method->getFileName());
+
+        return implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+    }
+}

--- a/tests/unit/library/Episciences/Rating/Episciences_Rating_GridTest.php
+++ b/tests/unit/library/Episciences/Rating/Episciences_Rating_GridTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace unit\library\Episciences\Rating;
+
+use Episciences_Rating_Criterion;
+use Episciences_Rating_Grid;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_Rating_Grid.
+ *
+ * All tests are DB-free: Grid is a pure in-memory entity.
+ *
+ * Bugs documented/fixed:
+ *   G1 — loadXML() dead call: getElementsByTagName('text') result discarded
+ *   G2 — loadXML() null dereference: item(0) on <head> when div has no head child
+ *   G3 — loadXML() null dereference: $node->firstChild on empty <f> elements
+ *   G4 — getCriterion() TypeError: array_key_exists on null when criteria not initialized
+ *
+ * @covers Episciences_Rating_Grid
+ */
+final class Episciences_Rating_GridTest extends TestCase
+{
+    // =========================================================================
+    // __construct / populate
+    // =========================================================================
+
+    public function testConstructWithEmptyArrayCreatesEmptyGrid(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+
+        self::assertNull($grid->getId());
+        self::assertNull($grid->getFilename());
+        self::assertNull($grid->getCriteria());
+        self::assertNull($grid->getXml());
+    }
+
+    public function testConstructWithValuesPopulatesProperties(): void
+    {
+        $grid = new Episciences_Rating_Grid(['id' => 42, 'filename' => 'grid.xml']);
+
+        self::assertSame(42, $grid->getId());
+        self::assertSame('grid.xml', $grid->getFilename());
+    }
+
+    public function testConstructIgnoresUnknownKeys(): void
+    {
+        $grid = new Episciences_Rating_Grid(['nonexistent' => 'value']);
+
+        self::assertNull($grid->getId());
+    }
+
+    // =========================================================================
+    // setCriteria / getCriteria
+    // =========================================================================
+
+    public function testSetCriteriaAcceptsCriterionObjects(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $c    = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_CRITERION);
+
+        $grid->setCriteria([$c]);
+
+        self::assertCount(1, $grid->getCriteria());
+        self::assertSame($c, $grid->getCriteria()[0]);
+    }
+
+    public function testSetCriteriaConvertsArraysToCriterionObjects(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([
+            ['type' => Episciences_Rating_Criterion::TYPE_SEPARATOR],
+        ]);
+
+        $criteria = $grid->getCriteria();
+        self::assertCount(1, $criteria);
+        self::assertInstanceOf(Episciences_Rating_Criterion::class, $criteria[0]);
+        self::assertTrue($criteria[0]->isSeparator());
+    }
+
+    public function testSetCriteriaRejectsNonCriterionNonArrayItems(): void
+    {
+        // is_a() check: objects that are not Criterion instances are converted via new Criterion()
+        // which may fail silently — just verify the count
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([
+            new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]),
+            new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_SEPARATOR]),
+        ]);
+
+        self::assertCount(2, $grid->getCriteria());
+    }
+
+    public function testSetCriteriaWithEmptyArrayGivesEmptyArray(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([]);
+
+        self::assertIsArray($grid->getCriteria());
+        self::assertCount(0, $grid->getCriteria());
+    }
+
+    // =========================================================================
+    // addCriterion
+    // =========================================================================
+
+    public function testAddCriterionAppendsToCriteria(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([]);
+
+        $c1 = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]);
+        $c2 = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_SEPARATOR]);
+
+        $grid->addCriterion($c1);
+        $grid->addCriterion($c2);
+
+        self::assertCount(2, $grid->getCriteria());
+    }
+
+    // =========================================================================
+    // setCriterion
+    // =========================================================================
+
+    public function testSetCriterionReplacesAtIndex(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $c1   = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]);
+        $c2   = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_SEPARATOR]);
+
+        $grid->setCriterion(0, $c1);
+        $grid->setCriterion(0, $c2);
+
+        self::assertSame($c2, $grid->getCriteria()[0]);
+    }
+
+    // =========================================================================
+    // getCriterion — Bug G4 fix
+    // =========================================================================
+
+    /**
+     * Fix G4: getCriterion() must return null (not throw TypeError) when
+     * _criteria has not been initialized (is null).
+     * Before the fix: array_key_exists($id, null) → TypeError in PHP 8.1+.
+     */
+    public function testGetCriterionReturnsNullWhenCriteriaNotInitialized(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        // _criteria is null by default
+
+        self::assertNull($grid->getCriterion(0));
+    }
+
+    public function testGetCriterionReturnsNullForMissingKey(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([]);
+
+        self::assertNull($grid->getCriterion(99));
+    }
+
+    public function testGetCriterionReturnsCorrectCriterion(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $c    = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]);
+        $grid->setCriterion('item_0', $c);
+
+        self::assertSame($c, $grid->getCriterion('item_0'));
+    }
+
+    // =========================================================================
+    // removeCriterion
+    // =========================================================================
+
+    public function testRemoveCriterionDeletesMatchingCriterion(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+
+        $c1 = new Episciences_Rating_Criterion();
+        $c1->setId('item_0');
+        $c2 = new Episciences_Rating_Criterion();
+        $c2->setId('item_1');
+
+        $grid->setCriteria([$c1, $c2]);
+        $grid->removeCriterion('item_0');
+
+        $remaining = array_values($grid->getCriteria());
+        self::assertCount(1, $remaining);
+        self::assertSame('item_0', $remaining[0]->getId(), 'item_1 should be renumbered to item_0');
+    }
+
+    public function testRemoveCriterionOnNonExistentIdLeavesAllCriteria(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+
+        $c = new Episciences_Rating_Criterion();
+        $c->setId('item_0');
+        $grid->setCriteria([$c]);
+
+        $grid->removeCriterion('item_99');
+
+        self::assertCount(1, $grid->getCriteria());
+    }
+
+    // =========================================================================
+    // toArray
+    // =========================================================================
+
+    public function testToArrayContainsCriteriaKey(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+        $grid->setCriteria([]);
+
+        $array = $grid->toArray();
+
+        self::assertArrayHasKey('criteria', $array);
+        self::assertIsArray($array['criteria']);
+    }
+
+    public function testToArrayWithNullCriteriaReturnsCriteriaKey(): void
+    {
+        $grid  = new Episciences_Rating_Grid();
+        $array = $grid->toArray();
+
+        self::assertArrayHasKey('criteria', $array);
+        self::assertIsArray($array['criteria']);
+        self::assertCount(0, $array['criteria']);
+    }
+
+    public function testToArraySerializesCriterionObjects(): void
+    {
+        $grid = new Episciences_Rating_Grid();
+
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_CRITERION);
+        $c->setVisibility(Episciences_Rating_Criterion::VISIBILITY_EDITORS);
+        $c->setPosition(1);
+
+        $grid->setCriteria([$c]);
+
+        $array = $grid->toArray();
+        self::assertCount(1, $array['criteria']);
+        self::assertSame(Episciences_Rating_Criterion::TYPE_CRITERION, $array['criteria'][0]['type']);
+    }
+
+    // =========================================================================
+    // Bug G1 — dead call removed from loadXML()
+    // =========================================================================
+
+    /**
+     * Fix G1: loadXML() previously called $xml->getElementsByTagName('text')
+     * without assigning or using the result — a no-op that wasted a DOM traversal.
+     * Verify the dead call was removed from the source.
+     */
+    public function testLoadXmlNoLongerHasDeadGetElementsByTagNameTextCall(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Grid::class, 'loadXML');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        self::assertStringNotContainsString(
+            "getElementsByTagName('text');",
+            $source,
+            "Fix G1: the dead call \$xml->getElementsByTagName('text') (result discarded) must be removed"
+        );
+    }
+
+    // =========================================================================
+    // Bug G2 — null safety on item(0) for <head> element
+    // =========================================================================
+
+    /**
+     * Fix G2: loadXML() previously called item(0)->getElementsByTagName('label')
+     * directly. If a <div> had no <head> child, item(0) returns null and PHP threw
+     * a TypeError. Verify the fix guards with a null check before iterating.
+     */
+    public function testLoadXmlGuardsAgainstNullHeadElement(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Grid::class, 'loadXML');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        // Old pattern: item(0)->getElementsByTagName — direct chaining without null check
+        self::assertStringNotContainsString(
+            "->item(0)->getElementsByTagName",
+            $source,
+            "Fix G2: item(0) must not be chained directly — assign to variable and null-check first"
+        );
+
+        // New pattern: null check before iterating
+        self::assertStringContainsString(
+            '$headElement !== null',
+            $source,
+            "Fix G2: a null guard on the head element must be present"
+        );
+    }
+
+    // =========================================================================
+    // Bug G3 — null safety on firstChild in <f> elements
+    // =========================================================================
+
+    /**
+     * Fix G3: loadXML() called $node->firstChild->getAttribute('value') without
+     * checking firstChild for null. An empty <f> element caused a fatal TypeError.
+     */
+    public function testLoadXmlGuardsAgainstNullFirstChild(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Grid::class, 'loadXML');
+        $lines      = file($reflection->getFileName());
+        $source     = implode('', array_slice($lines, $reflection->getStartLine() - 1, $reflection->getEndLine() - $reflection->getStartLine() + 1));
+
+        self::assertStringContainsString(
+            '$node->firstChild !== null',
+            $source,
+            "Fix G3: firstChild must be null-checked before calling getAttribute() on it"
+        );
+    }
+}

--- a/tests/unit/library/Episciences/Rating/Episciences_Rating_ManagerTest.php
+++ b/tests/unit/library/Episciences/Rating/Episciences_Rating_ManagerTest.php
@@ -1,0 +1,633 @@
+<?php
+
+namespace unit\library\Episciences\Rating;
+
+use Episciences_Rating_Criterion;
+use Episciences_Rating_Manager;
+use Episciences_Rating_Report;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_Rating_Manager (and related Rating entities).
+ *
+ * DB-dependent methods (find, getList, getPreviousRatings, isExistingCriterion)
+ * are covered via API-contract and source-inspection tests only.
+ * Pure-logic methods (getAverageRating) and entity classes (Report, Criterion)
+ * are tested with real objects — no DB required.
+ *
+ * Bugs documented here (tests that currently FAIL signal unfixed bugs):
+ *   B1 — getList() wrong order() call: direction 'DESC' silently dropped
+ *   B2 — getRatingForm() separator label not escaped (XSS)
+ *   B3 — getRatingForm() malformed HTML div (missing opening quote)
+ *   B4 — getAverageRating() excludes STATUS_PENDING=0 reports (falsy check)
+ *   B5 — Criterion::getMaxNote() throws ValueError on empty options
+ *   B6 — Manager::find() duplicates Report::find() (maintenance hazard)
+ *
+ * @covers Episciences_Rating_Manager
+ * @covers Episciences_Rating_Report
+ * @covers Episciences_Rating_Criterion
+ */
+final class Episciences_Rating_ManagerTest extends TestCase
+{
+    // =========================================================================
+    // getAverageRating() — pure logic, no DB
+    // =========================================================================
+
+    public function testGetAverageRatingReturnsNullForEmptyArray(): void
+    {
+        self::assertNull(Episciences_Rating_Manager::getAverageRating([]));
+    }
+
+    public function testGetAverageRatingReturnsNullForFalsyInput(): void
+    {
+        self::assertNull(Episciences_Rating_Manager::getAverageRating(false));
+        self::assertNull(Episciences_Rating_Manager::getAverageRating(null));
+    }
+
+    public function testGetAverageRatingReturnsNullWhenAllReportsHaveZeroStatus(): void
+    {
+        // STATUS_PENDING = 0 → falsy → all excluded → null returned
+        $r1 = $this->makeReport(Episciences_Rating_Report::STATUS_WIP, 8.0);
+        $r2 = $this->makeReport(Episciences_Rating_Report::STATUS_WIP, 6.0);
+
+        // Both WIP (status=1) are truthy and included
+        self::assertSame(7.0, Episciences_Rating_Manager::getAverageRating([$r1, $r2]));
+    }
+
+    public function testGetAverageRatingComputesCorrectAverage(): void
+    {
+        $r1 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 8.0);
+        $r2 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 6.0);
+
+        // round((8+6)/2, 0) = 7.0
+        self::assertSame(7.0, Episciences_Rating_Manager::getAverageRating([$r1, $r2]));
+    }
+
+    public function testGetAverageRatingRespectsPrecisionParameter(): void
+    {
+        $r1 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 7.0);
+        $r2 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 8.0);
+
+        // (7+8)/2 = 7.5 — with precision=1 should stay 7.5
+        self::assertSame(7.5, Episciences_Rating_Manager::getAverageRating([$r1, $r2], 1));
+    }
+
+    public function testGetAverageRatingDefaultPrecisionIsZero(): void
+    {
+        $r1 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 7.0);
+        $r2 = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 8.0);
+
+        // (7+8)/2 = 7.5 — round to 0 decimal → 8.0
+        self::assertSame(8.0, Episciences_Rating_Manager::getAverageRating([$r1, $r2]));
+    }
+
+    /**
+     * Pending reports (STATUS_PENDING = 0) are explicitly excluded from the average.
+     * Fix B4: replaced falsy check `if ($rating->getStatus())` with
+     * `if ($rating->getStatus() !== STATUS_PENDING)` so the exclusion is intentional
+     * and immune to any future reordering of status constant values.
+     */
+    public function testGetAverageRatingExcludesPendingReports(): void
+    {
+        $pending = $this->makeReport(Episciences_Rating_Report::STATUS_PENDING, 10.0);
+
+        self::assertNull(
+            Episciences_Rating_Manager::getAverageRating([$pending]),
+            'Pending reports must be excluded from the average (explicit !== STATUS_PENDING check)'
+        );
+    }
+
+    public function testGetAverageRatingIncludesWipReports(): void
+    {
+        $wip = $this->makeReport(Episciences_Rating_Report::STATUS_WIP, 8.0);
+
+        // STATUS_WIP = 1 → truthy → included
+        self::assertSame(8.0, Episciences_Rating_Manager::getAverageRating([$wip]));
+    }
+
+    public function testGetAverageRatingMixedStatusOnlyCountsNonPending(): void
+    {
+        $completed = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 9.0);
+        $pending   = $this->makeReport(Episciences_Rating_Report::STATUS_PENDING, 1.0);
+
+        // Only $completed passes the falsy check — average = 9.0
+        self::assertSame(9.0, Episciences_Rating_Manager::getAverageRating([$completed, $pending]));
+    }
+
+    public function testGetAverageRatingReturnsSingleScore(): void
+    {
+        $r = $this->makeReport(Episciences_Rating_Report::STATUS_COMPLETED, 7.0);
+
+        self::assertSame(7.0, Episciences_Rating_Manager::getAverageRating([$r]));
+    }
+
+    // =========================================================================
+    // API contract — method signatures (Reflection-based)
+    // =========================================================================
+
+    public function testGetListHasThreeOptionalParameters(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_Manager::class, 'getList');
+
+        self::assertCount(3, $method->getParameters());
+
+        foreach ($method->getParameters() as $param) {
+            self::assertTrue(
+                $param->isDefaultValueAvailable(),
+                "getList() parameter \${$param->getName()} must have a default value (null)"
+            );
+            self::assertNull($param->getDefaultValue());
+        }
+    }
+
+    public function testGetListParameterNames(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_Manager::class, 'getList');
+        $names  = array_map(fn($p) => $p->getName(), $method->getParameters());
+
+        self::assertSame(['docid', 'uid', 'status'], $names);
+    }
+
+    public function testGetAverageRatingSecondParamIsPrecisionWithDefaultZero(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_Manager::class, 'getAverageRating');
+        $params = $method->getParameters();
+
+        self::assertCount(2, $params);
+        self::assertSame('precision', $params[1]->getName());
+        self::assertTrue($params[1]->isDefaultValueAvailable());
+        self::assertSame(0, $params[1]->getDefaultValue());
+    }
+
+    public function testGetPreviousRatingsFirstParamIsTypedEpisciencesPaper(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_Manager::class, 'getPreviousRatings');
+        $first  = $method->getParameters()[0];
+
+        self::assertSame('paper', $first->getName());
+        self::assertNotNull($first->getType());
+        self::assertSame('Episciences_Paper', $first->getType()->getName());
+    }
+
+    // =========================================================================
+    // Bug B1 — getList() passes direction as ignored second argument to order()
+    // =========================================================================
+
+    /**
+     * Bug B1: Zend_Db_Select::order(string $spec) takes ONE argument.
+     * getList() calls ->order('CREATION_DATE', 'DESC') — the 'DESC' is silently
+     * discarded, so results are ordered ASC instead of DESC.
+     *
+     * The private helper getListQuery() correctly uses ->order('CREATION_DATE DESC')
+     * but getList() does not call that helper and has its own broken query.
+     *
+     * This test FAILS while the bug exists and PASSES once fixed.
+     */
+    public function testGetListUsesCorrectSingleStringOrderFormat(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Manager::class, 'getList');
+        $source     = $this->getMethodSource($reflection);
+
+        // Correct: direction embedded in the string → 'CREATION_DATE DESC'
+        // Buggy:   direction as second arg → ('CREATION_DATE', 'DESC') — silently dropped
+        self::assertStringNotContainsString(
+            "order('CREATION_DATE', 'DESC')",
+            $source,
+            "Bug B1: getList() passes 'DESC' as a second arg to order() — it is silently ignored "
+            . "by Zend_Db_Select. Use ->order('CREATION_DATE DESC') instead."
+        );
+
+        self::assertStringContainsString(
+            "order('CREATION_DATE DESC')",
+            $source,
+            "Bug B1: getList() should use ->order('CREATION_DATE DESC') (direction in the string)."
+        );
+    }
+
+    /**
+     * Verify that getListQuery() (used by getPreviousRatings()) already uses the
+     * correct format — confirming the fix pattern to apply to getList().
+     */
+    public function testGetListQueryUsesCorrectOrderFormat(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Manager::class, 'getListQuery');
+        $reflection->setAccessible(true);
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            "order('CREATION_DATE DESC')",
+            $source,
+            'getListQuery() should already use the correct single-string order format'
+        );
+    }
+
+    // =========================================================================
+    // Bug B3 — getRatingForm() malformed HTML (missing opening quote on div class)
+    // =========================================================================
+
+    /**
+     * Bug B3: Line 176 contains:
+     *   $bloc_delete_file = "<div class=col-sm-2'>";
+     * The opening single-quote before `col-sm-2` is missing.
+     * Correct:  "<div class='col-sm-2'>"
+     *
+     * This test FAILS while the bug exists and PASSES once fixed.
+     */
+    public function testGetRatingFormDeleteBlockHasNoMalformedDivClass(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Manager::class, 'getRatingForm');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringNotContainsString(
+            '"<div class=col-sm-2\'>"',
+            $source,
+            "Bug B3: malformed HTML — \"<div class=col-sm-2'>\" is missing the opening "
+            . "single-quote. Should be \"<div class='col-sm-2'>\"."
+        );
+    }
+
+    // =========================================================================
+    // Bug B2 — getRatingForm() separator label not escaped (XSS)
+    // =========================================================================
+
+    /**
+     * Bug B2: The separator criterion label is injected directly into HTML:
+     *   'value' => '<h2 class="separator">' . $criterion->getLabel() . '</h2>'
+     * without htmlspecialchars(). A label containing <script> tags would execute JS.
+     *
+     * This test FAILS while the bug exists and PASSES once fixed.
+     */
+    public function testGetRatingFormSeparatorLabelIsEscaped(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_Manager::class, 'getRatingForm');
+        $source     = $this->getMethodSource($reflection);
+
+        // Ensure the separator block exists (sanity check)
+        self::assertStringContainsString(
+            'isSeparator()',
+            $source,
+            'Sanity: separator branch must exist in getRatingForm()'
+        );
+
+        // The label must go through htmlspecialchars() before HTML injection
+        self::assertMatchesRegularExpression(
+            '/htmlspecialchars\s*\(\s*\$criterion->getLabel\(\)/',
+            $source,
+            'Bug B2: separator label must be escaped with htmlspecialchars() before HTML injection (XSS risk)'
+        );
+    }
+
+    // =========================================================================
+    // Bug B6 — Manager::find() duplicates Report::find()
+    // =========================================================================
+
+    /**
+     * Fix B6: Manager::find() now delegates to Report::find() instead of duplicating its body.
+     * A single implementation means bug fixes only need to be applied once.
+     */
+    public function testManagerFindDelegatesToReportFind(): void
+    {
+        $managerFind = new ReflectionMethod(Episciences_Rating_Manager::class, 'find');
+        $source      = $this->getMethodSource($managerFind);
+
+        self::assertStringContainsString(
+            'Episciences_Rating_Report::find(',
+            $source,
+            'Manager::find() must delegate to Report::find() instead of duplicating its body'
+        );
+    }
+
+    // =========================================================================
+    // Episciences_Rating_Report entity (no DB)
+    // =========================================================================
+
+    public function testReportStatusConstants(): void
+    {
+        self::assertSame(0, Episciences_Rating_Report::STATUS_PENDING);
+        self::assertSame(1, Episciences_Rating_Report::STATUS_WIP);
+        self::assertSame(2, Episciences_Rating_Report::STATUS_COMPLETED);
+    }
+
+    public function testReportDefaultStatusIsPending(): void
+    {
+        // Constructor without docid+uid → generatePath() returns false →
+        // _path stays null → file_exists('report.xml') → false → no loadXML call
+        $report = new Episciences_Rating_Report();
+
+        self::assertSame(Episciences_Rating_Report::STATUS_PENDING, $report->getStatus());
+        self::assertTrue($report->isPending());
+        self::assertFalse($report->isCompleted());
+        self::assertFalse($report->isInProgress());
+    }
+
+    public function testReportSetStatusCompleted(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setStatus(Episciences_Rating_Report::STATUS_COMPLETED);
+
+        self::assertTrue($report->isCompleted());
+        self::assertFalse($report->isPending());
+        self::assertFalse($report->isInProgress());
+    }
+
+    public function testReportSetStatusWip(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setStatus(Episciences_Rating_Report::STATUS_WIP);
+
+        self::assertTrue($report->isInProgress());
+        self::assertFalse($report->isPending());
+        self::assertFalse($report->isCompleted());
+    }
+
+    public function testReportSetStatusCastsStringToInt(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setStatus('2');
+
+        self::assertSame(2, $report->getStatus());
+        self::assertIsInt($report->getStatus());
+    }
+
+    public function testReportSetUidCastsStringToInt(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setUid('42');
+
+        self::assertSame(42, $report->getUid());
+        self::assertIsInt($report->getUid());
+    }
+
+    public function testReportIsCompletedUsesStrictComparison(): void
+    {
+        $report = new Episciences_Rating_Report();
+
+        // STATUS_PENDING=0 must NOT be treated as completed
+        self::assertFalse($report->isCompleted());
+        // STATUS_WIP=1 must NOT be treated as completed
+        $report->setStatus(Episciences_Rating_Report::STATUS_WIP);
+        self::assertFalse($report->isCompleted());
+    }
+
+    // =========================================================================
+    // Episciences_Rating_Criterion entity (no DB)
+    // =========================================================================
+
+    public function testCriterionVisibilityConstants(): void
+    {
+        self::assertSame('public', Episciences_Rating_Criterion::VISIBILITY_PUBLIC);
+        self::assertSame('contributor', Episciences_Rating_Criterion::VISIBILITY_CONTRIBUTOR);
+        self::assertSame('editors', Episciences_Rating_Criterion::VISIBILITY_EDITORS);
+    }
+
+    public function testCriterionTypeConstants(): void
+    {
+        self::assertSame('separator', Episciences_Rating_Criterion::TYPE_SEPARATOR);
+        self::assertSame('criterion', Episciences_Rating_Criterion::TYPE_CRITERION);
+    }
+
+    public function testCriterionIsSeparator(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_SEPARATOR);
+
+        self::assertTrue($c->isSeparator());
+        self::assertFalse($c->isCriterion());
+    }
+
+    public function testCriterionIsCriterion(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_CRITERION);
+
+        self::assertFalse($c->isSeparator());
+        self::assertTrue($c->isCriterion());
+    }
+
+    public function testCriterionHasNoOptionsByDefault(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+
+        self::assertFalse($c->hasOptions());
+        self::assertFalse($c->allowsNote());
+    }
+
+    public function testCriterionHasOptionsAfterSet(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setOptions([
+            0 => ['value' => 0, 'label' => null],
+            1 => ['value' => 1, 'label' => null],
+        ]);
+
+        self::assertTrue($c->hasOptions());
+        self::assertTrue($c->allowsNote());
+    }
+
+    public function testCriterionIsEmptyByDefault(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+
+        self::assertTrue($c->isEmpty());
+        self::assertFalse($c->hasValue());
+    }
+
+    public function testCriterionIsNotEmptyAfterComment(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setComment('Good methodology.');
+
+        self::assertFalse($c->isEmpty());
+        self::assertTrue($c->hasValue());
+        self::assertTrue($c->hasComment());
+    }
+
+    public function testCriterionIsNotEmptyAfterAttachment(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setAttachment('review.pdf');
+
+        self::assertFalse($c->isEmpty());
+        self::assertTrue($c->hasAttachment());
+    }
+
+    public function testCriterionSetNoteConvertsStringToInt(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setNote('3');
+
+        self::assertSame(3, $c->getNote());
+        self::assertIsInt($c->getNote());
+        self::assertTrue($c->hasNote());
+    }
+
+    public function testCriterionNoteZeroIsNumericSoHasNoteReturnsTrue(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setNote(0);
+
+        // is_numeric(0) === true — note 0 counts as "having a note"
+        self::assertTrue($c->hasNote());
+    }
+
+    public function testCriterionGetMaxNoteWithOptions(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setOptions([
+            0 => ['value' => 0, 'label' => null],
+            1 => ['value' => 1, 'label' => null],
+            2 => ['value' => 2, 'label' => null],
+            3 => ['value' => 3, 'label' => null],
+        ]);
+
+        self::assertSame(3, $c->getMaxNote());
+    }
+
+    /**
+     * Fix B5: getMaxNote() now guards against empty options.
+     * Previously max(array_keys([])) threw ValueError in PHP 8.x.
+     * The fix returns 1 as a safe default when no options are defined.
+     */
+    public function testCriterionGetMaxNoteReturnsOneOnEmptyOptions(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        // $_options = [] by default — must not throw
+
+        self::assertSame(1, $c->getMaxNote());
+    }
+
+    public function testCriterionHasCoefficientReturnsFalseWhenNull(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+
+        // is_numeric(null) === false
+        self::assertFalse($c->hasCoefficient());
+    }
+
+    public function testCriterionHasCoefficientReturnsTrueForIntCoefficient(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setCoefficient(2);
+
+        self::assertTrue($c->hasCoefficient());
+    }
+
+    public function testCriterionHasCoefficientReturnsTrueForFloatCoefficient(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setCoefficient(1.5);
+
+        self::assertTrue($c->hasCoefficient());
+    }
+
+    public function testCriterionAllowsCommentWhenSettingIsTrue(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setComment_setting(true);
+
+        self::assertTrue($c->allowsComment());
+    }
+
+    public function testCriterionDoesNotAllowCommentByDefault(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+
+        // _comment_setting is null by default → allowsComment() returns null (falsy, not false)
+        self::assertEmpty($c->allowsComment());
+    }
+
+    public function testCriterionAllowsAttachmentWhenSettingIsTrue(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setAttachment_setting(true);
+
+        self::assertTrue($c->allowsAttachment());
+    }
+
+    public function testCriterionDoesNotAllowAttachmentByDefault(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+
+        // _attachment_setting is null by default → allowsAttachment() returns null (falsy, not false)
+        self::assertEmpty($c->allowsAttachment());
+    }
+
+    public function testCriterionGetOptionReturnsCorrectOption(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setOptions([
+            0 => ['value' => 0, 'label' => ['en' => 'Poor']],
+            1 => ['value' => 1, 'label' => ['en' => 'Good']],
+        ]);
+
+        $option = $c->getOption(1);
+        self::assertIsArray($option);
+        self::assertSame(['en' => 'Good'], $option['label']);
+    }
+
+    public function testCriterionGetOptionReturnsFalseForMissingKey(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setOptions([0 => ['value' => 0, 'label' => null]]);
+
+        self::assertFalse($c->getOption(99));
+    }
+
+    public function testCriterionToArrayContainsExpectedKeysForCriterionType(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_CRITERION);
+        $c->setVisibility(Episciences_Rating_Criterion::VISIBILITY_EDITORS);
+        $c->setPosition(1);
+
+        $array = $c->toArray();
+
+        self::assertArrayHasKey('type', $array);
+        self::assertArrayHasKey('options', $array);
+        self::assertArrayHasKey('note', $array);
+        self::assertArrayHasKey('coefficient', $array);
+        self::assertArrayHasKey('comment', $array);
+        self::assertArrayHasKey('attachment', $array);
+        self::assertArrayHasKey('visibility', $array);
+    }
+
+    public function testCriterionToArrayDoesNotContainOptionKeysForSeparatorType(): void
+    {
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_SEPARATOR);
+        $c->setVisibility(Episciences_Rating_Criterion::VISIBILITY_PUBLIC);
+        $c->setPosition(1);
+
+        $array = $c->toArray();
+
+        self::assertArrayNotHasKey('options', $array);
+        self::assertArrayNotHasKey('note', $array);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function makeReport(int $status, float $score): Episciences_Rating_Report
+    {
+        $mock = $this->createMock(Episciences_Rating_Report::class);
+        $mock->method('getStatus')->willReturn($status);
+        $mock->method('getScore')->willReturn($score);
+
+        return $mock;
+    }
+
+    private function getMethodSource(ReflectionMethod $method): string
+    {
+        $lines = file($method->getFileName());
+
+        return implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+    }
+
+    private function normaliseSource(string $source): string
+    {
+        // Strip whitespace differences for comparison
+        return preg_replace('/\s+/', ' ', trim($source));
+    }
+}

--- a/tests/unit/library/Episciences/Rating/Episciences_Rating_ReportManagerTest.php
+++ b/tests/unit/library/Episciences/Rating/Episciences_Rating_ReportManagerTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace unit\library\Episciences\Rating;
+
+use Episciences_Rating_ReportManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_Rating_ReportManager.
+ *
+ * DB-dependent methods (updateUidS, deleteByUidAndDocId, updateProcessing) are
+ * covered via API-contract and source-inspection tests only.
+ * renameGrid() is covered via source inspection (requires real filesystem for
+ * full integration testing).
+ *
+ * Bugs documented/fixed:
+ *   R1 — renameGrid(): logic inversion — always returned true regardless of
+ *        whether rename() succeeded or failed.
+ *   R2 — renameGrid(): error_log message missing spaces around $nameDir.
+ *   R4 — updateProcessing(): trigger_error($msg, E_USER_ERROR) killed the process;
+ *        replaced with error_log() inside a proper catch block.
+ *   R5 — updateProcessing(): DELETE then INSERT without transaction — data loss
+ *        if INSERT failed; wrapped in beginTransaction/commit/rollBack.
+ *
+ * @covers Episciences_Rating_ReportManager
+ */
+final class Episciences_Rating_ReportManagerTest extends TestCase
+{
+    // =========================================================================
+    // API contract
+    // =========================================================================
+
+    public function testTableConstantIsDefined(): void
+    {
+        // T_REVIEWER_REPORTS is a compile-time constant resolved when the class loads
+        self::assertIsString(Episciences_Rating_ReportManager::TABLE);
+        self::assertNotEmpty(Episciences_Rating_ReportManager::TABLE);
+    }
+
+    public function testUpdateUidSHasTwoIntParameters(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'updateUidS');
+        $params = $method->getParameters();
+
+        self::assertCount(2, $params);
+
+        self::assertSame('oldUid', $params[0]->getName());
+        self::assertSame('int', $params[0]->getType()->getName());
+        self::assertSame(0, $params[0]->getDefaultValue());
+
+        self::assertSame('newUid', $params[1]->getName());
+        self::assertSame('int', $params[1]->getType()->getName());
+        self::assertSame(0, $params[1]->getDefaultValue());
+    }
+
+    public function testUpdateUidSReturnTypeIsInt(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'updateUidS');
+
+        self::assertSame('int', $method->getReturnType()->getName());
+    }
+
+    public function testDeleteByUidAndDocIdHasTwoIntParameters(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'deleteByUidAndDocId');
+        $params = $method->getParameters();
+
+        self::assertCount(2, $params);
+        self::assertSame('uid',   $params[0]->getName());
+        self::assertSame('docId', $params[1]->getName());
+    }
+
+    public function testRenameGridHasTwoIntParameters(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'renameGrid');
+        $params = $method->getParameters();
+
+        self::assertCount(2, $params);
+        self::assertSame('docId', $params[0]->getName());
+        self::assertSame('uid',   $params[1]->getName());
+    }
+
+    public function testRenameGridReturnTypeIsBool(): void
+    {
+        $method = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'renameGrid');
+
+        self::assertSame('bool', $method->getReturnType()->getName());
+    }
+
+    // =========================================================================
+    // Bug R1 — renameGrid() logic inversion fix
+    // =========================================================================
+
+    /**
+     * Fix R1: the original code was:
+     *   if ($result = !rename($nameDir, $newName)) { ... return $result; }
+     *   return !$result;
+     *
+     * This is an assignment inside the condition:
+     *   - rename fails  → !false = true  → enters if → returns true  (WRONG: should be false)
+     *   - rename succeeds → !true = false → skips if → returns !false = true (also returns true!)
+     *
+     * Both branches returned true. The fix uses a plain boolean expression:
+     *   if (!rename(...)) { ... return false; }
+     *   return true;
+     */
+    public function testRenameGridSourceUsesCorrectBooleanLogic(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'renameGrid');
+        $source     = $this->getMethodSource($reflection);
+
+        // Old pattern: assignment-in-condition inversion
+        self::assertStringNotContainsString(
+            '$result = !rename(',
+            $source,
+            'Fix R1: the assignment-in-condition pattern "$result = !rename()" must be removed'
+        );
+
+        // New pattern: plain negation
+        self::assertStringContainsString(
+            'if (!rename(',
+            $source,
+            'Fix R1: use "if (!rename(...))" for a clear, correct boolean branch'
+        );
+
+        // Explicit return values
+        self::assertStringContainsString(
+            'return false;',
+            $source,
+            'Fix R1: renameGrid() must explicitly return false on rename failure'
+        );
+        self::assertStringContainsString(
+            'return true;',
+            $source,
+            'Fix R1: renameGrid() must explicitly return true on success'
+        );
+    }
+
+    // =========================================================================
+    // Bug R2 — error_log message spaces
+    // =========================================================================
+
+    /**
+     * Fix R2: the original message was:
+     *   'The filename' . $nameDir . 'not exists or is not a directory'
+     * which produces "The filenamePATHnot exists..." with no spaces around the path.
+     */
+    public function testRenameGridErrorLogMessageHasSpacesAroundPath(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'renameGrid');
+        $source     = $this->getMethodSource($reflection);
+
+        self::assertStringNotContainsString(
+            "'The filename' . \$nameDir . 'not exists",
+            $source,
+            'Fix R2: error_log message must have spaces around $nameDir'
+        );
+
+        self::assertStringContainsString(
+            "'The filename '",
+            $source,
+            'Fix R2: error_log message must start with "The filename " (trailing space)'
+        );
+    }
+
+    // =========================================================================
+    // Bug R4 — fatal trigger_error replaced with error_log
+    // =========================================================================
+
+    /**
+     * Fix R4: trigger_error($msg, E_USER_ERROR) was fatal — it terminated the
+     * PHP process immediately, preventing any rollback or cleanup.
+     * Replaced with error_log() inside the catch block.
+     */
+    public function testUpdateProcessingDoesNotUseFatalTriggerError(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'updateProcessing');
+        $reflection->setAccessible(true);
+        $source = $this->getMethodSource($reflection);
+
+        self::assertStringNotContainsString(
+            'E_USER_ERROR',
+            $source,
+            'Fix R4: E_USER_ERROR is fatal — must be replaced with error_log() or a logger'
+        );
+
+        self::assertStringNotContainsString(
+            'trigger_error',
+            $source,
+            'Fix R4: trigger_error() must be removed from updateProcessing()'
+        );
+    }
+
+    // =========================================================================
+    // Bug R5 — transaction wrapping
+    // =========================================================================
+
+    /**
+     * Fix R5: the original code deleted rows then inserted new ones without a
+     * transaction. If the INSERT failed (exception), the DELETEd rows were gone
+     * forever — irreversible data loss.
+     *
+     * The fix wraps DELETE + INSERT in beginTransaction/commit, with rollBack
+     * on exception to restore the deleted rows.
+     */
+    public function testUpdateProcessingUsesTransaction(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'updateProcessing');
+        $reflection->setAccessible(true);
+        $source = $this->getMethodSource($reflection);
+
+        self::assertStringContainsString(
+            'beginTransaction()',
+            $source,
+            'Fix R5: updateProcessing() must use a DB transaction to prevent data loss'
+        );
+
+        self::assertStringContainsString(
+            'commit()',
+            $source,
+            'Fix R5: a commit() must be called after successful DELETE + INSERT'
+        );
+
+        self::assertStringContainsString(
+            'rollBack()',
+            $source,
+            'Fix R5: a rollBack() must be called in the catch block to restore deleted rows'
+        );
+    }
+
+    /**
+     * The DELETE must be inside the try block (after beginTransaction) so it
+     * is rolled back on INSERT failure.
+     */
+    public function testUpdateProcessingDeleteIsInsideTryBlock(): void
+    {
+        $reflection = new ReflectionMethod(Episciences_Rating_ReportManager::class, 'updateProcessing');
+        $reflection->setAccessible(true);
+        $source = $this->getMethodSource($reflection);
+
+        // beginTransaction must appear before delete in the source
+        $posBegin  = strpos($source, 'beginTransaction()');
+        $posDelete = strpos($source, '->delete(');
+        $posCommit = strpos($source, 'commit()');
+
+        self::assertNotFalse($posBegin,  'beginTransaction() must be present');
+        self::assertNotFalse($posDelete, '->delete() must be present');
+        self::assertNotFalse($posCommit, 'commit() must be present');
+
+        self::assertLessThan($posDelete, $posBegin,  'beginTransaction() must come before delete()');
+        self::assertLessThan($posCommit, $posDelete, 'delete() must come before commit()');
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function getMethodSource(ReflectionMethod $method): string
+    {
+        $lines = file($method->getFileName());
+
+        return implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+    }
+}

--- a/tests/unit/library/Episciences/Rating/Episciences_Rating_ReportTest.php
+++ b/tests/unit/library/Episciences/Rating/Episciences_Rating_ReportTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace unit\library\Episciences\Rating;
+
+use Episciences_Rating_Criterion;
+use Episciences_Rating_Report;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_Rating_Report.
+ *
+ * All tests are DB-free. Report::__construct() with no args is safe:
+ * generatePath() returns false when docid+uid are unset, so no filesystem access.
+ *
+ * Bugs documented/fixed:
+ *   Rp1 — DB column 'ID' maps to setId() (Grid's field), not setRid(); _rid never
+ *          populated from a DB row. Documented only — changing would risk breaking
+ *          callers that rely on the current ON DUPLICATE KEY UPDATE behaviour.
+ *   Rp2 — calculateScore(): if ($score != 0 && $coefs != 0) treats an all-zero
+ *          rating as null instead of 0. Fixed: check only $coefs != 0.
+ *
+ * @covers Episciences_Rating_Report
+ */
+final class Episciences_Rating_ReportTest extends TestCase
+{
+    // =========================================================================
+    // calculateScore() — pure logic (no DB, no filesystem)
+    // =========================================================================
+
+    public function testCalculateScoreReturnsFalseWhenNoCriteria(): void
+    {
+        $report = new Episciences_Rating_Report();
+        // _criteria is null → is_array(null) = false → returns false
+
+        self::assertFalse($report->calculateScore());
+    }
+
+    public function testCalculateScoreReturnsNullWhenAllCriteriaHaveNoCoefficient(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 3, maxNote: 5, coefficient: null),
+        ]);
+
+        $report->calculateScore();
+
+        // $coefs = 0 (coefficient is null → += null = 0) → returns null
+        self::assertNull($report->getScore());
+    }
+
+    /**
+     * Fix Rp2: a reviewer who rated everything at 0 (the minimum) must get
+     * a computed score of 0, not null.
+     *
+     * Before the fix: if ($score != 0 && $coefs != 0) → score=0 fails the
+     * first condition → null was returned even when coefficients exist.
+     */
+    public function testCalculateScoreReturnsZeroWhenAllNotesAreZero(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 0, maxNote: 4, coefficient: 1),
+            $this->makeCriterion(note: 0, maxNote: 4, coefficient: 2),
+        ]);
+
+        $report->calculateScore(0);
+
+        // score = (0/4*1 + 0/4*2) / 3 * 10 = 0 — not null
+        self::assertSame(0.0, $report->getScore(), 'Fix Rp2: all-zero rating must produce score 0, not null');
+    }
+
+    public function testCalculateScoreWithSingleCriterion(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 3, maxNote: 4, coefficient: 1),
+        ]);
+
+        $report->calculateScore(1);
+
+        // (3/4 * 1) / 1 * 10 = 7.5
+        self::assertSame(7.5, $report->getScore());
+    }
+
+    public function testCalculateScoreWithMultipleCriteria(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 4, maxNote: 4, coefficient: 2),  // 1.0 weighted
+            $this->makeCriterion(note: 2, maxNote: 4, coefficient: 1),  // 0.5 weighted
+        ]);
+
+        $report->calculateScore(1);
+
+        // score = (4/4*2 + 2/4*1) / 3 * 10 = (2 + 0.5) / 3 * 10 = 8.333...
+        self::assertSame(8.3, $report->getScore());
+    }
+
+    public function testCalculateScoreIgnoresCriteriaWithNoCoefficient(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 4, maxNote: 4, coefficient: 2),
+            $this->makeCriterion(note: 0, maxNote: 4, coefficient: null), // no coefficient: ignored
+        ]);
+
+        $report->calculateScore(0);
+
+        // Only first criterion counts: (4/4*2) / 2 * 10 = 10
+        self::assertSame(10.0, $report->getScore());
+    }
+
+    public function testCalculateScoreWithMaxScoreOverride(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setMax_score(5);
+        $report->setCriteria([
+            $this->makeCriterion(note: 2, maxNote: 4, coefficient: 1),
+        ]);
+
+        $report->calculateScore(1);
+
+        // (2/4 * 1) / 1 * 5 = 2.5
+        self::assertSame(2.5, $report->getScore());
+    }
+
+    public function testCalculateScorePrecisionParameter(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 1, maxNote: 3, coefficient: 1),
+        ]);
+
+        $report->calculateScore(2);
+
+        // (1/3 * 1) / 1 * 10 = 3.333... rounded to 2 decimals = 3.33
+        self::assertSame(3.33, $report->getScore());
+    }
+
+    public function testGetScoreLazilyCallsCalculateScore(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 4, maxNote: 4, coefficient: 1),
+        ]);
+
+        // _score not set yet — getScore() must trigger calculateScore()
+        $score = $report->getScore();
+
+        self::assertNotNull($score);
+        self::assertSame(10.0, $score);
+    }
+
+    public function testSetScoreOverridesCalculation(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([
+            $this->makeCriterion(note: 0, maxNote: 4, coefficient: 1),
+        ]);
+        $report->setScore(7.5);
+
+        // _score is already set → calculateScore() not called
+        self::assertSame(7.5, $report->getScore());
+    }
+
+    // =========================================================================
+    // populate() / getAttachments()
+    // =========================================================================
+
+    public function testGetAttachmentsReturnsEmptyArrayWhenNoCriteria(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([]);
+
+        self::assertSame([], $report->getAttachments());
+    }
+
+    public function testGetAttachmentsReturnsOnlyCriteriaWithAttachments(): void
+    {
+        $withAttachment    = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]);
+        $withAttachment->setId('item_1');
+        $withAttachment->setAttachment_setting(true);
+        $withAttachment->setAttachment('review.pdf');
+
+        $withoutAttachment = new Episciences_Rating_Criterion(['type' => Episciences_Rating_Criterion::TYPE_CRITERION]);
+        $withoutAttachment->setId('item_2');
+        $withoutAttachment->setAttachment_setting(true);
+        // no attachment file set
+
+        $report = new Episciences_Rating_Report();
+        $report->setCriteria([$withAttachment, $withoutAttachment]);
+
+        $attachments = $report->getAttachments();
+
+        self::assertCount(1, $attachments);
+        self::assertArrayHasKey('file_item_1', $attachments);
+        self::assertSame('review.pdf', $attachments['file_item_1']);
+    }
+
+    // =========================================================================
+    // exists()
+    // =========================================================================
+
+    public function testExistsReturnsFalseWhenNoPathSet(): void
+    {
+        $report = new Episciences_Rating_Report();
+        // _path is null → getPath() returns null → file_exists('report.xml') = false
+
+        self::assertFalse($report->exists());
+    }
+
+    // =========================================================================
+    // Bug Rp1 — DB column 'ID' maps to setId() (Grid's field), not setRid()
+    // =========================================================================
+
+    /**
+     * Design issue Rp1 (documented, not fixed): Episciences_Rating_Report extends
+     * Episciences_Rating_Grid. The constructor's magic `set{Ucfirst(Key)}` dispatch
+     * maps the DB column 'ID' to Grid::setId(), not Report::setRid().
+     *
+     * As a result, getRid() always returns null when a Report is constructed from
+     * a DB row. The save() method still works because ON DUPLICATE KEY UPDATE fires
+     * on the (UID, DOCID) unique constraint, not on the primary key.
+     *
+     * This test documents the current (unexpected) behaviour without fixing it,
+     * to guard against accidental changes that might break callers relying on it.
+     */
+    public function testRidIsNullWhenConstructedWithIdKey(): void
+    {
+        // Simulating what happens when the DB row ['ID' => 7, 'UID' => 5, 'DOCID' => 3]
+        // is passed to the constructor. No filesystem access occurs because uid+docid
+        // result in a path that doesn't exist.
+        $report = new Episciences_Rating_Report(['id' => 7, 'uid' => 5, 'docid' => 3]);
+
+        self::assertNull(
+            $report->getRid(),
+            'Design issue Rp1: DB column ID maps to Grid::setId(), not Report::setRid() — _rid stays null'
+        );
+
+        // The grid _id IS set (to the DB row ID) — confirming the mapping
+        self::assertSame(7, $report->getId());
+    }
+
+    /**
+     * setRid() works correctly when called explicitly (e.g. from other code).
+     */
+    public function testSetRidAndGetRid(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setRid(42);
+
+        self::assertSame(42, $report->getRid());
+    }
+
+    public function testSetRidWithNullResetsRid(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setRid(10);
+        $report->setRid(null);
+
+        self::assertNull($report->getRid());
+    }
+
+    // =========================================================================
+    // getMax_score / setMax_score
+    // =========================================================================
+
+    public function testDefaultMaxScoreIsTen(): void
+    {
+        $report = new Episciences_Rating_Report();
+
+        self::assertSame(10, $report->getMax_score());
+    }
+
+    public function testSetMaxScoreOverridesDefault(): void
+    {
+        $report = new Episciences_Rating_Report();
+        $report->setMax_score(5);
+
+        self::assertSame(5, $report->getMax_score());
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private function makeCriterion(int $note, int $maxNote, int|float|null $coefficient): Episciences_Rating_Criterion
+    {
+        $options = [];
+        for ($i = 0; $i <= $maxNote; $i++) {
+            $options[$i] = ['value' => $i, 'label' => null];
+        }
+
+        $c = new Episciences_Rating_Criterion();
+        $c->setType(Episciences_Rating_Criterion::TYPE_CRITERION);
+        $c->setOptions($options);
+        $c->setNote($note);
+        $c->setCoefficient($coefficient);
+
+        return $c;
+    }
+}


### PR DESCRIPTION
## Summary

Bug-fix audit of `library/Episciences/Rating/` and `library/Episciences/Reviewer*` — **15 bugs fixed**, 6 new PHPUnit test files added (1837 tests, 0 failures).

### Rating/Manager.php
- **B1** `getList()`: `order('CREATION_DATE', 'DESC')` — Zend_Db silently drops the second arg; fixed to `order('CREATION_DATE DESC')`
- **B2** `getRatingForm()` separator label: XSS — grid label injected raw into HTML; fixed with `htmlspecialchars()`
- **B3** `getRatingForm()` delete block: malformed `<div class=col-sm-2'>` (missing opening quote); fixed to `<div class='col-sm-2'>`
- **B4** `getAverageRating()`: `if ($rating->getStatus())` — `STATUS_PENDING = 0` is falsy, excluding pending ratings; fixed to strict `!== STATUS_PENDING`
- **B6** `find()`: exact duplicate of `Report::find()`; now delegates to `Report::find()`
- **B7** `getRatingForm()`: `$file_delete_url`, `$filepath`, `$attachment` unescaped in HTML output — XSS; fixed with `htmlspecialchars()`

### Rating/Criterion.php
- **B5** `getMaxNote()`: `max([])` throws `ValueError` on empty options; added empty guard

### Rating/Grid.php
- **G1** `loadXML()`: dead call `getElementsByTagName('text')` removed
- **G2** `loadXML()`: `->item(0)->getElementsByTagName(...)` chained without null check — `TypeError` when no `<head>`; added null guard
- **G3** `loadXML()`: `$node->firstChild->getAttribute('value')` without null check — `TypeError` when `<f>` has no children; added null guard
- **G4** `getCriterion()`: `array_key_exists($id, null)` throws `TypeError` in PHP 8.1+; added `is_array()` guard

### Rating/Report.php
- **Rp2** `calculateScore()`: `if ($score != 0 && $coefs != 0)` — all-zero rating (deliberate minimum score) returned `null` instead of `0`; fixed to `if ($coefs != 0)`

### Rating/ReportManager.php
- **R1** `renameGrid()`: logic inversion `if ($result = !rename(...))` — always returned `true`; fixed to `if (!rename(...)) { return false; } return true`
- **R2** `renameGrid()`: error_log message missing spaces around `$nameDir` — unreadable concatenated path
- **R4** `updateProcessing()`: `trigger_error($e->getMessage(), E_USER_ERROR)` is fatal — replaced with `error_log()` in catch block
- **R5** `updateProcessing()`: DELETE then INSERT without a transaction — data loss if INSERT fails; wrapped in `beginTransaction` / `commit` / `rollBack`

### Reviewer.php
- **Rv1** `getAssignment($docId)`: direct array access `$this->_assignments[$docId]` — undefined index notice; fixed with `?? null`
- **Rv2** `loadReviewingById()`: overwrote `$this->_reviewings` with a fresh one-element array, destroying all previously loaded reviewings; fixed to merge via `getReviewings()` / `setReviewings()`
- **Rv3** `getComments(int $docId)`: cache stored flat in `$this->_comments` — second call for a different `$docId` returned stale data; fixed to key by `$this->_comments[$docId]`
- **Rv4** `getAssignedPapers()` / `loadAssignedPapers()`: `$isLimit` missing `bool` type hint (the other three parameters were typed); added `bool $isLimit = true`
- **Rv5** `unassign()`: `Ccsd_Tools::ifsetor($params['rvid'], RVID)` — legacy helper, inconsistent with `assign()`; replaced with `$params['rvid'] ?? RVID`

### ReviewersManager.php
- **RM2** `addReviewerToPool()`: no exception handling — DB errors propagated silently; return type `: bool` was always `true`; wrapped in try/catch
- **RM3** `getSuggestedReviewers()` / `getUnwantedReviewers()`: raw string literals in `where()` bypass Zend_Db quoting; changed to parameterized `where('SETTING = ?', 'value')`

## Test plan

- [x] `make test-php` — 1837 tests, 0 failures, 6 pre-existing skips
- [x] New test files covering all fixed bugs via behavioral tests and source-inspection assertions:
  - `tests/unit/library/Episciences/Rating/Episciences_Rating_ManagerTest.php`
  - `tests/unit/library/Episciences/Rating/Episciences_Rating_GridTest.php`
  - `tests/unit/library/Episciences/Rating/Episciences_Rating_ReportTest.php`
  - `tests/unit/library/Episciences/Rating/Episciences_Rating_ReportManagerTest.php`
  - `tests/unit/library/Episciences/Episciences_ReviewerTest.php`
  - `tests/unit/library/Episciences/Episciences_ReviewersManagerTest.php`