### PR TITLE
refactor(settings): rename author-editor communication constant and u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [#679](https://github.com/CCSDForge/episciences/issues/679) "Ask other editors for their opinion" form now includes chief editors (ROLE_CHIEF_EDITOR) in addition to regular editors (ROLE_EDITOR).
 * [#691](http://github.com/CCSDForge/episciences/issues/691) Display "(optional)" label below comment and cover letter fields in submission forms to clarify these fields are not required.
 * [#350](https://github.com/CCSDForge/episciences/issues/350) Author-Editor Communication Settings:
-  - New option to allow authors to contact assigned editors (`authorsCanContactEditors`)
+  - New option to allow authors to contact assigned editors (`authorEditorCommunication`)
   - New option to disclose editor names to authors or keep them anonymized (`discloseEditorNamesToAuthors`)
 * feat(navigation): sync predefined page titles with T_PAGES table on menu save.
 * New `library/Episciences/Api/` namespace with 5 injectable, independently-testable API clients: `AbstractApiClient`, `CrossrefApiClient`, `OpenAlexApiClient`, `OpenCitationsApiClient`, `OpenAireApiClient`.

--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -307,6 +307,8 @@ return array(
     "Les rédacteurs peuvent réattribuer la gestion de l'article" => "Editors can reassign handled articles to another editor",
     "Permettre aux auteurs de contacter les rédacteurs responsables" => "Allow authors to contact assigned editors",
     "Si activé, les auteurs peuvent envoyer des messages directement aux rédacteurs assignés à leur article" => "If enabled, authors can send messages directly to the editors assigned to their article",
+    "Permettre la communication entre auteurs et rédacteurs" => "Allow communication between authors and editors",
+    "Si activé, les auteurs et les rédacteurs assignés peuvent s'envoyer des messages directement" => "If enabled, authors and assigned editors can send messages directly to each other",
     "Afficher les noms des rédacteurs aux auteurs" => "Display editor names to authors",
     "Si activé, les auteurs peuvent voir les noms des rédacteurs assignés à leur article" => "If enabled, authors can see the names of the editors assigned to their article",
     "Le lieu de publication est renseigné, veuillez saisir l'éditeur également" => "The publication location is provided, please also enter the publisher",

--- a/application/modules/journal/controllers/ReviewController.php
+++ b/application/modules/journal/controllers/ReviewController.php
@@ -54,7 +54,7 @@ class ReviewController extends Zend_Controller_Action
                     Episciences_Review::SETTING_EDITORS_CAN_EDIT_TEMPLATES,
                     Episciences_Review::SETTING_EDITORS_CAN_ABANDON_CONTINUE_PUBLICATION_PROCESS,
                     Episciences_Review::SETTING_EDITORS_CAN_REASSIGN_ARTICLES,
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS,
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION,
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS,
                     Episciences_Review::SETTING_DO_NOT_ALLOW_EDITOR_IN_CHIEF_SELECTION,
                     Episciences_Review::SETTING_CAN_CHOOSE_VOLUME,

--- a/application/modules/journal/views/scripts/partials/author_editor_communication.phtml
+++ b/application/modules/journal/views/scripts/partials/author_editor_communication.phtml
@@ -14,7 +14,7 @@
 // Check if the author-to-editor communication is enabled
 // $review is passed from the controller to avoid redundant DB query
 $review = $this->review;
-$canAuthorContactEditors = $review->getSetting(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS);
+$canAuthorContactEditors = $review->getSetting(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION);
 $discloseEditorNames = $review->getSetting(Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS);
 
 // Determine if the user can see this panel

--- a/library/Episciences/Paper/AuthorEditorCommunicationService.php
+++ b/library/Episciences/Paper/AuthorEditorCommunicationService.php
@@ -49,7 +49,7 @@ class Episciences_Paper_AuthorEditorCommunicationService
      */
     public function canAuthorContactEditors(): bool
     {
-        return (bool)$this->review->getSetting(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS);
+        return (bool)$this->review->getSetting(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION);
     }
 
     /**

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -63,7 +63,7 @@ class Episciences_Review
     public const SETTING_ALLOW_EDIT_VOLUME_TITLE_WITH_PUBLISHED_ARTICLES = 'allowEditVolumeTitleWithPublishedArticles';
     public const SETTING_ENCAPSULATE_REVIEWERS = 'encapsulateReviewers';
     public const SETTING_EDITORS_CAN_REASSIGN_ARTICLES = 'editorsCanReassignArticle';
-    public const SETTING_AUTHORS_CAN_CONTACT_EDITORS = 'authorsCanContactEditors';
+    public const SETTING_AUTHOR_EDITOR_COMMUNICATION = 'authorEditorCommunication';
     public const SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS = 'discloseEditorNamesToAuthors';
     //Assignation automatique de rédacteurs
     public const SETTING_SYSTEM_AUTO_EDITORS_ASSIGNMENT = 'systemAutoEditorsAssignment';
@@ -210,7 +210,7 @@ class Episciences_Review
             self::SETTING_SPECIAL_ISSUE_ACCESS_CODE,
             self::SETTING_ENCAPSULATE_REVIEWERS,
             self::SETTING_EDITORS_CAN_REASSIGN_ARTICLES,
-            self::SETTING_AUTHORS_CAN_CONTACT_EDITORS,
+            self::SETTING_AUTHOR_EDITOR_COMMUNICATION,
             self::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS,
             self::SETTING_SYSTEM_AUTO_EDITORS_ASSIGNMENT,
             self::SETTING_AUTOMATICALLY_REASSIGN_SAME_REVIEWERS_WHEN_NEW_VERSION,
@@ -1082,7 +1082,7 @@ class Episciences_Review
             self::SETTING_EDITORS_CAN_EDIT_TEMPLATES,
             self::SETTING_SYSTEM_AUTO_EDITORS_ASSIGNMENT,
             self::SETTING_EDITORS_CAN_ABANDON_CONTINUE_PUBLICATION_PROCESS,
-            self::SETTING_AUTHORS_CAN_CONTACT_EDITORS,
+            self::SETTING_AUTHOR_EDITOR_COMMUNICATION,
             self::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS,
         ], 'editors', ["legend" => "Paramètres des rédacteurs"]);
         $form->getDisplayGroup('editors')->removeDecorator('DtDdWrapper');
@@ -1467,11 +1467,17 @@ class Episciences_Review
                 'decorators' => $checkboxDecorators]
         );
 
-        $form->addElement('checkbox', self::SETTING_AUTHORS_CAN_CONTACT_EDITORS, [
-                'label' => "Permettre aux auteurs de contacter les rédacteurs responsables",
-                'description' => "Si activé, les auteurs peuvent envoyer des messages directement aux rédacteurs assignés à leur article",
+        $form->addElement('checkbox', self::SETTING_AUTHOR_EDITOR_COMMUNICATION, [
+                'label' => "Permettre la communication entre auteurs et rédacteurs",
+                'description' => "Si activé, les auteurs et les rédacteurs assignés peuvent s'envoyer des messages directement",
                 'options' => ['uncheckedValue' => 0, 'checkedValue' => 1],
-                'decorators' => $checkboxDecorators]
+                'decorators' => [
+                    'ViewHelper',
+                    'Description',
+                    ['Label', ['placement' => 'APPEND']],
+                    ['HtmlTag', ['tag' => 'div', 'class' => 'col-md-9 col-md-offset-3', 'id' => 'authorEditorCommunication-wrapper']],
+                    ['Errors', ['placement' => 'APPEND']]
+                ]]
         );
 
         $form->addElement('checkbox', self::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS, [
@@ -1852,7 +1858,7 @@ class Episciences_Review
             self::SETTING_REFUSED_ARTICLE_AUTHORS_MESSAGE_AUTOMATICALLY_SENT_TO_REVIEWERS,
             self::SETTING_TO_REQUIRE_REVISION_DEADLINE, self::SETTING_START_STATS_AFTER_DATE,
             self::SETTING_ALLOW_EDIT_VOLUME_TITLE_WITH_PUBLISHED_ARTICLES, self::SETTING_DISPLAY_EMPTY_VOLUMES,
-            self::SETTING_AUTHORS_CAN_CONTACT_EDITORS, self::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS
+            self::SETTING_AUTHOR_EDITOR_COMMUNICATION, self::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS
         ];
 
         foreach ($settings as $setting) {

--- a/sass/layout/_forms.scss
+++ b/sass/layout/_forms.scss
@@ -384,3 +384,7 @@ button.btn.btn-primary:disabled {
   cursor: not-allowed;
   color: black;
 }
+
+#authorEditorCommunication-wrapper {
+  margin-top: 15px;
+}

--- a/scripts/SQL_History/2025-12-09_Insert_author_editor_communication_settings.sql
+++ b/scripts/SQL_History/2025-12-09_Insert_author_editor_communication_settings.sql
@@ -1,18 +1,35 @@
 -- SQL script to add author-editor communication settings
 -- Date: 2025-12-09
 -- Description: Adds two new settings to journal configuration:
---   1. authorsCanContactEditors: Allow authors to contact editors
+--   1. authorEditorCommunication: Allow authors to contact editors
 --   2. discloseEditorNamesToAuthors: Disclose editor names to authors
 
 -- Note: These settings are disabled by default (value 0)
 -- They can be enabled individually for each journal via the administration interface
 
+-- before update
 INSERT INTO REVIEW_SETTING (RVID, SETTING, VALUE)
    SELECT RVID, 'authorsCanContactEditors', '0'
    FROM REVIEW
    WHERE RVID NOT IN (
        SELECT RVID FROM REVIEW_SETTING WHERE SETTING = 'authorsCanContactEditors'
    );
+
+-- update
+-- Rename setting 'authorsCanContactEditors' to 'authorEditorCommunication'
+-- This reflects the bidirectional nature of the feature (authors <-> editors)
+
+UPDATE REVIEW_SETTING
+SET SETTING = 'authorEditorCommunication'
+WHERE SETTING = 'authorsCanContactEditors';
+
+--after update
+INSERT INTO REVIEW_SETTING (RVID, SETTING, VALUE)
+SELECT RVID, 'authorEditorCommunication', '0'
+FROM REVIEW
+WHERE RVID NOT IN (
+    SELECT RVID FROM REVIEW_SETTING WHERE SETTING = 'authorEditorCommunication'
+);
 
 INSERT INTO REVIEW_SETTING (RVID, SETTING, VALUE)
    SELECT RVID, 'discloseEditorNamesToAuthors', '0'

--- a/scripts/SQL_History/2025-12-15_Insert_author_editor_communication_template.sql
+++ b/scripts/SQL_History/2025-12-15_Insert_author_editor_communication_template.sql
@@ -7,7 +7,7 @@
 --   3. paper_comment_from_author_to_editor_coauthor_copy: Email template sent to co-authors when a co-author sends a message to assigned editors
 
 -- Note: These templates are global (NULL RVID) and apply to all journals
--- They are used in conjunction with the authorsCanContactEditors setting
+-- They are used in conjunction with the authorEditorCommunication setting
 
 -- Update existing template key if it was inserted with old name
 UPDATE MAIL_TEMPLATE

--- a/tests/unit/library/Episciences/Paper/Episciences_Paper_AuthorEditorCommunicationServiceTest.php
+++ b/tests/unit/library/Episciences/Paper/Episciences_Paper_AuthorEditorCommunicationServiceTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  * - Episciences_Review: The journal containing settings
  *
  * Related settings in REVIEW_SETTINGS table:
- * - SETTING_AUTHORS_CAN_CONTACT_EDITORS: Enable/disable author-editor messaging
+ * - SETTING_AUTHOR_EDITOR_COMMUNICATION: Enable/disable author-editor messaging
  * - SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS: Show/hide editor names to authors
  *
  * @covers Episciences_Paper_AuthorEditorCommunicationService
@@ -74,7 +74,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
     /**
      * Test that canAuthorContactEditors() returns true when the setting is enabled.
      *
-     * When SETTING_AUTHORS_CAN_CONTACT_EDITORS = '1' (or truthy value),
+     * When SETTING_AUTHOR_EDITOR_COMMUNICATION = '1' (or truthy value),
      * authors should be able to send messages to assigned editors.
      *
      * This setting is configured per journal in the review settings panel.
@@ -85,7 +85,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review = $this->createMock(Episciences_Review::class);
 
         $review->method('getSetting')
-            ->with(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS)
+            ->with(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION)
             ->willReturn('1');
 
         $service = new Episciences_Paper_AuthorEditorCommunicationService($paper, $review);
@@ -96,7 +96,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
     /**
      * Test that canAuthorContactEditors() returns false when the setting is disabled.
      *
-     * When SETTING_AUTHORS_CAN_CONTACT_EDITORS = '0', the author-editor
+     * When SETTING_AUTHOR_EDITOR_COMMUNICATION = '0', the author-editor
      * communication panel should not be displayed and message submission
      * should be blocked.
      */
@@ -106,7 +106,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review = $this->createMock(Episciences_Review::class);
 
         $review->method('getSetting')
-            ->with(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS)
+            ->with(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION)
             ->willReturn('0');
 
         $service = new Episciences_Paper_AuthorEditorCommunicationService($paper, $review);
@@ -126,7 +126,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review = $this->createMock(Episciences_Review::class);
 
         $review->method('getSetting')
-            ->with(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS)
+            ->with(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION)
             ->willReturn(null);
 
         $service = new Episciences_Paper_AuthorEditorCommunicationService($paper, $review);
@@ -204,7 +204,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review->method('getSetting')
             ->willReturnCallback(function ($setting) {
                 return match ($setting) {
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS => '0',
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION => '0',
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS => '0',
                     default => null
                 };
@@ -238,7 +238,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review->method('getSetting')
             ->willReturnCallback(function ($setting) {
                 return match ($setting) {
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS => '1',
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION => '1',
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS => '0',
                     default => null
                 };
@@ -270,7 +270,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review->method('getSetting')
             ->willReturnCallback(function ($setting) {
                 return match ($setting) {
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS => '0',
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION => '0',
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS => '1',
                     default => null
                 };
@@ -304,7 +304,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review->method('getSetting')
             ->willReturnCallback(function ($setting) {
                 return match ($setting) {
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS => '1',
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION => '1',
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS => '1',
                     default => null
                 };
@@ -421,7 +421,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review = $this->createMock(Episciences_Review::class);
 
         $review->method('getSetting')
-            ->with(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS)
+            ->with(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION)
             ->willReturn('');
 
         $service = new Episciences_Paper_AuthorEditorCommunicationService($paper, $review);
@@ -441,7 +441,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review = $this->createMock(Episciences_Review::class);
 
         $review->method('getSetting')
-            ->with(Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS)
+            ->with(Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION)
             ->willReturn('2');
 
         $service = new Episciences_Paper_AuthorEditorCommunicationService($paper, $review);
@@ -548,7 +548,7 @@ class Episciences_Paper_AuthorEditorCommunicationServiceTest extends TestCase
         $review->method('getSetting')
             ->willReturnCallback(function ($setting) {
                 return match ($setting) {
-                    Episciences_Review::SETTING_AUTHORS_CAN_CONTACT_EDITORS => null,
+                    Episciences_Review::SETTING_AUTHOR_EDITOR_COMMUNICATION => null,
                     Episciences_Review::SETTING_DISCLOSE_EDITOR_NAMES_TO_AUTHORS => '1',
                     default => null
                 };


### PR DESCRIPTION
 - Rename SETTING_AUTHORS_CAN_CONTACT_EDITORS to SETTING_AUTHOR_EDITOR_COMMUNICATION                                                 
  - Update labels to reflect bidirectional communication                                                                              
  - Add spacing for form element   