### PR TITLE
feat(stats): add stats:import-logs command to parse Apache logs into STAT_TEMP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ help: ## Display this help message
 	@grep -h -E '^deploy.*:.*##' $(MAKEFILE_LIST) 2>/dev/null | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}' || echo "  No deployment commands found"
 	@echo ""
 	@echo "Other Commands:"
-	@grep -E '^(send-mails|merge-pdf|get-classification|can-i-use):.*##' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
+	@grep -E '^(send-mails|merge-pdf|get-classification|can-i-use|import-apache-logs):.*##' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
 
 # =============================================================================
 # Core Docker Commands
@@ -469,6 +469,44 @@ stats-download-kpi: ## Generate download KPI JSON for all published articles (op
 can-i-use-update: ## Update browserslist database when caniuse-lite is outdated
 	@echo "Updating browserslist database..."
 	@$(NPX) update-browserslist-db@latest
+
+import-apache-logs: ## Parse Apache logs into STAT_TEMP (rvcode=JOURNAL|all=1 [date=YYYY-MM-DD|month=YYYY-MM|year=YYYY|start-date=…+end-date=…] [logs-path=PATH] [force=1])
+	@if [ -z "$(rvcode)" ] && [ "$(all)" != "1" ]; then \
+		echo "Error: specify rvcode=JOURNAL_CODE or all=1"; \
+		echo "Usage: make import-apache-logs rvcode=JOURNAL_CODE [options]"; \
+		echo "       make import-apache-logs all=1 [options]"; \
+		echo "Options:"; \
+		echo "  date=YYYY-MM-DD          Process a specific day"; \
+		echo "  month=YYYY-MM            Process entire month"; \
+		echo "  year=YYYY                Process entire year"; \
+		echo "  start-date=YYYY-MM-DD    Start date for custom range"; \
+		echo "  end-date=YYYY-MM-DD      End date for custom range"; \
+		echo "  logs-path=PATH           Base path to Apache log directory"; \
+		echo "  force=1                  Force reprocessing of already-processed dates"; \
+		exit 1; \
+	fi
+	@cmd="php scripts/console.php stats:import-logs"; \
+	if [ "$(all)" = "1" ]; then \
+		cmd="$$cmd --all"; \
+	else \
+		cmd="$$cmd --rvcode=$(rvcode)"; \
+	fi; \
+	if [ -n "$(date)" ]; then \
+		cmd="$$cmd --date=$(date)"; \
+	elif [ -n "$(month)" ]; then \
+		cmd="$$cmd --month=$(month)"; \
+	elif [ -n "$(year)" ]; then \
+		cmd="$$cmd --year=$(year)"; \
+	elif [ -n "$(start-date)" ] && [ -n "$(end-date)" ]; then \
+		cmd="$$cmd --start-date=$(start-date) --end-date=$(end-date)"; \
+	fi; \
+	if [ -n "$(logs-path)" ]; then \
+		cmd="$$cmd --logs-path=$(logs-path)"; \
+	fi; \
+	if [ "$(force)" = "1" ]; then \
+		cmd="$$cmd --force"; \
+	fi; \
+	$(DOCKER_COMPOSE) exec -u $(CNTR_APP_USER) -w $(CNTR_APP_DIR) $(CNTR_NAME_PHP) $$cmd
 
 # =============================================================================
 # Code Formatting Commands (Prettier)

--- a/docs/STATISTICS_UPDATE_README.md
+++ b/docs/STATISTICS_UPDATE_README.md
@@ -1,0 +1,122 @@
+# UpdateStatistics.php Enhancement
+
+## Overview
+The UpdateStatistics.php script has been enhanced with new features for processing Apache log files in date ranges, handling compressed files, and preventing duplicate processing.
+
+## New Features
+
+### 1. Enhanced Date Processing Options
+- **Single Date**: `--date YYYY-MM-DD` (existing functionality)
+- **Date Range**: `--start-date YYYY-MM-DD --end-date YYYY-MM-DD`
+- **Full Month**: `--month YYYY-MM`
+- **Force Reprocessing**: `--force` (reprocess already processed dates)
+
+### 2. Compressed File Support
+- Automatically handles both `.access_log` and `.access_log.gz` files
+- Uses PHP's gzopen/gzgets for transparent decompression
+- No re-compression needed (files left as-is after processing)
+
+### 3. Duplicate Prevention
+- New `STAT_PROCESSING_LOG` InnoDB table tracks processed dates per journal
+- Prevents reprocessing unless `--force` flag is used
+- Tracks processing status and record counts
+
+### 4. Security Enhancements
+- Input sanitization for document IDs, IP addresses, and user agents
+- Prepared statements for all database operations
+- Control character removal from user agent strings
+- Document ID validation (1-9999999 range)
+
+## Usage Examples
+
+### Makefile Commands (Recommended)
+```bash
+# Process yesterday's logs for journal 'mbj'
+make update-statistics rvcode=mbj
+
+# Process specific date
+make update-statistics rvcode=mbj date=2023-01-15
+
+# Process entire month
+make update-statistics rvcode=mbj month=2023-01
+
+# Process date range
+make update-statistics rvcode=mbj start-date=2023-01-01 end-date=2023-01-07
+
+# Force reprocess (ignore duplicate prevention)
+make update-statistics rvcode=mbj date=2023-01-15 force=1
+```
+
+### Direct PHP Commands
+```bash
+# Single date
+php scripts/UpdateStatistics.php update:statistics --rvcode mbj --date 2023-01-15
+
+# Date range
+php scripts/UpdateStatistics.php update:statistics --rvcode mbj --start-date 2023-01-01 --end-date 2023-01-07
+
+# Full month
+php scripts/UpdateStatistics.php update:statistics --rvcode mbj --month 2023-01
+
+# Force reprocessing
+php scripts/UpdateStatistics.php update:statistics --rvcode mbj --date 2023-01-15 --force
+```
+
+## Database Changes
+
+### New Table: STAT_PROCESSING_LOG
+```sql
+CREATE TABLE `STAT_PROCESSING_LOG` (
+  `ID` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `JOURNAL_CODE` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `PROCESSED_DATE` date NOT NULL,
+  `PROCESSED_AT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `FILE_PATH` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `RECORDS_PROCESSED` int UNSIGNED NOT NULL DEFAULT 0,
+  `STATUS` enum('success','error','partial') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'success',
+  PRIMARY KEY (`ID`),
+  UNIQUE KEY `unique_journal_date` (`JOURNAL_CODE`, `PROCESSED_DATE`),
+  KEY `idx_journal_code` (`JOURNAL_CODE`),
+  KEY `idx_processed_date` (`PROCESSED_DATE`),
+  KEY `idx_processed_at` (`PROCESSED_AT`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+### STAT_TEMP Table Fix
+- Fixed auto-increment issue by removing `VISITID` from INSERT statements
+- Column names updated to match actual table structure: `DOCID`, `IP`, `HTTP_USER_AGENT`, `DHIT`, `CONSULT`
+
+## File Structure
+- **Apache Logs**: `../logs/httpd/{journal}.episciences.org/{year}/{month}/{day}-{journal}.episciences.org.access_log[.gz]`
+- **Processing Logs**: Database-based tracking in `STAT_PROCESSING_LOG` table
+
+## Log File Format Support
+The script processes Apache Combined Log Format:
+```
+IP - - [timestamp] "GET /articles/{id} HTTP/1.1" status size "referer" "user-agent"
+```
+
+### Supported URL Patterns
+- `/articles/{id}` → Notice view (`CONSULT = 'notice'`)
+- `/articles/{id}/download` → File download (`CONSULT = 'file'`)
+- `/articles/{id}/preview` → File preview (`CONSULT = 'file'`)
+
+## Testing
+Run the test suite to verify functionality:
+```bash
+# PHP unit tests
+make phpunit tests/unit/scripts/UpdateStatisticsTest.php
+make phpunit tests/unit/scripts/UpdateStatisticsIntegrationTest.php
+```
+
+## Error Handling
+- Missing log files are skipped with warnings (not errors)
+- Invalid document IDs are filtered out
+- Malformed log lines are logged but don't stop processing
+- Database errors cause rollback and proper error reporting
+
+## Performance Considerations
+- Uses transactions for bulk database inserts
+- Progress reporting for large date ranges
+- Memory-efficient line-by-line file processing
+- Indexes on processing log table for fast duplicate checking

--- a/scripts/ImportApacheLogsCommand.php
+++ b/scripts/ImportApacheLogsCommand.php
@@ -1,0 +1,585 @@
+<?php
+declare(strict_types=1);
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: parse Apache access logs → STAT_TEMP.
+ *
+ * Replaces the legacy scripts/UpdateStatistics.php.
+ *
+ * Processing per log file:
+ *   1. Resolve log file path for the target date (plain or .gz)
+ *   2. Parse each line: extract docId, IP, User-Agent, timestamp
+ *   3. Filter to article notice/file-download patterns only
+ *   4. Bulk-insert matching rows into STAT_TEMP (transaction)
+ *   5. Record processed date in STAT_PROCESSING_LOG (duplicate prevention)
+ *
+ * The stats:process cron (ProcessStatTempCommand) then enriches STAT_TEMP
+ * rows with GeoIP data and moves them to PAPER_STAT.
+ */
+class ImportApacheLogsCommand extends Command
+{
+    protected static $defaultName = 'stats:import-logs';
+
+    /** Apache combined-log patterns mapped to CONSULT type. */
+    private const PATTERNS = [
+        'notice'   => '/GET \/articles\/(\d+) HTTP/',
+        'file'     => '/GET \/articles\/(\d+)\/download HTTP/',
+        'file'     => '/GET \/articles\/(\d+)\/preview HTTP/',
+    ];
+
+    private string $logsBasePath = '../logs/httpd';
+
+    private ?ProgressBar $progressBar = null;
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Parse Apache access logs and insert article visits into STAT_TEMP.')
+            ->addOption('rvcode',      null, InputOption::VALUE_REQUIRED, 'Journal code (e.g., mbj) — mutually exclusive with --all')
+            ->addOption('all',         null, InputOption::VALUE_NONE,     'Process all journals with is_new_front_switched = yes — mutually exclusive with --rvcode')
+            ->addOption('date',        null, InputOption::VALUE_OPTIONAL, 'Single date to process (YYYY-MM-DD; default: yesterday)')
+            ->addOption('month',       null, InputOption::VALUE_OPTIONAL, 'Process entire month (YYYY-MM)')
+            ->addOption('year',        null, InputOption::VALUE_OPTIONAL, 'Process entire year (YYYY)')
+            ->addOption('start-date',  null, InputOption::VALUE_OPTIONAL, 'Start of date range (YYYY-MM-DD)')
+            ->addOption('end-date',    null, InputOption::VALUE_OPTIONAL, 'End of date range (YYYY-MM-DD)')
+            ->addOption('force',       null, InputOption::VALUE_NONE,     'Reprocess dates already recorded in STAT_PROCESSING_LOG')
+            ->addOption('logs-path',   null, InputOption::VALUE_OPTIONAL, 'Base path to Apache log directory', $this->logsBasePath);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $startTime = microtime(true);
+
+        $io = new SymfonyStyle($input, $output);
+        $io->title('stats:import-logs — Apache logs → STAT_TEMP');
+
+        $this->bootstrap();
+
+        $logger = $this->buildLogger($io);
+
+        $rvcode = $input->getOption('rvcode');
+        $all    = (bool) $input->getOption('all');
+
+        if ($rvcode && $all) {
+            $io->error('--rvcode and --all are mutually exclusive.');
+            return Command::FAILURE;
+        }
+
+        if (!$rvcode && !$all) {
+            $io->error('Specify either --rvcode=CODE or --all.');
+            return Command::FAILURE;
+        }
+
+        try {
+            $dateRange = $this->resolveDateRange($input);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->logsBasePath = (string) $input->getOption('logs-path');
+        $io->writeln('Logs path : ' . $this->logsBasePath);
+        $logger->info('Logs path: ' . $this->logsBasePath);
+
+        $rvcodes = $all ? $this->fetchNewFrontRvcodes($logger) : [$rvcode];
+
+        if (empty($rvcodes)) {
+            $io->warning('No journal found with is_new_front_switched = yes.');
+            return Command::SUCCESS;
+        }
+
+        $io->writeln(sprintf('Journals to process: %s', implode(', ', $rvcodes)));
+        $logger->info(sprintf('Journals to process: %s', implode(', ', $rvcodes)));
+
+        $force         = (bool) $input->getOption('force');
+        $totalInserted = 0;
+
+        foreach ($rvcodes as $rvcode) {
+            $io->section("Journal: {$rvcode}");
+            $logger->info("--- Journal: {$rvcode} ---");
+            $siteName = $rvcode . '.episciences.org';
+
+            foreach ($dateRange as $dateObj) {
+                $date = $dateObj->format('Y-m-d');
+
+                if (!$force && $this->isDateAlreadyProcessed($rvcode, $date)) {
+                    $io->writeln("Skipping {$date} (already processed — use --force to reprocess).");
+                    $logger->info("Skipping {$date}: already in STAT_PROCESSING_LOG.");
+                    continue;
+                }
+
+                $logFile = $this->buildLogFilePath($siteName, $dateObj);
+                if ($logFile === null) {
+                    $io->warning("No log file found for {$date}.");
+                    $logger->warning("Log file not found for {$date}.");
+                    continue;
+                }
+
+                $logger->info("Processing {$logFile}");
+                $accesses = $this->collectArticleAccesses($logFile, $date, $logger);
+
+                if (empty($accesses)) {
+                    $io->writeln("No article accesses found for {$date}.");
+                    $logger->info("No article accesses for {$date}.");
+                    $this->markDateAsProcessed($rvcode, $date, $logFile, 0, 'success');
+                    continue;
+                }
+
+                $io->writeln(sprintf('Found %d accesses for %s.', count($accesses), $date));
+                $logger->info(sprintf('Found %d accesses for %s.', count($accesses), $date));
+
+                try {
+                    $inserted = $this->insertIntoStatTemp($accesses, $io, $logger);
+                } catch (\Exception $e) {
+                    $io->error("DB error for {$date}: " . $e->getMessage());
+                    $logger->error("DB error for {$date}: " . $e->getMessage());
+                    $this->markDateAsProcessed($rvcode, $date, $logFile, 0, 'error');
+                    return Command::FAILURE;
+                }
+
+                $this->markDateAsProcessed($rvcode, $date, $logFile, $inserted, 'success');
+                $io->writeln("Inserted {$inserted} records for {$date}.");
+                $logger->info("Inserted {$inserted} records for {$date}.");
+                $totalInserted += $inserted;
+            }
+        }
+
+        $elapsed = round(microtime(true) - $startTime, 2);
+        $io->success(sprintf('Done. Total inserted: %d record(s) in %s s.', $totalInserted, $elapsed));
+        $logger->info(sprintf('Done. Total inserted: %d in %s s.', $totalInserted, $elapsed));
+
+        return Command::SUCCESS;
+    }
+
+    // -------------------------------------------------------------------------
+    // Date resolution
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve the list of dates to process from command options.
+     *
+     * @return \DateTime[]
+     * @throws \Exception
+     */
+    private function resolveDateRange(InputInterface $input): array
+    {
+        $date      = $input->getOption('date');
+        $month     = $input->getOption('month');
+        $year      = $input->getOption('year');
+        $startDate = $input->getOption('start-date');
+        $endDate   = $input->getOption('end-date');
+
+        $yesterday = (new \DateTime('yesterday'))->format('Y-m-d');
+
+        // Count explicitly set options (exclude implicit default date)
+        $explicit = 0;
+        if ($date !== null && $date !== $yesterday) $explicit++;
+        if ($month)                                  $explicit++;
+        if ($year)                                   $explicit++;
+        if ($startDate || $endDate)                  $explicit++;
+
+        if ($explicit > 1) {
+            throw new \Exception('Specify only one of: --date, --month, --year, or --start-date/--end-date.');
+        }
+
+        if ($year) {
+            return $this->yearRange($year);
+        }
+
+        if ($month) {
+            return $this->monthRange($month);
+        }
+
+        if ($startDate || $endDate) {
+            if (!$startDate || !$endDate) {
+                throw new \Exception('--start-date and --end-date must both be provided.');
+            }
+            return $this->dateRange($startDate, $endDate);
+        }
+
+        $target = ($date !== null && $date !== $yesterday) ? $date : $yesterday;
+        return [$this->parseDate($target)];
+    }
+
+    /** @return \DateTime[] */
+    private function yearRange(string $year): array
+    {
+        if (!preg_match('/^\d{4}$/', $year)) {
+            throw new \Exception('Invalid --year format. Use YYYY.');
+        }
+        return $this->dateRange($year . '-01-01', $year . '-12-31');
+    }
+
+    /** @return \DateTime[] */
+    private function monthRange(string $month): array
+    {
+        if (!preg_match('/^\d{4}-\d{2}$/', $month)) {
+            throw new \Exception('Invalid --month format. Use YYYY-MM.');
+        }
+        $start = $this->parseDate($month . '-01');
+        return $this->dateRange($month . '-01', $start->format('Y-m-t'));
+    }
+
+    /** @return \DateTime[] */
+    private function dateRange(string $startDate, string $endDate): array
+    {
+        $start = $this->parseDate($startDate);
+        $end   = $this->parseDate($endDate);
+
+        if ($start > $end) {
+            throw new \Exception('--start-date must be before or equal to --end-date.');
+        }
+
+        $dates   = [];
+        $current = clone $start;
+        while ($current <= $end) {
+            $dates[] = clone $current;
+            $current->modify('+1 day');
+        }
+        return $dates;
+    }
+
+    private function parseDate(string $date): \DateTime
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d', $date);
+        if ($dt === false) {
+            throw new \Exception("Invalid date format '{$date}'. Use YYYY-MM-DD.");
+        }
+        $dt->setTime(0, 0, 0);
+        return $dt;
+    }
+
+    // -------------------------------------------------------------------------
+    // Log file resolution
+    // -------------------------------------------------------------------------
+
+    /**
+     * Resolve the log file path for a given site and date, trying plain then .gz.
+     */
+    private function buildLogFilePath(string $siteName, \DateTime $date): ?string
+    {
+        $base = sprintf(
+            '%s/%s/%s/%s/%s-%s.access_log',
+            $this->logsBasePath,
+            $siteName,
+            $date->format('Y'),
+            $date->format('m'),
+            $date->format('d'),
+            $siteName
+        );
+
+        if (file_exists($base)) {
+            return $base;
+        }
+        if (file_exists($base . '.gz')) {
+            return $base . '.gz';
+        }
+
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Log parsing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parse a log file and return matching article access records for $targetDate.
+     *
+     * @return array<int, array{doc_id: int, ip: int, user_agent: string, date_time: string, timestamp: int, access_type: string}>
+     */
+    private function collectArticleAccesses(string $logFile, string $targetDate, Logger $logger): array
+    {
+        $startOfDay = strtotime($targetDate . ' 00:00:00');
+        $endOfDay   = strtotime($targetDate . ' 23:59:59');
+
+        $accesses = [];
+        $handle   = $this->openLogFile($logFile);
+        $lines    = 0;
+        $matched  = 0;
+
+        while (($line = $this->readLine($handle, $logFile)) !== false) {
+            $lines++;
+
+            $timestamp = $this->extractTimestamp($line, $logger);
+            if ($timestamp < $startOfDay || $timestamp > $endOfDay) {
+                continue;
+            }
+
+            $accessInfo = $this->matchAccessPattern($line);
+            if ($accessInfo === null) {
+                continue;
+            }
+
+            $matched++;
+            ['accessType' => $accessType, 'docId' => $rawDocId] = $accessInfo;
+
+            $docId = filter_var($rawDocId, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 9999999]]);
+            if ($docId === false) {
+                $logger->warning("Invalid docId '{$rawDocId}', skipping.");
+                continue;
+            }
+
+            $ipv4 = $this->extractIP($line);
+            if (filter_var($ipv4, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+                $logger->warning("Invalid IP '{$ipv4}', skipping.");
+                continue;
+            }
+
+            $accesses[] = [
+                'doc_id'      => $docId,
+                'ip'          => (int) sprintf('%u', ip2long($ipv4)),
+                'user_agent'  => $this->sanitizeUserAgent($this->extractUserAgent($line)),
+                'date_time'   => date('Y-m-d H:i:s', $timestamp),
+                'timestamp'   => $timestamp,
+                'access_type' => $accessType,
+            ];
+        }
+
+        $this->closeFile($handle, $logFile);
+
+        usort($accesses, static fn(array $a, array $b): int => $a['timestamp'] <=> $b['timestamp']);
+
+        $logger->info(sprintf('Scanned %d lines, matched %d accesses for %s.', $lines, $matched, $targetDate));
+
+        return $accesses;
+    }
+
+    /** Match a log line against article patterns; returns ['accessType', 'docId'] or null. */
+    private function matchAccessPattern(string $line): ?array
+    {
+        // notice pattern
+        if (preg_match('/GET \/articles\/(\d+) HTTP/', $line, $m)) {
+            return ['accessType' => 'notice', 'docId' => $m[1]];
+        }
+        // file download or preview
+        if (preg_match('/GET \/articles\/(\d+)\/(?:download|preview) HTTP/', $line, $m)) {
+            return ['accessType' => 'file', 'docId' => $m[1]];
+        }
+        return null;
+    }
+
+    private function extractTimestamp(string $line, Logger $logger): int
+    {
+        if (preg_match('/\[(\d{2}\/[A-Za-z]+\/\d{4}):(\d{2}:\d{2}:\d{2}) [+-]\d{4}\]/', $line, $m)) {
+            $dt = \DateTime::createFromFormat('d/M/Y H:i:s', $m[1] . ' ' . $m[2]);
+            if ($dt !== false) {
+                return $dt->getTimestamp();
+            }
+        }
+        $logger->warning('Could not extract timestamp from line; using current time.');
+        return time();
+    }
+
+    private function extractIP(string $line): string
+    {
+        if (preg_match('/^(\d{1,3}(?:\.\d{1,3}){3})/', $line, $m)) {
+            return $m[1];
+        }
+        return '';
+    }
+
+    private function extractUserAgent(string $line): string
+    {
+        // Combined Log Format: last quoted field is the User-Agent
+        preg_match_all('/"([^"]*)"/', $line, $m);
+        $parts = $m[1] ?? [];
+        return count($parts) >= 2 ? end($parts) : '';
+    }
+
+    private function sanitizeUserAgent(string $ua): string
+    {
+        $clean = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', '', $ua) ?? '';
+        return mb_substr($clean, 0, 2000, 'UTF-8');
+    }
+
+    // -------------------------------------------------------------------------
+    // Database insertion
+    // -------------------------------------------------------------------------
+
+    /**
+     * Bulk-insert article accesses into STAT_TEMP inside a transaction.
+     *
+     * @param array<int, array<string, mixed>> $accesses
+     * @throws \Exception on DB error (transaction is rolled back)
+     */
+    private function insertIntoStatTemp(array $accesses, SymfonyStyle $io, Logger $logger): int
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        if ($db === null) {
+            throw new \Exception('No database adapter available.');
+        }
+
+        $sql  = 'INSERT INTO STAT_TEMP (DOCID, IP, HTTP_USER_AGENT, DHIT, CONSULT) VALUES (?, ?, ?, ?, ?)';
+        $stmt = $db->prepare($sql);
+
+        $this->progressBar = $io->createProgressBar(count($accesses));
+        $this->progressBar->start();
+
+        $db->beginTransaction();
+        $inserted = 0;
+
+        try {
+            foreach ($accesses as $access) {
+                $stmt->execute([
+                    (int)    $access['doc_id'],
+                    (int)    $access['ip'],
+                    (string) $access['user_agent'],
+                    (string) $access['date_time'],
+                    (string) $access['access_type'],
+                ]);
+                $inserted++;
+                $this->progressBar->advance();
+            }
+            $db->commit();
+        } catch (\Exception $e) {
+            $db->rollBack();
+            $logger->error('Transaction rolled back: ' . $e->getMessage());
+            throw $e;
+        }
+
+        $this->progressBar->finish();
+        $io->newLine(2);
+
+        return $inserted;
+    }
+
+    // -------------------------------------------------------------------------
+    // STAT_PROCESSING_LOG
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return the list of journal rvcode values that have is_new_front_switched = 'yes'.
+     *
+     * @return string[]
+     */
+    private function fetchNewFrontRvcodes(Logger $logger): array
+    {
+        $db   = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $sql  = "SELECT CODE FROM REVIEW WHERE is_new_front_switched = 'yes' ORDER BY CODE";
+        $stmt = $db->prepare($sql);
+        $stmt->execute();
+        $codes = $stmt->fetchAll(\PDO::FETCH_COLUMN);
+        $logger->info(sprintf('Found %d journal(s) with is_new_front_switched = yes.', count($codes)));
+        return $codes;
+    }
+
+    private function isDateAlreadyProcessed(string $rvcode, string $date): bool
+    {
+        $db   = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $sql  = 'SELECT COUNT(*) FROM STAT_PROCESSING_LOG WHERE JOURNAL_CODE = ? AND PROCESSED_DATE = ?';
+        $stmt = $db->prepare($sql);
+        $stmt->execute([$rvcode, $date]);
+        return (int) $stmt->fetchColumn() > 0;
+    }
+
+    private function markDateAsProcessed(string $rvcode, string $date, string $filePath, int $records, string $status): void
+    {
+        $db  = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $sql = 'INSERT INTO STAT_PROCESSING_LOG (JOURNAL_CODE, PROCESSED_DATE, FILE_PATH, RECORDS_PROCESSED, STATUS)
+                VALUES (?, ?, ?, ?, ?)
+                ON DUPLICATE KEY UPDATE
+                    PROCESSED_AT      = CURRENT_TIMESTAMP,
+                    FILE_PATH         = VALUES(FILE_PATH),
+                    RECORDS_PROCESSED = VALUES(RECORDS_PROCESSED),
+                    STATUS            = VALUES(STATUS)';
+        $stmt = $db->prepare($sql);
+        $stmt->execute([$rvcode, $date, $filePath, $records, $status]);
+    }
+
+    // -------------------------------------------------------------------------
+    // File helpers (plain + gzip)
+    // -------------------------------------------------------------------------
+
+    /** @return resource */
+    private function openLogFile(string $logFile)
+    {
+        if (str_ends_with($logFile, '.gz')) {
+            $handle = gzopen($logFile, 'r');
+        } else {
+            $handle = fopen($logFile, 'r');
+        }
+
+        if ($handle === false) {
+            throw new \RuntimeException("Cannot open log file: {$logFile}");
+        }
+
+        return $handle;
+    }
+
+    /** @param resource $handle */
+    private function readLine($handle, string $logFile): string|false
+    {
+        return str_ends_with($logFile, '.gz') ? gzgets($handle) : fgets($handle);
+    }
+
+    /** @param resource $handle */
+    private function closeFile($handle, string $logFile): void
+    {
+        str_ends_with($logFile, '.gz') ? gzclose($handle) : fclose($handle);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bootstrap (identical pattern to ProcessStatTempCommand / GenerateDownloadKpiCommand)
+    // -------------------------------------------------------------------------
+
+    private function buildLogger(SymfonyStyle $io): Logger
+    {
+        $logger  = new Logger('importApacheLogs');
+        $logFile = EPISCIENCES_LOG_PATH . 'importApacheLogs_' . date('Y-m-d') . '.log';
+        $logDir  = dirname($logFile);
+
+        if (is_dir($logDir) && is_writable($logDir)) {
+            $logger->pushHandler(new StreamHandler($logFile, Logger::INFO));
+        }
+
+        if (!$io->isQuiet()) {
+            $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));
+        }
+
+        return $logger;
+    }
+
+    private function bootstrap(): void
+    {
+        // Guard against re-execution when multiple tests call execute() in the same process.
+        if (defined('REVIEW_TMP_PATH')) {
+            return;
+        }
+
+        if (!defined('APPLICATION_PATH')) {
+            define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
+        }
+        require_once __DIR__ . '/../public/const.php';
+        require_once __DIR__ . '/../public/bdd_const.php';
+
+        defineProtocol();
+        defineSimpleConstants();
+        defineSQLTableConstants();
+        defineApplicationConstants();
+        defineJournalConstants();
+
+        $libraries = [realpath(APPLICATION_PATH . '/../library')];
+        set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
+        require_once 'Zend/Application.php';
+
+        $application = new Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
+
+        $autoloader = Zend_Loader_Autoloader::getInstance();
+        $autoloader->setFallbackAutoloader(true);
+
+        $db = Zend_Db::factory('PDO_MYSQL', $application->getOption('resources')['db']['params']);
+        Zend_Db_Table::setDefaultAdapter($db);
+
+        Zend_Registry::set('metadataSources', Episciences_Paper_MetaDataSourcesManager::all(false));
+        Zend_Registry::set('Zend_Locale', new Zend_Locale('en'));
+    }
+}

--- a/scripts/console.php
+++ b/scripts/console.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/ImportSectionsCommand.php';
 require_once __DIR__ . '/ImportVolumesCommand.php';
 require_once __DIR__ . '/UpdateCounterRobotsListCommand.php';
 require_once __DIR__ . '/ProcessStatTempCommand.php';
+require_once __DIR__ . '/ImportApacheLogsCommand.php';
 require_once __DIR__ . '/UpdateGeoIpCommand.php';
 require_once __DIR__ . '/GenerateDownloadKpiCommand.php';
 
@@ -60,6 +61,7 @@ $application->add(new ImportVolumesCommand());
 
 // Stats commands
 $application->add(new UpdateCounterRobotsListCommand());
+$application->add(new ImportApacheLogsCommand());
 $application->add(new ProcessStatTempCommand());
 $application->add(new GenerateDownloadKpiCommand());
 

--- a/src/mysql/2025-08-24-stat-processing-log-table.sql
+++ b/src/mysql/2025-08-24-stat-processing-log-table.sql
@@ -1,0 +1,18 @@
+-- Statistics Processing Log Table
+-- Tracks which log files have been processed to prevent duplicates
+-- Created: 2025-08-24
+
+CREATE TABLE `STAT_PROCESSING_LOG` (
+  `ID` int UNSIGNED NOT NULL AUTO_INCREMENT,
+  `JOURNAL_CODE` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `PROCESSED_DATE` date NOT NULL,
+  `PROCESSED_AT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `FILE_PATH` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `RECORDS_PROCESSED` int UNSIGNED NOT NULL DEFAULT 0,
+  `STATUS` enum('success','error','partial') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'success',
+  PRIMARY KEY (`ID`),
+  UNIQUE KEY `unique_journal_date` (`JOURNAL_CODE`, `PROCESSED_DATE`),
+  KEY `idx_journal_code` (`JOURNAL_CODE`),
+  KEY `idx_processed_date` (`PROCESSED_DATE`),
+  KEY `idx_processed_at` (`PROCESSED_AT`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Tracks processed statistics log files to prevent duplicates';

--- a/tests/integration/scripts/ImportApacheLogsIntegrationTest.php
+++ b/tests/integration/scripts/ImportApacheLogsIntegrationTest.php
@@ -1,0 +1,234 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+
+require_once __DIR__ . '/../../../scripts/ImportApacheLogsCommand.php';
+
+/**
+ * Integration tests for ImportApacheLogsCommand log-file parsing.
+ *
+ * These tests exercise the parsing pipeline end-to-end (file → accesses array)
+ * without touching the database.
+ */
+class ImportApacheLogsIntegrationTest extends TestCase
+{
+    private ImportApacheLogsCommand $command;
+    private string $tempLogDir;
+    private Logger $nullLogger;
+
+    protected function setUp(): void
+    {
+        $this->tempLogDir = sys_get_temp_dir() . '/epi_integration_test_' . uniqid();
+        mkdir($this->tempLogDir, 0755, true);
+
+        $this->command = new ImportApacheLogsCommand();
+        $prop = (new ReflectionClass($this->command))->getProperty('logsBasePath');
+        $prop->setAccessible(true);
+        $prop->setValue($this->command, $this->tempLogDir);
+
+        $this->nullLogger = new Logger('test');
+        $this->nullLogger->pushHandler(new NullHandler());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempLogDir);
+    }
+
+    // -------------------------------------------------------------------------
+    // collectArticleAccesses
+    // -------------------------------------------------------------------------
+
+    public function testParsesNoticeDownloadAndPreview(): void
+    {
+        $logPath = $this->writeLog([
+            '192.168.1.1 - - [01/Jan/2023:10:30:00 +0100] "GET /articles/123 HTTP/1.1" 200 1 "-" "UA-A"',
+            '192.168.1.2 - - [01/Jan/2023:10:31:00 +0100] "GET /articles/456/download HTTP/1.1" 200 1 "-" "UA-B"',
+            '192.168.1.3 - - [01/Jan/2023:10:32:00 +0100] "GET /articles/789/preview HTTP/1.1" 200 1 "-" "UA-C"',
+            '192.168.1.4 - - [01/Jan/2023:10:33:00 +0100] "GET /other/path HTTP/1.1" 200 1 "-" "UA-D"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(3, $results);
+        $this->assertSame(123,      $results[0]['doc_id']);
+        $this->assertSame('notice', $results[0]['access_type']);
+        $this->assertSame(456,      $results[1]['doc_id']);
+        $this->assertSame('file',   $results[1]['access_type']);
+        $this->assertSame(789,      $results[2]['doc_id']);
+        $this->assertSame('file',   $results[2]['access_type']);
+    }
+
+    public function testGzippedFileTransparentlyRead(): void
+    {
+        $gzPath = $this->tempLogDir . '/test.access_log.gz';
+        $gz     = gzopen($gzPath, 'w');
+        gzwrite($gz, '192.168.1.1 - - [01/Jan/2023:10:30:00 +0100] "GET /articles/123 HTTP/1.1" 200 1 "-" "UA"' . "\n");
+        gzclose($gz);
+
+        $results = $this->collect($gzPath, '2023-01-01');
+
+        $this->assertCount(1, $results);
+        $this->assertSame(123, $results[0]['doc_id']);
+    }
+
+    public function testFiltersEntriesOutsideTargetDate(): void
+    {
+        $logPath = $this->writeLog([
+            '192.168.1.1 - - [31/Dec/2022:23:59:59 +0100] "GET /articles/111 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.2 - - [01/Jan/2023:00:00:00 +0100] "GET /articles/222 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.3 - - [01/Jan/2023:12:00:00 +0100] "GET /articles/333 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.4 - - [01/Jan/2023:23:59:59 +0100] "GET /articles/444 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.5 - - [02/Jan/2023:00:00:01 +0100] "GET /articles/555 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(3, $results);
+        $this->assertSame(222, $results[0]['doc_id']);
+        $this->assertSame(333, $results[1]['doc_id']);
+        $this->assertSame(444, $results[2]['doc_id']);
+    }
+
+    public function testSkipsInvalidDocIds(): void
+    {
+        $logPath = $this->writeLog([
+            '192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/0 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.2 - - [01/Jan/2023:10:01:00 +0100] "GET /articles/10000000 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.3 - - [01/Jan/2023:10:02:00 +0100] "GET /articles/123 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(1, $results);
+        $this->assertSame(123, $results[0]['doc_id']);
+    }
+
+    public function testSkipsInvalidIpAddresses(): void
+    {
+        $logPath = $this->writeLog([
+            'not-an-ip - - [01/Jan/2023:10:00:00 +0100] "GET /articles/111 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.1 - - [01/Jan/2023:10:01:00 +0100] "GET /articles/222 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(1, $results);
+        $this->assertSame(222, $results[0]['doc_id']);
+    }
+
+    public function testResultsSortedByTimestamp(): void
+    {
+        // Lines in reverse chronological order in the file
+        $logPath = $this->writeLog([
+            '192.168.1.3 - - [01/Jan/2023:10:03:00 +0100] "GET /articles/333 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.1 - - [01/Jan/2023:10:01:00 +0100] "GET /articles/111 HTTP/1.1" 200 1 "-" "UA"',
+            '192.168.1.2 - - [01/Jan/2023:10:02:00 +0100] "GET /articles/222 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertSame(111, $results[0]['doc_id']);
+        $this->assertSame(222, $results[1]['doc_id']);
+        $this->assertSame(333, $results[2]['doc_id']);
+    }
+
+    public function testUserAgentControlCharsRemoved(): void
+    {
+        $logPath = $this->writeLog([
+            '192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/123 HTTP/1.1" 200 1 "-" "Mozilla' . "\x00\x1F" . '/5.0"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(1, $results);
+        $this->assertStringNotContainsString("\x00", $results[0]['user_agent']);
+        $this->assertStringNotContainsString("\x1F", $results[0]['user_agent']);
+        $this->assertStringContainsString('Mozilla', $results[0]['user_agent']);
+    }
+
+    public function testIpConvertedToUnsignedInt(): void
+    {
+        $logPath = $this->writeLog([
+            '1.2.3.4 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/123 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-01-01');
+
+        $this->assertCount(1, $results);
+        $this->assertSame((int) sprintf('%u', ip2long('1.2.3.4')), $results[0]['ip']);
+    }
+
+    public function testDateTimeFormattedCorrectly(): void
+    {
+        $logPath = $this->writeLog([
+            '1.2.3.4 - - [15/Mar/2023:14:30:45 +0100] "GET /articles/1 HTTP/1.1" 200 1 "-" "UA"',
+        ]);
+
+        $results = $this->collect($logPath, '2023-03-15');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('2023-03-15 14:30:45', $results[0]['date_time']);
+    }
+
+    public function testEmptyFileReturnsNoAccesses(): void
+    {
+        $logPath = $this->writeLog([]);
+        $results = $this->collect($logPath, '2023-01-01');
+        $this->assertCount(0, $results);
+    }
+
+    // -------------------------------------------------------------------------
+    // Timestamp extraction
+    // -------------------------------------------------------------------------
+
+    public function testExtractTimestampValidLine(): void
+    {
+        $line      = '1.2.3.4 - - [01/Jan/2023:10:30:45 +0100] "GET /articles/1 HTTP/1.1" 200 0';
+        $timestamp = $this->invokePrivate('extractTimestamp', [$line, $this->nullLogger]);
+        $this->assertSame('2023-01-01 10:30:45', date('Y-m-d H:i:s', $timestamp));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** @param string[] $lines */
+    private function writeLog(array $lines): string
+    {
+        $path = $this->tempLogDir . '/test_' . uniqid() . '.access_log';
+        file_put_contents($path, implode("\n", $lines) . "\n");
+        return $path;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function collect(string $logPath, string $date): array
+    {
+        $m = (new ReflectionClass($this->command))->getMethod('collectArticleAccesses');
+        $m->setAccessible(true);
+        return $m->invoke($this->command, $logPath, $date, $this->nullLogger);
+    }
+
+    /** @param mixed[] $args */
+    private function invokePrivate(string $method, array $args): mixed
+    {
+        $m = (new ReflectionClass($this->command))->getMethod($method);
+        $m->setAccessible(true);
+        return $m->invokeArgs($this->command, $args);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff((array) scandir($dir), ['.', '..']) as $file) {
+            $p = "$dir/$file";
+            is_dir($p) ? $this->removeDirectory($p) : unlink($p);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/unit/scripts/ImportApacheLogsCommandTest.php
+++ b/tests/unit/scripts/ImportApacheLogsCommandTest.php
@@ -1,0 +1,354 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Monolog\Logger;
+use Monolog\Handler\NullHandler;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+require_once __DIR__ . '/../../../scripts/ImportApacheLogsCommand.php';
+
+class ImportApacheLogsCommandTest extends TestCase
+{
+    private ImportApacheLogsCommand $command;
+    private CommandTester $commandTester;
+    private string $tempLogDir;
+
+    protected function setUp(): void
+    {
+        $this->tempLogDir = sys_get_temp_dir() . '/epi_test_logs_' . uniqid();
+        mkdir($this->tempLogDir, 0755, true);
+
+        $application = new Application();
+        $application->add(new ImportApacheLogsCommand());
+        $this->command = $application->find('stats:import-logs');
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempLogDir);
+    }
+
+    // -------------------------------------------------------------------------
+    // Option validation
+    // -------------------------------------------------------------------------
+
+    public function testFailsWithNoJournalOption(): void
+    {
+        $this->commandTester->execute([]);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('--rvcode', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWhenBothRvcodeAndAllProvided(): void
+    {
+        $this->commandTester->execute(['--rvcode' => 'mbj', '--all' => true]);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('mutually exclusive', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithInvalidDate(): void
+    {
+        $this->commandTester->execute(['--rvcode' => 'test', '--date' => 'not-a-date']);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Invalid date format', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWhenStartDateAfterEndDate(): void
+    {
+        $this->commandTester->execute([
+            '--rvcode'     => 'test',
+            '--start-date' => '2023-01-10',
+            '--end-date'   => '2023-01-01',
+        ]);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('before or equal to', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithMultipleDateOptions(): void
+    {
+        $this->commandTester->execute([
+            '--rvcode' => 'test',
+            '--date'   => '2023-01-01',
+            '--month'  => '2023-01',
+        ]);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('only one of', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithYearAndMonthTogether(): void
+    {
+        $this->commandTester->execute([
+            '--rvcode' => 'test',
+            '--year'   => '2023',
+            '--month'  => '2023-01',
+        ]);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('only one of', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithInvalidMonthFormat(): void
+    {
+        $this->commandTester->execute(['--rvcode' => 'test', '--month' => '2023/01']);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Invalid --month format', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithInvalidYearFormat(): void
+    {
+        $this->commandTester->execute(['--rvcode' => 'test', '--year' => '23']);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('Invalid --year format', $this->commandTester->getDisplay());
+    }
+
+    public function testFailsWithOnlyStartDate(): void
+    {
+        $this->commandTester->execute(['--rvcode' => 'test', '--start-date' => '2023-01-01']);
+        $this->assertSame(1, $this->commandTester->getStatusCode());
+        $this->assertStringContainsString('both be provided', $this->commandTester->getDisplay());
+    }
+
+    // -------------------------------------------------------------------------
+    // Date range helpers (via reflection)
+    // -------------------------------------------------------------------------
+
+    public function testMonthRangeJanuary(): void
+    {
+        $dates = $this->invokePrivate('monthRange', ['2023-01']);
+        $this->assertCount(31, $dates);
+        $this->assertSame('2023-01-01', $dates[0]->format('Y-m-d'));
+        $this->assertSame('2023-01-31', $dates[30]->format('Y-m-d'));
+    }
+
+    public function testMonthRangeFebruaryNonLeap(): void
+    {
+        $dates = $this->invokePrivate('monthRange', ['2023-02']);
+        $this->assertCount(28, $dates);
+        $this->assertSame('2023-02-28', $dates[27]->format('Y-m-d'));
+    }
+
+    public function testMonthRangeFebruaryLeap(): void
+    {
+        $dates = $this->invokePrivate('monthRange', ['2024-02']);
+        $this->assertCount(29, $dates);
+        $this->assertSame('2024-02-29', $dates[28]->format('Y-m-d'));
+    }
+
+    public function testYearRangeNonLeap(): void
+    {
+        $dates = $this->invokePrivate('yearRange', ['2023']);
+        $this->assertCount(365, $dates);
+        $this->assertSame('2023-01-01', $dates[0]->format('Y-m-d'));
+        $this->assertSame('2023-12-31', $dates[364]->format('Y-m-d'));
+    }
+
+    public function testYearRangeLeap(): void
+    {
+        $dates = $this->invokePrivate('yearRange', ['2024']);
+        $this->assertCount(366, $dates);
+        $this->assertSame('2024-12-31', $dates[365]->format('Y-m-d'));
+    }
+
+    public function testDateRangeSingleDay(): void
+    {
+        $dates = $this->invokePrivate('dateRange', ['2023-03-15', '2023-03-15']);
+        $this->assertCount(1, $dates);
+        $this->assertSame('2023-03-15', $dates[0]->format('Y-m-d'));
+    }
+
+    public function testDateRangeMultipleDays(): void
+    {
+        $dates = $this->invokePrivate('dateRange', ['2023-01-01', '2023-01-03']);
+        $this->assertCount(3, $dates);
+        $this->assertSame('2023-01-02', $dates[1]->format('Y-m-d'));
+    }
+
+    // -------------------------------------------------------------------------
+    // User-agent sanitization
+    // -------------------------------------------------------------------------
+
+    public function testSanitizeUserAgentNormal(): void
+    {
+        $result = $this->invokePrivate('sanitizeUserAgent', ['Mozilla/5.0 (Windows NT 10.0)']);
+        $this->assertSame('Mozilla/5.0 (Windows NT 10.0)', $result);
+    }
+
+    public function testSanitizeUserAgentStripsControlChars(): void
+    {
+        $result = $this->invokePrivate('sanitizeUserAgent', ["Mozilla\x00\x08\x1F/5.0"]);
+        $this->assertSame('Mozilla/5.0', $result);
+    }
+
+    public function testSanitizeUserAgentTruncatesAt2000(): void
+    {
+        $result = $this->invokePrivate('sanitizeUserAgent', [str_repeat('A', 2100)]);
+        $this->assertSame(2000, mb_strlen($result));
+    }
+
+    // -------------------------------------------------------------------------
+    // Log file path resolution
+    // -------------------------------------------------------------------------
+
+    public function testBuildLogFilePathReturnsNullWhenMissing(): void
+    {
+        $command = $this->commandWithLogsPath($this->tempLogDir);
+        $result  = $this->invokePrivateOn($command, 'buildLogFilePath', ['test.episciences.org', new DateTime('2023-01-01')]);
+        $this->assertNull($result);
+    }
+
+    public function testBuildLogFilePathFindsPlainFile(): void
+    {
+        $command  = $this->commandWithLogsPath($this->tempLogDir);
+        $logPath  = $this->tempLogDir . '/test.episciences.org/2023/01/01-test.episciences.org.access_log';
+        $this->mkfile($logPath, 'x');
+
+        $result = $this->invokePrivateOn($command, 'buildLogFilePath', ['test.episciences.org', new DateTime('2023-01-01')]);
+        $this->assertSame($logPath, $result);
+    }
+
+    public function testBuildLogFilePathFindsGzFile(): void
+    {
+        $command = $this->commandWithLogsPath($this->tempLogDir);
+        $gzPath  = $this->tempLogDir . '/test.episciences.org/2023/01/01-test.episciences.org.access_log.gz';
+        mkdir(dirname($gzPath), 0755, true);
+        $gz = gzopen($gzPath, 'w');
+        gzwrite($gz, 'x');
+        gzclose($gz);
+
+        $result = $this->invokePrivateOn($command, 'buildLogFilePath', ['test.episciences.org', new DateTime('2023-01-01')]);
+        $this->assertSame($gzPath, $result);
+    }
+
+    public function testBuildLogFilePathPrefersPlainOverGz(): void
+    {
+        $command = $this->commandWithLogsPath($this->tempLogDir);
+        $logPath = $this->tempLogDir . '/test.episciences.org/2023/01/01-test.episciences.org.access_log';
+        $gzPath  = $logPath . '.gz';
+        $this->mkfile($logPath, 'x');
+        // Directory already created by mkfile(); no need to mkdir again.
+        $gz = gzopen($gzPath, 'w');
+        gzwrite($gz, 'x');
+        gzclose($gz);
+
+        $result = $this->invokePrivateOn($command, 'buildLogFilePath', ['test.episciences.org', new DateTime('2023-01-01')]);
+        $this->assertSame($logPath, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Pattern matching
+    // -------------------------------------------------------------------------
+
+    /** @dataProvider provideMatchingLines */
+    public function testMatchAccessPatternMatches(string $line, string $expectedType, int $expectedDocId): void
+    {
+        $result = $this->invokePrivate('matchAccessPattern', [$line]);
+        $this->assertNotNull($result);
+        $this->assertSame($expectedType, $result['accessType']);
+        $this->assertSame((string) $expectedDocId, $result['docId']);
+    }
+
+    /** @return array<string, array{string, string, int}> */
+    public static function provideMatchingLines(): array
+    {
+        return [
+            'notice'   => ['192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/123 HTTP/1.1" 200 1', 'notice', 123],
+            'download' => ['192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/456/download HTTP/1.1" 200 1', 'file', 456],
+            'preview'  => ['192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/789/preview HTTP/1.1" 200 1', 'file', 789],
+        ];
+    }
+
+    /** @dataProvider provideNonMatchingLines */
+    public function testMatchAccessPatternIgnores(string $line): void
+    {
+        $result = $this->invokePrivate('matchAccessPattern', [$line]);
+        $this->assertNull($result);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function provideNonMatchingLines(): array
+    {
+        return [
+            'other path'   => ['192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "GET /other/path HTTP/1.1" 200 1'],
+            'POST request' => ['192.168.1.1 - - [01/Jan/2023:10:00:00 +0100] "POST /articles/123 HTTP/1.1" 200 1'],
+            'empty line'   => [''],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // IP and User-Agent extraction
+    // -------------------------------------------------------------------------
+
+    public function testExtractIPValid(): void
+    {
+        $line = '192.168.1.100 - - [01/Jan/2023:10:30:45 +0100] "GET /articles/1 HTTP/1.1" 200 0';
+        $ip   = $this->invokePrivate('extractIP', [$line]);
+        $this->assertSame('192.168.1.100', $ip);
+    }
+
+    public function testExtractIPReturnsEmptyOnInvalidLine(): void
+    {
+        $ip = $this->invokePrivate('extractIP', ['not-an-ip line']);
+        $this->assertSame('', $ip);
+    }
+
+    public function testExtractUserAgentCombinedFormat(): void
+    {
+        $line = '1.2.3.4 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/1 HTTP/1.1" 200 0 "http://ref.com" "Mozilla/5.0 (Test)"';
+        $ua   = $this->invokePrivate('extractUserAgent', [$line]);
+        $this->assertSame('Mozilla/5.0 (Test)', $ua);
+    }
+
+    public function testExtractUserAgentReturnsEmptyWhenAbsent(): void
+    {
+        $line = '1.2.3.4 - - [01/Jan/2023:10:00:00 +0100] "GET /articles/1 HTTP/1.1" 200 0';
+        $ua   = $this->invokePrivate('extractUserAgent', [$line]);
+        $this->assertSame('', $ua);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** @param mixed[] $args */
+    private function invokePrivate(string $method, array $args = []): mixed
+    {
+        return $this->invokePrivateOn(new ImportApacheLogsCommand(), $method, $args);
+    }
+
+    /** @param mixed[] $args */
+    private function invokePrivateOn(object $obj, string $method, array $args = []): mixed
+    {
+        $m = (new ReflectionClass($obj))->getMethod($method);
+        $m->setAccessible(true);
+        return $m->invokeArgs($obj, $args);
+    }
+
+    private function commandWithLogsPath(string $path): ImportApacheLogsCommand
+    {
+        $command = new ImportApacheLogsCommand();
+        $prop    = (new ReflectionClass($command))->getProperty('logsBasePath');
+        $prop->setAccessible(true);
+        $prop->setValue($command, $path);
+        return $command;
+    }
+
+    private function mkfile(string $path, string $content): void
+    {
+        mkdir(dirname($path), 0755, true);
+        file_put_contents($path, $content);
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (array_diff((array) scandir($dir), ['.', '..']) as $file) {
+            $p = "$dir/$file";
+            is_dir($p) ? $this->removeDirectory($p) : unlink($p);
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `ImportApacheLogsCommand` (`stats:import-logs`), a Symfony Console command that parses Apache access logs and feeds article visits into `STAT_TEMP`
- Migrated from the legacy `UpdateStatistics.php` (never merged, branch `staging-feature-add-stats-options`, last modified Aug 2025) to the standard `*Command.php` pattern used by all other console commands
- Registered in `scripts/console.php` alongside `stats:process` and `stats:download-kpi`

## Features

- Parses `/articles/{id}` (notice) and `/articles/{id}/download|preview` (file) URL patterns
- Supports plain and `.gz` compressed log files transparently
- Duplicate prevention via `STAT_PROCESSING_LOG` table (`--force` to bypass)
- Date selection: `--date`, `--month`, `--year`, `--start-date`/`--end-date`
- `--all`: process all journals with `is_new_front_switched = 'yes'` in one run (designed for cron)
- `--logs-path`: override the base Apache log directory

## Cron usage

```
0 5 * * * php scripts/console.php stats:import-logs --all
```

## Database prerequisite

Run migration before deploying:
```sql
-- src/mysql/2025-08-24-stat-processing-log-table.sql
```

## Changes

- `scripts/ImportApacheLogsCommand.php` — new command (replaces `UpdateStatistics.php`)
- `scripts/console.php` — command registered
- `Makefile` — `import-apache-logs` target (replaces `update-statistics`)
- `src/mysql/2025-08-24-stat-processing-log-table.sql` — `STAT_PROCESSING_LOG` table
- `tests/unit/scripts/ImportApacheLogsCommandTest.php`
- `tests/integration/scripts/ImportApacheLogsIntegrationTest.php`
- `docs/STATISTICS_UPDATE_README.md`