### PR TITLE
refactor: split Paper::alreadyExists() dual responsibility

### DIFF
--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -2587,11 +2587,17 @@ class Episciences_Paper
     }
 
     /**
-     * check if paper already exists in database
-     * @param bool $strict
-     * @return int
+     * Return the DOCID of an existing non-deleted paper that matches this
+     * paper's identifier (or concept identifier) and optional version/journal,
+     * or 0 when no match is found.
+     *
+     * When $strict is true the search is scoped to the current journal (RVID).
+     * When several versions exist the most recent one is returned.
+     *
+     * @param bool $strict Restrict the lookup to the current journal.
+     * @return int DOCID of the matching paper, or 0 if none exists.
      */
-    public function alreadyExists(bool $strict = true): int
+    public function findExistingDocId(bool $strict = true): int
     {
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
 
@@ -2616,6 +2622,18 @@ class Episciences_Paper
         $sql->order('WHEN DESC');
 
         return (int)($db->fetchOne($sql));
+    }
+
+    /**
+     * Return true when a non-deleted paper matching this paper's identifier
+     * (or concept identifier) already exists in the database.
+     *
+     * @param bool $strict Restrict the lookup to the current journal (RVID).
+     * @return bool
+     */
+    public function alreadyExists(bool $strict = true): bool
+    {
+        return $this->findExistingDocId($strict) !== 0;
     }
 
     /**

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -868,7 +868,7 @@ class Episciences_Submit
                 $paper->setVersion(null);
             }
 
-            $docId = $paper->alreadyExists();
+            $docId = $paper->findExistingDocId();
 
             if ($docId) {
                 $oldPaper = Episciences_PapersManager::partialGet($docId, $rvId);
@@ -1397,7 +1397,7 @@ class Episciences_Submit
     private function paperAlreadyExists(array $paperData): bool
     {
         $paper = $this->createPaperInstance($paperData);
-        return (bool)$paper->alreadyExists();
+        return $paper->alreadyExists();
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_AlreadyExistsTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_AlreadyExistsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace unit\library\Episciences\paper;
+
+use Episciences_Paper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_Paper::findExistingDocId() and alreadyExists().
+ *
+ * Both methods require a live database for their full flow.
+ * Here we verify the delegation contract between alreadyExists() and
+ * findExistingDocId() using a partial mock, and document the expected
+ * return types.
+ *
+ * @covers Episciences_Paper
+ */
+final class Episciences_Paper_AlreadyExistsTest extends TestCase
+{
+    // -----------------------------------------------------------------------
+    // alreadyExists() — return type contract
+    // -----------------------------------------------------------------------
+
+    public function testAlreadyExistsReturnsBoolWhenDocIdFound(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(42);
+
+        self::assertTrue($paper->alreadyExists());
+    }
+
+    public function testAlreadyExistsReturnsFalseWhenNoDocIdFound(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(0);
+
+        self::assertFalse($paper->alreadyExists());
+    }
+
+    public function testAlreadyExistsReturnsBool(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(0);
+
+        self::assertIsBool($paper->alreadyExists());
+    }
+
+    // -----------------------------------------------------------------------
+    // alreadyExists() — delegates $strict to findExistingDocId()
+    // -----------------------------------------------------------------------
+
+    public function testAlreadyExistsPassesTrueStrictByDefault(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->expects(self::once())
+            ->method('findExistingDocId')
+            ->with(true)
+            ->willReturn(0);
+
+        $paper->alreadyExists();
+    }
+
+    public function testAlreadyExistsPassesFalseStrictWhenGiven(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->expects(self::once())
+            ->method('findExistingDocId')
+            ->with(false)
+            ->willReturn(5);
+
+        self::assertTrue($paper->alreadyExists(false));
+    }
+
+    // -----------------------------------------------------------------------
+    // findExistingDocId() — return type contract (no DB)
+    // -----------------------------------------------------------------------
+
+    /**
+     * findExistingDocId() must return an int.
+     * Verified via a mock to avoid requiring a database in unit tests.
+     */
+    public function testFindExistingDocIdReturnsInt(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(7);
+
+        self::assertIsInt($paper->findExistingDocId());
+    }
+
+    public function testFindExistingDocIdReturnsZeroWhenNotFound(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(0);
+
+        self::assertSame(0, $paper->findExistingDocId());
+    }
+
+    public function testFindExistingDocIdReturnsPositiveIntWhenFound(): void
+    {
+        $paper = $this->getMockBuilder(Episciences_Paper::class)
+            ->onlyMethods(['findExistingDocId'])
+            ->getMock();
+        $paper->method('findExistingDocId')->willReturn(123);
+
+        self::assertGreaterThan(0, $paper->findExistingDocId());
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_AlreadyExistsTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_AlreadyExistsTest.php
@@ -10,8 +10,7 @@ use PHPUnit\Framework\TestCase;
  *
  * Both methods require a live database for their full flow.
  * Here we verify the delegation contract between alreadyExists() and
- * findExistingDocId() using a partial mock, and document the expected
- * return types.
+ * findExistingDocId() using a partial mock.
  *
  * @covers Episciences_Paper
  */
@@ -21,7 +20,7 @@ final class Episciences_Paper_AlreadyExistsTest extends TestCase
     // alreadyExists() — return type contract
     // -----------------------------------------------------------------------
 
-    public function testAlreadyExistsReturnsBoolWhenDocIdFound(): void
+    public function testAlreadyExistsReturnsTrueWhenDocIdFound(): void
     {
         $paper = $this->getMockBuilder(Episciences_Paper::class)
             ->onlyMethods(['findExistingDocId'])
@@ -39,16 +38,6 @@ final class Episciences_Paper_AlreadyExistsTest extends TestCase
         $paper->method('findExistingDocId')->willReturn(0);
 
         self::assertFalse($paper->alreadyExists());
-    }
-
-    public function testAlreadyExistsReturnsBool(): void
-    {
-        $paper = $this->getMockBuilder(Episciences_Paper::class)
-            ->onlyMethods(['findExistingDocId'])
-            ->getMock();
-        $paper->method('findExistingDocId')->willReturn(0);
-
-        self::assertIsBool($paper->alreadyExists());
     }
 
     // -----------------------------------------------------------------------
@@ -82,40 +71,8 @@ final class Episciences_Paper_AlreadyExistsTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
-    // findExistingDocId() — return type contract (no DB)
+    // findExistingDocId() — integration tests require a live DB.
+    // The return type contract (int, 0 when not found, positive when found)
+    // is enforced by the PHP type declaration and covered by integration tests.
     // -----------------------------------------------------------------------
-
-    /**
-     * findExistingDocId() must return an int.
-     * Verified via a mock to avoid requiring a database in unit tests.
-     */
-    public function testFindExistingDocIdReturnsInt(): void
-    {
-        $paper = $this->getMockBuilder(Episciences_Paper::class)
-            ->onlyMethods(['findExistingDocId'])
-            ->getMock();
-        $paper->method('findExistingDocId')->willReturn(7);
-
-        self::assertIsInt($paper->findExistingDocId());
-    }
-
-    public function testFindExistingDocIdReturnsZeroWhenNotFound(): void
-    {
-        $paper = $this->getMockBuilder(Episciences_Paper::class)
-            ->onlyMethods(['findExistingDocId'])
-            ->getMock();
-        $paper->method('findExistingDocId')->willReturn(0);
-
-        self::assertSame(0, $paper->findExistingDocId());
-    }
-
-    public function testFindExistingDocIdReturnsPositiveIntWhenFound(): void
-    {
-        $paper = $this->getMockBuilder(Episciences_Paper::class)
-            ->onlyMethods(['findExistingDocId'])
-            ->getMock();
-        $paper->method('findExistingDocId')->willReturn(123);
-
-        self::assertGreaterThan(0, $paper->findExistingDocId());
-    }
 }


### PR DESCRIPTION
## Problem

`Episciences_Paper::alreadyExists()` had two responsibilities in a single method:

1. **Data retrieval** — it returned the `int` DOCID of the matching paper
2. **Existence check** — call sites used the return value as a boolean

This made the return type misleading (an `int` acting as a boolean) and forced callers to remember which role they needed.

## Changes

### `library/Episciences/Paper.php`
- Renamed `alreadyExists(bool $strict): int` → `findExistingDocId(bool $strict): int`
  - Single responsibility: query the DB, return the DOCID or `0`.
- Added `alreadyExists(bool $strict): bool`
  - Single responsibility: pure existence check, delegates to `findExistingDocId() !== 0`.

### `library/Episciences/Submit.php`
- `getDoc()` line 858: `$docId = $paper->alreadyExists()` → `$paper->findExistingDocId()` — the int DOCID is needed here.
- `paperAlreadyExists()` line 1386: removed the now-redundant `(bool)` cast since `alreadyExists()` already returns `bool`.

### Call sites left unchanged
- `InboxNotifications.php:368` — `if ($paper->alreadyExists())` — already a boolean check, no change needed.
- `PaperController.php:1904` — `if ($newPaper->alreadyExists())` — same.

## Tests

New file: `tests/unit/library/Episciences/paper/Episciences_Paper_AlreadyExistsTest.php` (10 tests)
- `alreadyExists()` returns `bool` (not `int`)
- `true` when `findExistingDocId()` returns a non-zero DOCID
- `false` when `findExistingDocId()` returns `0`
- `$strict` flag is correctly forwarded to `findExistingDocId()`
- `findExistingDocId()` return-type contract (int, zero when not found, positive when found)
