### PR TITLE
fix: TypeError in enrichment:creators on non-sequential affiliation keys

### DIFF
--- a/library/Episciences/Paper/Authors/EnrichmentService.php
+++ b/library/Episciences/Paper/Authors/EnrichmentService.php
@@ -155,7 +155,7 @@ class Episciences_Paper_Authors_EnrichmentService
     private static function mergeExistingAffiliations(array &$dbAuthors, int|string $authorIndex, array $dbAuthor, array $teiAuthor): void
     {
         foreach ($teiAuthor[self::KEY_AFFILIATIONS] as $teiAffiliation) {
-            $existingNames = array_column($dbAuthor[self::KEY_AFFILIATION], self::KEY_NAME);
+            $existingNames = array_map(static fn($aff) => $aff[self::KEY_NAME] ?? null, $dbAuthor[self::KEY_AFFILIATION]);
             $affiliationName = $teiAffiliation[self::KEY_NAME];
 
             if (!in_array($affiliationName, $existingNames, true)) {


### PR DESCRIPTION
## Summary
- `array_column()` in `mergeExistingAffiliations()` re-indexes results from 0, so when `$dbAuthor[KEY_AFFILIATION]` has non-sequential keys, `array_search` returns an index that doesn't exist in the original array
- Accessing a missing key returns `null` (with a PHP warning), which is then passed to `AffiliationHelper::hasRor(array $authorAffiliation)` → fatal `TypeError`
- Fix: replace `array_column` with `array_map` which preserves the original array keys

## Reproduction
`console.php enrichment:creators` crashes at paper 1027/7723 with:
```
PHP Warning: Undefined array key 1 in EnrichmentService.php on line 173
PHP Fatal error: Uncaught TypeError: hasRor(): Argument #1 must be of type array, null given
```

## Test plan
- [ ] Run `console.php enrichment:creators` past the previously failing paper
- [ ] Verify no regression on papers with sequential affiliation keys