### PR TITLE
fix(website): fix header manager broken edit/delete and missing CSS

### DIFF
--- a/application/modules/common/controllers/WebsiteDefaultController.php
+++ b/application/modules/common/controllers/WebsiteDefaultController.php
@@ -83,10 +83,6 @@ class WebsiteDefaultController extends Zend_Controller_Action
      */
     public function ajaxheaderAction()
     {
-        if (!$this->_validateCsrf()) {
-            $this->getResponse()->setHttpResponseCode(403);
-            return;
-        }
         $this->_helper->layout()->disableLayout();
         $header = new Episciences_Website_Header();
         $this->view->form = $header->getLogoForm($this->getRequest()->getParam('id', '0'));

--- a/application/modules/common/views/scripts/website/header.phtml
+++ b/application/modules/common/views/scripts/website/header.phtml
@@ -27,19 +27,11 @@ $this->layout()->description = $this->translate("Personnalisez le bandeau en-tê
 <div aria-live="polite" aria-atomic="true" class="sr-only" id="header-announcer"></div>
 
 <form enctype="multipart/form-data" method="post" class="form-horizontal" action="/website/header">
-    <table class="table table-hover" id="tableLogo">
-        <thead>
-        <tr>
-            <th style="width:20px"></th>
-            <th><?php echo $this->translate('Logo'); ?></th>
-            <th style="width:20px"><?php echo $this->translate('Actions'); ?></th>
-        </tr>
-        </thead>
-        <tbody id="sortable-header">
+    <ul class="menu-sortable" id="sortable-header">
         <?php foreach ($this->forms as $i => $form) {
             $hasImgError = isset($this->errors[$i]) && $this->errors[$i] == Ccsd_Website_Header::LOGO_IMG;
             $hasTextError = isset($this->errors[$i]) && $this->errors[$i] != Ccsd_Website_Header::LOGO_IMG;
-            
+
             if ($hasImgError) {
                 $form->getElement($this->errors[$i])->addError($this->translate('Merci de déposer une image'));
             } elseif ($hasTextError) {
@@ -54,33 +46,34 @@ $this->layout()->description = $this->translate("Personnalisez le bandeau en-tê
                 $textValues = $form->getElement('text')->getValue();
                 $text = isset($textValues[Zend_Registry::get('lang')]) ? $textValues[Zend_Registry::get('lang')] : '';
             } ?>
-            <tr class="logo" id="logo-<?php echo $this->escape($i); ?>">
-                <td><button type="button" class="menu-drag-handle" aria-label="<?php echo $this->escape($this->translate('Déplacer')) ?>"><span aria-hidden="true">⠿</span></button></td>
-                <td>
-                    <b class="menu-item-name logo-title"><?php echo $icon; ?>&nbsp;-&nbsp;<span class="menu-item-name-text"><?php echo $this->escape($text); ?></span></b>
-                    <div class="menu-edit-form div-form" id="form-logo-<?php echo $this->escape($i); ?>" <?php echo(isset($this->errors[$i]) ? '' : 'hidden'); ?>>
-                        <?php echo $this->partial('website/header-logo-form.phtml', ['form' => $form]); ?>
+            <li class="logo" id="logo-<?php echo $this->escape($i); ?>">
+                <div class="menu-item">
+                    <button type="button" class="menu-drag-handle" aria-label="<?php echo $this->escape($this->translate('Déplacer')) ?>"><span aria-hidden="true">⠿</span></button>
+                    <div class="menu-item-label">
+                        <span class="menu-item-name"><?php echo $icon; ?>&nbsp;-&nbsp;<span class="menu-item-name-text"><?php echo $this->escape($text); ?></span></span>
+                        <div class="menu-edit-form" id="form-logo-<?php echo $this->escape($i); ?>" <?php echo(isset($this->errors[$i]) ? '' : 'hidden'); ?>>
+                            <?php echo $this->partial('website/header-logo-form.phtml', ['form' => $form]); ?>
+                        </div>
                     </div>
-                </td>
-                <td style="text-align:right">
-                    <button type="button" class="menu-action-btn menu-action-btn--edit" 
-                            title="<?php echo $this->escape($this->translate("Modifier")); ?>"
-                            aria-expanded="<?php echo isset($this->errors[$i]) ? 'true' : 'false' ?>"
-                            aria-controls="form-logo-<?php echo $this->escape($i); ?>"
-                            data-action="toggle-edit">
-                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                    </button>
-                    <button type="button" class="menu-action-btn menu-action-btn--delete"
-                            title="<?php echo $this->escape($this->translate("Supprimer")); ?>"
-                            data-logo-id="logo-<?php echo $this->escape($i); ?>"
-                            data-action="delete-logo">
-                        <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
-                    </button>
-                </td>
-            </tr>
+                    <div class="menu-item-actions">
+                        <button type="button" class="menu-action-btn menu-action-btn--edit"
+                                title="<?php echo $this->escape($this->translate("Modifier")); ?>"
+                                aria-expanded="<?php echo isset($this->errors[$i]) ? 'true' : 'false' ?>"
+                                aria-controls="form-logo-<?php echo $this->escape($i); ?>"
+                                data-action="toggle-edit">
+                            <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                        </button>
+                        <button type="button" class="menu-action-btn menu-action-btn--delete"
+                                title="<?php echo $this->escape($this->translate("Supprimer")); ?>"
+                                data-logo-id="logo-<?php echo $this->escape($i); ?>"
+                                data-action="delete-logo">
+                            <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+                        </button>
+                    </div>
+                </div>
+            </li>
         <?php } ?>
-        </tbody>
-    </table>
+    </ul>
     
     <!-- Template for new logos added via addLogo() -->
     <template id="logo-template">
@@ -121,7 +114,15 @@ $this->layout()->description = $this->translate("Personnalisez le bandeau en-tê
     ->setJsCallback('confirmDelete();'); ?>
 
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-    window._headerManager = new HeaderManager(document.getElementById('sortable-header'), <?php echo count($this->forms)?>);
-});
+// Next unique index computed from existing keys (e.g. 'logo_0', 'logo_3') to avoid
+// colliding with PHP-rendered form field names (logo_0[text], logo_0[type], etc.)
+window._headerUniq = <?php
+    $maxIndex = -1;
+    foreach (array_keys($this->forms) as $key) {
+        if (preg_match('/^logo_(\d+)$/', $key, $m)) {
+            $maxIndex = max($maxIndex, (int)$m[1]);
+        }
+    }
+    echo $maxIndex + 1;
+?>;
 </script>

--- a/public/js/website/header-manager.js
+++ b/public/js/website/header-manager.js
@@ -191,13 +191,21 @@ class HeaderManager {
                 if (dt && dt.tagName === 'DT') {
                     dt.hidden = !shouldBeVisible;
                     dd.hidden = !shouldBeVisible;
+                    if (shouldBeVisible) {
+                        dt.style.display = '';
+                        dd.style.display = '';
+                    }
                 } else if (dd) {
                     dd.hidden = !shouldBeVisible;
+                    if (shouldBeVisible) dd.style.display = '';
                 } else {
                     el.hidden = !shouldBeVisible;
+                    if (shouldBeVisible) el.style.display = '';
                 }
             } else {
                 container.hidden = !shouldBeVisible;
+                // Clear any inline display:none set by jQuery's .hide() (e.g. from the global form.js)
+                if (shouldBeVisible) container.style.display = '';
             }
 
             // Toggle required attribute to avoid blocking submission when hidden


### PR DESCRIPTION
## Summary

- **CSRF removed from `ajaxheaderAction()`**: read-only GET endpoint returning a form fragment — no state mutation, CSRF not applicable. The check was causing ZF1 to auto-render the non-existent `ajaxheader.phtml` (500 error).
- **`header.phtml` table → `<ul class="menu-sortable">`**: the old `<table>/<tr>/<td>` structure was incompatible with `menu.css` (targets `.menu-item`, `.menu-sortable`) and with the `<template id="logo-template">` which already used `<li>`. Appending `<li>` into `<tbody>` is invalid HTML; browsers ejected the element outside the table, losing all styles.
- **Duplicate `HeaderManager` fixed**: `header.phtml` was creating an instance inline *and* `header.js` was creating a second one with `uniq=0`. Double event listeners caused the edit button toggle to cancel itself and the delete confirmation to require two clicks. `header.phtml` now only sets `window._headerUniq`; `header.js` creates the single instance.
- **`form.js` / `header-manager.js` conflict resolved**: the global `form.js` uses jQuery `.hide()` which sets `style="display:none"` on conditional elements. `header-manager.js` was toggling the `hidden` attribute, which does not clear inline `style.display`. `displayElements` now also clears `style.display = ''` when making an element visible.
- **`window._headerUniq` computed as `max(existing indices) + 1`** instead of `count(forms)` to avoid form field name collisions when logo indices are non-contiguous.

## Test plan

- [ ] Open the header manager page (`/website/header`)
- [ ] Click **Edit** on an existing logo — form should expand; click again to collapse
- [ ] Click **Delete** on an existing logo — single confirmation click should suffice
- [ ] Click **Add logo** — a new form should appear with correct Bootstrap styling
- [ ] On a multi-language journal (FR+EN), verify both FR and EN label inputs appear
- [ ] Save changes and verify they persist after reload