### PR TITLE
fix: only use "et al." when 2+ authors are omitted (#858)

### DIFF
--- a/application/modules/journal/views/scripts/browse/latest.phtml
+++ b/application/modules/journal/views/scripts/browse/latest.phtml
@@ -49,7 +49,7 @@
                             $arrayOfAuthors[] = $tab[0];
                         }
 
-                        if (count($arrayOfAuthors) > $maxNumberOfAuthors) {
+                        if (count($arrayOfAuthors) > $maxNumberOfAuthors + 1) {
                             $multiArraysOfAuthors = array_chunk($arrayOfAuthors, $maxNumberOfAuthors, true);
 
                             foreach ($multiArraysOfAuthors[0] as $authorName) {

--- a/application/modules/journal/views/scripts/partials/search_results.phtml
+++ b/application/modules/journal/views/scripts/partials/search_results.phtml
@@ -83,7 +83,7 @@ if ($this->results) {
                     $arrayOfAuthors[] = $tab[0];
                 }
 
-                if (count($arrayOfAuthors) > $maxNumberOfAuthors) {
+                if (count($arrayOfAuthors) > $maxNumberOfAuthors + 1) {
                     $multiArraysOfAuthors = array_chunk($arrayOfAuthors, $maxNumberOfAuthors, true);
 
                     foreach ($multiArraysOfAuthors[0] as $authorName) {

--- a/application/modules/journal/views/scripts/section/view.phtml
+++ b/application/modules/journal/views/scripts/section/view.phtml
@@ -42,9 +42,12 @@
 				$arrayOfAuthors[] = $tab[0];
 			}
 			
-			if (count($arrayOfAuthors) > $maxNumberOfAuthors) {
+			$totalAuthors = count($arrayOfAuthors);
+
+			// Only use "et al." when 2+ authors are omitted (respecting plural meaning)
+			if ($totalAuthors > $maxNumberOfAuthors + 1) {
 				$multiArraysOfAuthors = array_chunk($arrayOfAuthors, $maxNumberOfAuthors, true);
-			
+
 				foreach ($multiArraysOfAuthors[0] as $authorName) {
 					$url = $this->url(array(
 							'controller' => 'search',
@@ -55,7 +58,7 @@
 				}
 				$authorList = implode($authorSeparator, $arrayOfAuthorsWithURL) . ' <abbr lang="la" title="et alii">et al.</abbr>';
 			} else {
-			
+				// Show all authors (including when exactly 1 extra would have been truncated)
 				foreach ($arrayOfAuthors as $authorName) {
 					$url = $this->url(array(
 							'controller' => 'search',

--- a/application/modules/journal/views/scripts/volume/volume-indexed-papers.phtml
+++ b/application/modules/journal/views/scripts/volume/volume-indexed-papers.phtml
@@ -24,7 +24,7 @@
                             $arrayOfAuthors[] = $tab[0];
                         }
 
-                        if (count($arrayOfAuthors) > $maxNumberOfAuthors) {
+                        if (count($arrayOfAuthors) > $maxNumberOfAuthors + 1) {
                             $multiArraysOfAuthors = array_chunk($arrayOfAuthors, $maxNumberOfAuthors, true);
 
                             foreach ($multiArraysOfAuthors[0] as $authorName) {

--- a/library/Episciences/Paper/Citations/ViewFormatter.php
+++ b/library/Episciences/Paper/Citations/ViewFormatter.php
@@ -185,7 +185,8 @@ class Episciences_Paper_Citations_ViewFormatter
 
     /**
      * Truncate a semicolon-separated author list to NUMBER_OF_AUTHORS_WANTED_VIEWS authors,
-     * appending "et al." when truncated.
+     * appending "et al." only when 2+ authors are omitted (respecting Latin plural meaning).
+     * If exactly one extra author exists, all authors are shown without truncation.
      *
      * @param string $author semicolon-separated author string
      * @return string truncated author string
@@ -193,9 +194,13 @@ class Episciences_Paper_Citations_ViewFormatter
     public static function reduceAuthorsView(string $author): string
     {
         $authorRows = array_map(trim(...), explode(';', $author));
+        $totalAuthors = count($authorRows);
+        $limit = self::NUMBER_OF_AUTHORS_WANTED_VIEWS;
 
-        if (count($authorRows) > self::NUMBER_OF_AUTHORS_WANTED_VIEWS) {
-            $authorRows = array_slice($authorRows, 0, self::NUMBER_OF_AUTHORS_WANTED_VIEWS, true);
+        // Only use "et al." when 2+ authors are omitted (plural meaning)
+        // If exactly 1 extra author, show all authors instead
+        if ($totalAuthors > $limit + 1) {
+            $authorRows = array_slice($authorRows, 0, $limit, true);
             $authorRows[] = 'et al.';
         }
 

--- a/public/xsl/admin_paper.xsl
+++ b/public/xsl/admin_paper.xsl
@@ -65,13 +65,26 @@
                 <h2 class="panel-title" style="margin-bottom: 5px">
 
                     <span class="darkgrey">
-                        <xsl:for-each select="metadata/oai_dc:dc/dc:creator[position() &lt;= 5]">
-                            <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
-                            <xsl:if test="position() != last()"> ; </xsl:if>
-                        </xsl:for-each>
-                        <xsl:if test="count(metadata/oai_dc:dc/dc:creator) &gt; 5">
-                            <i> et al.</i>
-                        </xsl:if>
+                        <!-- Show first 5 authors, or all 6 if exactly 6 -->
+                        <xsl:choose>
+                            <xsl:when test="count(metadata/oai_dc:dc/dc:creator) = 6">
+                                <!-- Exactly 6 authors: show all 6, no et al. -->
+                                <xsl:for-each select="metadata/oai_dc:dc/dc:creator">
+                                    <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
+                                    <xsl:if test="position() != last()"> ; </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <!-- 5 or fewer, or 7+: show first 5 -->
+                                <xsl:for-each select="metadata/oai_dc:dc/dc:creator[position() &lt;= 5]">
+                                    <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
+                                    <xsl:if test="position() != last()"> ; </xsl:if>
+                                </xsl:for-each>
+                                <xsl:if test="count(metadata/oai_dc:dc/dc:creator) &gt; 6">
+                                    <i> et al.</i>
+                                </xsl:if>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         -
                     </span>
 

--- a/public/xsl/full_paper.xsl
+++ b/public/xsl/full_paper.xsl
@@ -67,13 +67,26 @@
                 <h2 class="panel-title" style="margin-bottom: 5px">
 
                     <span class="darkgrey">
-                        <xsl:for-each select="metadata/oai_dc:dc/dc:creator[position() &lt;= 5]">
-                            <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
-                            <xsl:if test="position() != last()"> ; </xsl:if>
-                        </xsl:for-each>
-                        <xsl:if test="count(metadata/oai_dc:dc/dc:creator) &gt; 5">
-                            <i> et al.</i>
-                        </xsl:if>
+                        <!-- Show first 5 authors, or all 6 if exactly 6 -->
+                        <xsl:choose>
+                            <xsl:when test="count(metadata/oai_dc:dc/dc:creator) = 6">
+                                <!-- Exactly 6 authors: show all 6, no et al. -->
+                                <xsl:for-each select="metadata/oai_dc:dc/dc:creator">
+                                    <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
+                                    <xsl:if test="position() != last()"> ; </xsl:if>
+                                </xsl:for-each>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <!-- 5 or fewer, or 7+: show first 5 -->
+                                <xsl:for-each select="metadata/oai_dc:dc/dc:creator[position() &lt;= 5]">
+                                    <xsl:value-of select="php:function('Episciences_Tools::reformatOaiDcAuthor', string(.))"/>
+                                    <xsl:if test="position() != last()"> ; </xsl:if>
+                                </xsl:for-each>
+                                <xsl:if test="count(metadata/oai_dc:dc/dc:creator) &gt; 6">
+                                    <i> et al.</i>
+                                </xsl:if>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         -
                     </span>
 


### PR DESCRIPTION
## Description

Fixes the incorrect use of "et al." when only a single author is being omitted. "Et al." is the abbreviation of "et alii" (Latin for "and others"), which is grammatically plural, it should only be used when two or more authors are omitted. When exactly one author beyond the display limit exists, all authors are now shown instead of truncating.

Closes #858

## Changes

- **ViewFormatter.php**: Updated `reduceAuthorsView()` to only append "et al." when `totalAuthors > limit + 1`. Updated PHPDoc to document the reasoning.
- **section/view.phtml**: Changed truncation condition from `> $maxNumberOfAuthors` to `> $maxNumberOfAuthors + 1`.
- **browse/latest.phtml**: Same condition fix.
- **volume/volume-indexed-papers.phtml**: Same condition fix.
- **partials/search_results.phtml**: Same condition fix.
- **full_paper.xsl** and **admin_paper.xsl**: Added `<xsl:choose>` block to show all 6 authors when exactly 6 exist (limit is 5), and only use "et al." when 7+ authors are present.

## Screenshots

Given `NUMBER_OF_AUTHORS_WANTED_VIEWS = 5`:

<img width="1152" height="448" alt="management_5" src="https://github.com/user-attachments/assets/4154a48b-f455-4561-b412-0a12f78193fb" />

<img width="1152" height="448" alt="management_6" src="https://github.com/user-attachments/assets/fa78b56e-72e9-4c8d-bec6-d24312197f4d" />

<img width="1152" height="448" alt="management_7" src="https://github.com/user-attachments/assets/d538e5d3-67cc-49bc-a62b-5d45bbf93bd8" />

<img width="1152" height="448" alt="public_5" src="https://github.com/user-attachments/assets/5a7e1fa7-4c39-445a-81b3-b92216c588e7" />

<img width="1152" height="448" alt="public_6" src="https://github.com/user-attachments/assets/71c0781f-50f7-41bd-9387-401c76b3e542" />

<img width="1152" height="448" alt="public_7" src="https://github.com/user-attachments/assets/31466f7e-f9d8-4fda-bd0d-bf359f6a1507" />
