### PR TITLE
feat(solr): add ref_pps core and PPS import pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ download-ref-pps: ## Download PPS CSV file from IRIT (optional: force=1)
 	@echo "Downloading PPS data..."
 	@$(DOCKER_COMPOSE) exec -u $(CNTR_APP_USER) -w $(CNTR_APP_DIR) $(CNTR_NAME_PHP) \
 		php scripts/console.php download:ref-pps $(if $(filter 1,$(force)),--force)
+	@echo "Download complete!"
 
 # =============================================================================
 # Development Setup Commands

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SOLR_COLLECTION_CONFIG := /opt/configsets/episciences
 # PHONY Targets
 # =============================================================================
 .PHONY: help build up down status logs restart clean clean-mysql
-.PHONY: collection index dev-setup setup-logs copy-config generate-users init-dev-users create-bot-user init-data-dir yarn-encore-dev
+.PHONY: collection collection-ref-pps index import-ref-pps download-ref-pps dev-setup setup-logs copy-config generate-users init-dev-users create-bot-user init-data-dir yarn-encore-dev
 .PHONY: send-mails composer-install composer-update yarn-encore-production
 .PHONY: restart-httpd restart-php merge-pdf-volume
 .PHONY: get-classification-msc get-classification-jel can-i-use-update
@@ -55,7 +55,7 @@ help: ## Display this help message
 	@grep -h -E '^(wait-for-db|load-db.*|generate-users|shell-mysql.*|backup-db):.*##' $(MAKEFILE_LIST) 2>/dev/null | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}' || echo "  No database commands found"
 	@echo ""
 	@echo "Solr Commands:"
-	@grep -E '^(collection|index):.*##' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
+	@grep -E '^(collection|collection-ref-pps|index|import-ref-pps|download-ref-pps):.*##' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Development Commands:"
 	@grep -E '^(dev-setup|composer|yarn|enter):.*##' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-25s %s\n", $$1, $$2}'
@@ -151,8 +151,8 @@ clean-mysql: down ## Remove all MySQL volumes (WARNING: This will delete all dat
 # =============================================================================
 # Solr Commands
 # =============================================================================
-collection: up ## Create Solr collection after starting containers
-	@echo "Setting up Solr collection..."
+collection: up ## Create Solr collection 'episciences' after starting containers
+	@echo "Setting up Solr collection 'episciences'..."
 	@echo "Waiting for Solr container to be ready..."
 	@until $(DOCKER_COMPOSE) exec $(CNTR_NAME_SOLR) curl -s http://localhost:8983/solr >/dev/null 2>&1; do \
 		echo "Waiting for Solr..."; \
@@ -163,10 +163,36 @@ collection: up ## Create Solr collection after starting containers
 		echo "Collection may already exist, continuing..."
 	@echo "Solr collection setup complete!"
 
+collection-ref-pps: up ## Create Solr core 'ref_pps'
+	@echo "Setting up Solr core 'ref_pps'..."
+	@echo "Waiting for Solr container to be ready..."
+	@until $(DOCKER_COMPOSE) exec $(CNTR_NAME_SOLR) curl -s http://localhost:8983/solr >/dev/null 2>&1; do \
+		echo "Waiting for Solr..."; \
+		sleep 2; \
+	done
+	@echo "Solr is ready. Creating 'ref_pps' core..."
+	@# We need to ensure the config directory exists in the container or use a configset
+	@$(DOCKER_COMPOSE) exec -u 0:0 $(CNTR_NAME_SOLR) mkdir -p /opt/solr/server/solr/configsets/ref_pps
+	@$(DOCKER_COMPOSE) cp src/solr/ref_pps/conf $(CNTR_NAME_SOLR):/opt/solr/server/solr/configsets/ref_pps/
+	@$(DOCKER_COMPOSE) exec $(CNTR_NAME_SOLR) solr create_core -c ref_pps -d /opt/solr/server/solr/configsets/ref_pps/conf -s http://localhost:8983 || \
+		echo "Core may already exist, continuing..."
+	@echo "Solr core ref_pps setup complete!"
+
 index: ## Index content into Solr  [V=1 verbose] [D=1 debug]
 	@echo "Indexing content into Solr..."
 	@$(DOCKER_COMPOSE) exec -u $(CNTR_APP_USER) -w $(CNTR_APP_DIR) $(CNTR_NAME_PHP) php scripts/solr/solrJob.php -D % $(if $(V),-v) $(if $(D),-d)
 	@echo "Indexing complete!"
+
+import-ref-pps: ## Import PPS data from CSV into Solr core ref_pps (optional: csv-file=PATH)
+	@echo "Importing PPS data into Solr..."
+	@$(DOCKER_COMPOSE) exec -u $(CNTR_APP_USER) -w $(CNTR_APP_DIR) $(CNTR_NAME_PHP) \
+		php scripts/console.php import:ref-pps $(if $(csv-file),$(csv-file))
+	@echo "Import complete!"
+
+download-ref-pps: ## Download PPS CSV file from IRIT (optional: force=1)
+	@echo "Downloading PPS data..."
+	@$(DOCKER_COMPOSE) exec -u $(CNTR_APP_USER) -w $(CNTR_APP_DIR) $(CNTR_NAME_PHP) \
+		php scripts/console.php download:ref-pps $(if $(filter 1,$(force)),--force)
 
 # =============================================================================
 # Development Setup Commands

--- a/docs/console-commands.md
+++ b/docs/console-commands.md
@@ -35,6 +35,8 @@ php scripts/console.php <command> --help
 | [`zbjats:zip`](#zbjatszip) | Package PDF + zbJATS XML into a ZIP archive per volume |
 | [`import:sections`](#importsections) | Import journal sections from a CSV file |
 | [`import:volumes`](#importvolumes) | Import journal volumes from a CSV file |
+| [`import:ref-pps`](#importref-pps) | Import PPS data from a CSV file into Solr |
+| [`download:ref-pps`](#downloadref-pps) | Download the PPS CSV file from IRIT |
 | [`stats:import-logs`](#statsimport-logs) | Parse Apache access logs and insert article visits into `STAT_TEMP` |
 | [`stats:download-kpi`](#statsdownload-kpi) | Aggregate download KPIs for all published articles and write a JSON file |
 | [`stats:update-robots-list`](#statsupdate-robots-list) | Download the COUNTER Robots list for bot detection |
@@ -321,6 +323,34 @@ php scripts/console.php import:volumes [options]
 | `--rvid <id>` | Journal RVID (integer) |
 | `--csv-file <path>` | Path to the CSV file containing volumes data |
 | `--dry-run` | Simulate the import without writing to the database |
+
+---
+
+### `import:ref-pps`
+
+Imports PPS data from a CSV file into the `ref_pps` Solr core.
+
+```bash
+php scripts/console.php import:ref-pps [csv-file]
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `csv-file` | `data/ref_pps/pps-current.csv` | Path to the CSV file to import |
+
+---
+
+### `download:ref-pps`
+
+Downloads the PPS CSV file from IRIT. Includes a 48h limit check and keeps timestamped backups of previous versions.
+
+```bash
+php scripts/console.php download:ref-pps [options]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--force` / `-f` | Force download even if the 48h limit is not reached |
 
 ---
 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -119,6 +119,8 @@ docker compose exec -u www-data php php scripts/console.php enrichment:creators 
 | **zbjats** | `zbjats:zip` | Package PDF + zbJATS XML files into a ZIP archive |
 | **import** | `import:sections` | Import journal sections from a CSV file |
 | | `import:volumes` | Import journal volumes from a CSV file |
+| | `import:ref-pps` | Import PPS data from a CSV file into Solr |
+| | `download:ref-pps` | Download the PPS CSV file from IRIT |
 | **stats** | `stats:import-logs` | Parse Apache access logs into `STAT_TEMP` |
 | | `stats:download-kpi` | Aggregate download KPIs and write `data/kpi_downloads.json` |
 | | `stats:update-robots-list` | Download the COUNTER Robots list for bot detection |

--- a/scripts/DownloadRefPpsCommand.php
+++ b/scripts/DownloadRefPpsCommand.php
@@ -12,15 +12,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Symfony Console command: download the PPS CSV file from IRIT.
  *
- * Downloads the CSV, handles the 48h limit, and keeps previous versions.
+ * Downloads the CSV, handles the 48h rate limit, and keeps timestamped backups.
  */
 class DownloadRefPpsCommand extends Command
 {
     protected static $defaultName = 'download:ref-pps';
 
     private const URL = 'https://dbrech.irit.fr/pls/apex/f?p=9999:3::CSV::::';
-    private const DOWNLOAD_DIR = 'data/ref_pps';
-    private const CURRENT_FILE = 'data/ref_pps/pps-current.csv';
     private const LIMIT_HOURS = 48;
 
     protected function configure(): void
@@ -32,20 +30,24 @@ class DownloadRefPpsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $force = (bool)$input->getOption('force');
+        $io    = new SymfonyStyle($input, $output);
+        $force = (bool) $input->getOption('force');
 
-        if (!is_dir(self::DOWNLOAD_DIR)) {
-            mkdir(self::DOWNLOAD_DIR, 0755, true);
+        $downloadDir = dirname(__DIR__) . '/data/ref_pps';
+        $currentFile = $downloadDir . '/pps-current.csv';
+
+        if (!is_dir($downloadDir)) {
+            if (!mkdir($downloadDir, 0755, true) && !is_dir($downloadDir)) {
+                $io->error(sprintf('Cannot create download directory "%s". Check filesystem permissions.', $downloadDir));
+                return Command::FAILURE;
+            }
         }
 
-        if (!$force && file_exists(self::CURRENT_FILE)) {
-            $lastDownload = filemtime(self::CURRENT_FILE);
-            $hoursSinceLast = (time() - $lastDownload) / 3600;
-
-            if ($hoursSinceLast < self::LIMIT_HOURS) {
+        if (!$force && file_exists($currentFile)) {
+            $hoursSinceLast = $this->hoursSince((int) filemtime($currentFile));
+            if ($this->isRateLimited($hoursSinceLast)) {
                 $io->note(sprintf(
-                    "The last download was %.1f hours ago. The limit is %d hours. Use --force to override.",
+                    'The last download was %.1f hours ago. The limit is %d hours. Use --force to override.',
                     $hoursSinceLast,
                     self::LIMIT_HOURS
                 ));
@@ -53,56 +55,90 @@ class DownloadRefPpsCommand extends Command
             }
         }
 
-        $io->title("Downloading PPS CSV from IRIT");
+        $io->title('Downloading PPS CSV from IRIT');
 
+        $tempFile = null;
         try {
             $client = new Client([
                 'timeout' => 1200, // 20 minutes timeout for large CSV export
-                'verify' => true,
-                'headers' => [
-                    'User-Agent' => 'Mozilla/5.0 (Episciences-GPL Download Script)',
-                ]
+                'verify'  => true,
+                'headers' => ['User-Agent' => 'Mozilla/5.0 (Episciences-GPL Download Script)'],
             ]);
 
-            $tempFile = self::DOWNLOAD_DIR . '/pps-download-' . bin2hex(random_bytes(8)) . '.tmp';
-            
-            $io->text("Fetching: " . self::URL . " (this may take up to 10-15 minutes)");
-            
-            $client->get(self::URL, [
-                'sink' => $tempFile,
-            ]);
+            $tempFile = $downloadDir . '/pps-download-' . bin2hex(random_bytes(8)) . '.tmp';
+            $io->text('Fetching: ' . self::URL . ' (this may take up to 20 minutes)');
+            $client->get(self::URL, ['sink' => $tempFile]);
 
-            if (file_exists(self::CURRENT_FILE)) {
-                // Check if file content changed (MD5 comparison)
-                if (md5_file($tempFile) === md5_file(self::CURRENT_FILE)) {
+            if (file_exists($currentFile)) {
+                $newHash     = md5_file($tempFile);
+                $currentHash = md5_file($currentFile);
+
+                if ($newHash === false || $currentHash === false) {
+                    $io->error('Cannot read file(s) for MD5 comparison. Check permissions.');
+                    unlink($tempFile);
+                    $tempFile = null;
+                    return Command::FAILURE;
+                }
+
+                if ($newHash === $currentHash) {
                     $io->info("The file hasn't changed. Skipping versioning.");
                     unlink($tempFile);
+                    $tempFile = null;
                     // Update mtime to reset the 48h clock even if content is same
-                    touch(self::CURRENT_FILE);
+                    touch($currentFile);
                     return Command::SUCCESS;
                 }
 
-                // Keep previous version
-                $timestamp = date('Ymd_His', filemtime(self::CURRENT_FILE));
-                $backupFile = self::DOWNLOAD_DIR . '/pps-' . $timestamp . '.csv';
-                rename(self::CURRENT_FILE, $backupFile);
-                $io->note("Previous version saved to: " . $backupFile);
+                $backupFile = $this->buildBackupPath($downloadDir, (int) filemtime($currentFile));
+                if (!rename($currentFile, $backupFile)) {
+                    $io->error(sprintf('Failed to archive previous version to: %s', $backupFile));
+                    unlink($tempFile);
+                    $tempFile = null;
+                    return Command::FAILURE;
+                }
+                $io->note('Previous version saved to: ' . $backupFile);
             }
 
-            rename($tempFile, self::CURRENT_FILE);
-            $io->success("New version downloaded successfully: " . self::CURRENT_FILE);
+            if (!rename($tempFile, $currentFile)) {
+                $io->error(sprintf('Failed to install downloaded file as "%s".', $currentFile));
+                if (isset($backupFile) && file_exists($backupFile) && !file_exists($currentFile)) {
+                    rename($backupFile, $currentFile);
+                }
+                return Command::FAILURE;
+            }
+            $tempFile = null;
+
+            $io->success('New version downloaded successfully: ' . $currentFile);
 
         } catch (GuzzleException $e) {
-            $io->error("Download failed: " . $e->getMessage());
-            if (isset($tempFile) && file_exists($tempFile)) {
+            $io->error('Download failed: ' . $e->getMessage());
+            if ($tempFile !== null && file_exists($tempFile)) {
                 unlink($tempFile);
             }
             return Command::FAILURE;
-        } catch (\Exception $e) {
-            $io->error("An error occurred: " . $e->getMessage());
+        } catch (\Throwable $e) {
+            $io->error(sprintf('Unexpected %s: %s', get_class($e), $e->getMessage()));
+            if ($tempFile !== null && file_exists($tempFile)) {
+                unlink($tempFile);
+            }
             return Command::FAILURE;
         }
 
         return Command::SUCCESS;
+    }
+
+    public function isRateLimited(float $hoursSinceLast): bool
+    {
+        return $hoursSinceLast < self::LIMIT_HOURS;
+    }
+
+    public function hoursSince(int $timestamp): float
+    {
+        return (time() - $timestamp) / 3600;
+    }
+
+    public function buildBackupPath(string $dir, int $mtime): string
+    {
+        return $dir . '/pps-' . date('Ymd_His', $mtime) . '.csv';
     }
 }

--- a/scripts/DownloadRefPpsCommand.php
+++ b/scripts/DownloadRefPpsCommand.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: download the PPS CSV file from IRIT.
+ *
+ * Downloads the CSV, handles the 48h limit, and keeps previous versions.
+ */
+class DownloadRefPpsCommand extends Command
+{
+    protected static $defaultName = 'download:ref-pps';
+
+    private const URL = 'https://dbrech.irit.fr/pls/apex/f?p=9999:3::CSV::::';
+    private const DOWNLOAD_DIR = 'data/ref_pps';
+    private const CURRENT_FILE = 'data/ref_pps/pps-current.csv';
+    private const LIMIT_HOURS = 48;
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Download the PPS CSV file from IRIT.')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force download even if the 48h limit is not reached');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $force = (bool)$input->getOption('force');
+
+        if (!is_dir(self::DOWNLOAD_DIR)) {
+            mkdir(self::DOWNLOAD_DIR, 0755, true);
+        }
+
+        if (!$force && file_exists(self::CURRENT_FILE)) {
+            $lastDownload = filemtime(self::CURRENT_FILE);
+            $hoursSinceLast = (time() - $lastDownload) / 3600;
+
+            if ($hoursSinceLast < self::LIMIT_HOURS) {
+                $io->note(sprintf(
+                    "The last download was %.1f hours ago. The limit is %d hours. Use --force to override.",
+                    $hoursSinceLast,
+                    self::LIMIT_HOURS
+                ));
+                return Command::SUCCESS;
+            }
+        }
+
+        $io->title("Downloading PPS CSV from IRIT");
+
+        try {
+            $client = new Client([
+                'timeout' => 1200, // 20 minutes timeout for large CSV export
+                'verify' => true,
+                'headers' => [
+                    'User-Agent' => 'Mozilla/5.0 (Episciences-GPL Download Script)',
+                ]
+            ]);
+
+            $tempFile = self::DOWNLOAD_DIR . '/pps-download-' . bin2hex(random_bytes(8)) . '.tmp';
+            
+            $io->text("Fetching: " . self::URL . " (this may take up to 10-15 minutes)");
+            
+            $client->get(self::URL, [
+                'sink' => $tempFile,
+            ]);
+
+            if (file_exists(self::CURRENT_FILE)) {
+                // Check if file content changed (MD5 comparison)
+                if (md5_file($tempFile) === md5_file(self::CURRENT_FILE)) {
+                    $io->info("The file hasn't changed. Skipping versioning.");
+                    unlink($tempFile);
+                    // Update mtime to reset the 48h clock even if content is same
+                    touch(self::CURRENT_FILE);
+                    return Command::SUCCESS;
+                }
+
+                // Keep previous version
+                $timestamp = date('Ymd_His', filemtime(self::CURRENT_FILE));
+                $backupFile = self::DOWNLOAD_DIR . '/pps-' . $timestamp . '.csv';
+                rename(self::CURRENT_FILE, $backupFile);
+                $io->note("Previous version saved to: " . $backupFile);
+            }
+
+            rename($tempFile, self::CURRENT_FILE);
+            $io->success("New version downloaded successfully: " . self::CURRENT_FILE);
+
+        } catch (GuzzleException $e) {
+            $io->error("Download failed: " . $e->getMessage());
+            if (isset($tempFile) && file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+            return Command::FAILURE;
+        } catch (\Exception $e) {
+            $io->error("An error occurred: " . $e->getMessage());
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/scripts/ImportRefPpsCommand.php
+++ b/scripts/ImportRefPpsCommand.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: import PPS data from a CSV file into Solr.
+ *
+ * Expected CSV format (with header row):
+ *   Detectors,Doi,Title,Pubpeerusers,Pubpeerurl,Status
+ */
+class ImportRefPpsCommand extends Command
+{
+    protected static $defaultName = 'import:ref-pps';
+
+    private const BATCH_SIZE = 1000;
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Import PPS data from a CSV file into the ref_pps Solr core.')
+            ->addArgument('csv-file', InputArgument::OPTIONAL, 'Path to the CSV file', 'data/ref_pps/pps-current.csv');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $csvFile = (string) $input->getArgument('csv-file');
+
+        if (!file_exists($csvFile) || !is_readable($csvFile)) {
+            $io->error("CSV file not found or not readable: {$csvFile}");
+            return Command::FAILURE;
+        }
+
+        $io->title("Importing PPS data from {$csvFile}");
+
+        $this->bootstrap();
+
+        $handle = fopen($csvFile, 'rb');
+        if ($handle === false) {
+            $io->error("Failed to open CSV file: {$csvFile}");
+            return Command::FAILURE;
+        }
+
+        // Detect total lines for progress bar (optional, can be slow for 1.1M lines)
+        // For now, let's use a dynamic progress bar or skip total count if it's too slow.
+        $io->note("Counting lines...");
+        $totalLines = 0;
+        $lineCountHandle = fopen($csvFile, 'rb');
+        while (!feof($lineCountHandle)) {
+            fgets($lineCountHandle);
+            $totalLines++;
+        }
+        fclose($lineCountHandle);
+        $totalLines--; // Subtract header
+
+        $progressBar = new ProgressBar($output, $totalLines);
+        $progressBar->start();
+
+        // Skip header
+        $header = fgetcsv($handle);
+        
+        $solrClient = $this->getSolrClient();
+        $updateQuery = $solrClient->createUpdate();
+        
+        $batch = [];
+        $count = 0;
+        $imported = 0;
+
+        while (($data = fgetcsv($handle)) !== false) {
+            if (count($data) < 6) {
+                continue;
+            }
+
+            // Detectors,Doi,Title,Pubpeerusers,Pubpeerurl,Status
+            $docData = [
+                'detectors'    => $data[0],
+                'doi'          => $data[1],
+                'title'        => $data[2],
+                'pubpeerusers' => $data[3],
+                'pubpeerurl'   => $data[4],
+                'status'       => $data[5],
+            ];
+
+            // Generate unique ID based on row content
+            $docData['id'] = md5(implode('|', $data));
+
+            $doc = $updateQuery->createDocument($docData);
+            $batch[] = $doc;
+            $count++;
+
+            if ($count >= self::BATCH_SIZE) {
+                $updateQuery->addDocuments($batch);
+                $solrClient->update($updateQuery);
+                
+                // Reset for next batch
+                $updateQuery = $solrClient->createUpdate();
+                $batch = [];
+                $imported += $count;
+                $count = 0;
+                $progressBar->advance(self::BATCH_SIZE);
+            }
+        }
+
+        // Last batch
+        if ($count > 0) {
+            $updateQuery->addDocuments($batch);
+            $solrClient->update($updateQuery);
+            $imported += $count;
+            $progressBar->advance($count);
+        }
+
+        // Commit changes
+        $finalUpdate = $solrClient->createUpdate();
+        $finalUpdate->addCommit();
+        $solrClient->update($finalUpdate);
+
+        $progressBar->finish();
+        fclose($handle);
+
+        $io->newLine(2);
+        $io->success("Import completed: {$imported} documents imported into ref_pps core.");
+
+        return Command::SUCCESS;
+    }
+
+    private function getSolrClient(): \Solarium\Client
+    {
+        $adapter = new \Solarium\Core\Client\Adapter\Curl();
+        // Adjust timeout for large updates
+        $adapter->setTimeout(300); 
+        $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        
+        $config = [
+            'endpoint' => [
+                'localhost' => [
+                    'host' => ENDPOINTS_SEARCH_HOST,
+                    'port' => ENDPOINTS_SEARCH_PORT,
+                    'core' => 'ref_pps',
+                ]
+            ]
+        ];
+
+        return new \Solarium\Client($adapter, $eventDispatcher, $config);
+    }
+
+    private function bootstrap(): void
+    {
+        if (!defined('APPLICATION_PATH')) {
+            define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
+        }
+        require_once __DIR__ . '/../public/const.php';
+        require_once __DIR__ . '/../public/bdd_const.php';
+
+        defineApplicationConstants();
+        // Load additional constants if needed
+    }
+}

--- a/scripts/ImportRefPpsCommand.php
+++ b/scripts/ImportRefPpsCommand.php
@@ -29,17 +29,22 @@ class ImportRefPpsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
+        $io      = new SymfonyStyle($input, $output);
         $csvFile = (string) $input->getArgument('csv-file');
+
+        // Resolve relative paths from the project root (one level above scripts/)
+        if (!str_starts_with($csvFile, '/')) {
+            $csvFile = dirname(__DIR__) . '/' . $csvFile;
+        }
 
         if (!file_exists($csvFile) || !is_readable($csvFile)) {
             $io->error("CSV file not found or not readable: {$csvFile}");
             return Command::FAILURE;
         }
 
-        $io->title("Importing PPS data from {$csvFile}");
-
         $this->bootstrap();
+
+        $io->title("Importing PPS data from {$csvFile}");
 
         $handle = fopen($csvFile, 'rb');
         if ($handle === false) {
@@ -47,101 +52,158 @@ class ImportRefPpsCommand extends Command
             return Command::FAILURE;
         }
 
-        // Detect total lines for progress bar (optional, can be slow for 1.1M lines)
-        // For now, let's use a dynamic progress bar or skip total count if it's too slow.
-        $io->note("Counting lines...");
-        $totalLines = 0;
-        $lineCountHandle = fopen($csvFile, 'rb');
-        while (!feof($lineCountHandle)) {
-            fgets($lineCountHandle);
-            $totalLines++;
+        $totalLines = $this->countDataLines($csvFile);
+        if ($totalLines === null) {
+            $io->error("Failed to count lines in CSV file: {$csvFile}");
+            fclose($handle);
+            return Command::FAILURE;
         }
-        fclose($lineCountHandle);
-        $totalLines--; // Subtract header
 
+        $io->note("Lines to import: {$totalLines}");
         $progressBar = new ProgressBar($output, $totalLines);
         $progressBar->start();
 
-        // Skip header
         $header = fgetcsv($handle);
-        
-        $solrClient = $this->getSolrClient();
+        if ($header === false) {
+            $io->error("CSV file appears empty or has no header row: {$csvFile}");
+            $progressBar->finish();
+            fclose($handle);
+            return Command::FAILURE;
+        }
+
+        $solrClient  = $this->getSolrClient();
         $updateQuery = $solrClient->createUpdate();
-        
-        $batch = [];
-        $count = 0;
-        $imported = 0;
+        $batch       = [];
+        $count       = 0;
+        $imported    = 0;
+        $skipped     = 0;
 
         while (($data = fgetcsv($handle)) !== false) {
-            if (count($data) < 6) {
+            if (!self::isValidRow($data)) {
+                $skipped++;
                 continue;
             }
 
-            // Detectors,Doi,Title,Pubpeerusers,Pubpeerurl,Status
-            $docData = [
-                'detectors'    => $data[0],
-                'doi'          => $data[1],
-                'title'        => $data[2],
-                'pubpeerusers' => $data[3],
-                'pubpeerurl'   => $data[4],
-                'status'       => $data[5],
-            ];
-
-            // Generate unique ID based on row content
-            $docData['id'] = md5(implode('|', $data));
-
-            $doc = $updateQuery->createDocument($docData);
+            $doc     = $updateQuery->createDocument(self::mapRowToDocument($data));
             $batch[] = $doc;
             $count++;
 
             if ($count >= self::BATCH_SIZE) {
                 $updateQuery->addDocuments($batch);
-                $solrClient->update($updateQuery);
-                
-                // Reset for next batch
+                try {
+                    $solrClient->update($updateQuery);
+                } catch (\Solarium\Exception\ExceptionInterface $e) {
+                    $progressBar->finish();
+                    $io->newLine(2);
+                    $io->error(sprintf('Solr update failed after %d documents: %s', $imported, $e->getMessage()));
+                    fclose($handle);
+                    return Command::FAILURE;
+                }
                 $updateQuery = $solrClient->createUpdate();
-                $batch = [];
-                $imported += $count;
-                $count = 0;
+                $batch       = [];
+                $imported   += $count;
+                $count       = 0;
                 $progressBar->advance(self::BATCH_SIZE);
             }
         }
 
-        // Last batch
         if ($count > 0) {
             $updateQuery->addDocuments($batch);
-            $solrClient->update($updateQuery);
+            try {
+                $solrClient->update($updateQuery);
+            } catch (\Solarium\Exception\ExceptionInterface $e) {
+                $progressBar->finish();
+                $io->newLine(2);
+                $io->error(sprintf('Solr update failed on final batch after %d documents: %s', $imported, $e->getMessage()));
+                fclose($handle);
+                return Command::FAILURE;
+            }
             $imported += $count;
             $progressBar->advance($count);
         }
 
-        // Commit changes
         $finalUpdate = $solrClient->createUpdate();
         $finalUpdate->addCommit();
-        $solrClient->update($finalUpdate);
+        try {
+            $solrClient->update($finalUpdate);
+        } catch (\Solarium\Exception\ExceptionInterface $e) {
+            $progressBar->finish();
+            $io->newLine(2);
+            $io->error(sprintf(
+                'Solr commit failed after sending %d documents. Data may not be fully committed: %s',
+                $imported,
+                $e->getMessage()
+            ));
+            fclose($handle);
+            return Command::FAILURE;
+        }
 
         $progressBar->finish();
         fclose($handle);
 
         $io->newLine(2);
+        if ($skipped > 0) {
+            $io->warning("Skipped {$skipped} rows with fewer than 6 fields.");
+        }
         $io->success("Import completed: {$imported} documents imported into ref_pps core.");
 
         return Command::SUCCESS;
     }
 
-    private function getSolrClient(): \Solarium\Client
+    /** @param list<string|null> $data */
+    public static function isValidRow(array $data): bool
+    {
+        return count($data) >= 6;
+    }
+
+    /**
+     * Maps a CSV data row to a Solr document array.
+     *
+     * @param list<string> $data
+     * @return array<string, string>
+     */
+    public static function mapRowToDocument(array $data): array
+    {
+        return [
+            'id'           => strtolower(trim($data[1])), // DOI as stable unique key
+            'detectors'    => $data[0],
+            'doi'          => $data[1],
+            'title'        => $data[2],
+            'pubpeerusers' => $data[3],
+            'pubpeerurl'   => $data[4],
+            'status'       => $data[5],
+        ];
+    }
+
+    public function countDataLines(string $csvFile): ?int
+    {
+        $handle = fopen($csvFile, 'rb');
+        if ($handle === false) {
+            return null;
+        }
+        $lines = 0;
+        while (fgets($handle) !== false) {
+            $lines++;
+        }
+        fclose($handle);
+        return max(0, $lines - 1); // subtract header
+    }
+
+    protected function getSolrClient(): \Solarium\Client
     {
         $adapter = new \Solarium\Core\Client\Adapter\Curl();
-        // Adjust timeout for large updates
-        $adapter->setTimeout(300); 
+        $adapter->setTimeout(ENDPOINTS_SEARCH_TIMEOUT);
         $eventDispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
-        
+
         $config = [
             'endpoint' => [
                 'localhost' => [
-                    'host' => ENDPOINTS_SEARCH_HOST,
-                    'port' => ENDPOINTS_SEARCH_PORT,
-                    'core' => 'ref_pps',
+                    'host'     => ENDPOINTS_SEARCH_HOST,
+                    'port'     => ENDPOINTS_SEARCH_PORT,
+                    'timeout'  => ENDPOINTS_SEARCH_TIMEOUT,
+                    'username' => ENDPOINTS_SEARCH_USERNAME,
+                    'password' => ENDPOINTS_SEARCH_PASSWORD,
+                    'core'     => 'ref_pps',
                 ]
             ]
         ];
@@ -157,7 +219,15 @@ class ImportRefPpsCommand extends Command
         require_once __DIR__ . '/../public/const.php';
         require_once __DIR__ . '/../public/bdd_const.php';
 
+        defineProtocol();
+        defineSimpleConstants();
         defineApplicationConstants();
-        // Load additional constants if needed
+
+        $libraries = [realpath(APPLICATION_PATH . '/../library')];
+        set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
+        require_once 'Zend/Application.php';
+
+        $autoloader = Zend_Loader_Autoloader::getInstance();
+        $autoloader->setFallbackAutoloader(true);
     }
 }

--- a/scripts/console.php
+++ b/scripts/console.php
@@ -18,6 +18,8 @@ require_once __DIR__ . '/CreateDoajVolumeExportsCommand.php';
 require_once __DIR__ . '/ZbjatsZipperCommand.php';
 require_once __DIR__ . '/ImportSectionsCommand.php';
 require_once __DIR__ . '/ImportVolumesCommand.php';
+require_once __DIR__ . '/ImportRefPpsCommand.php';
+require_once __DIR__ . '/DownloadRefPpsCommand.php';
 require_once __DIR__ . '/UpdateCounterRobotsListCommand.php';
 require_once __DIR__ . '/ProcessStatTempCommand.php';
 require_once __DIR__ . '/ImportApacheLogsCommand.php';
@@ -59,6 +61,8 @@ $application->add(new ZbjatsZipperCommand());
 // Import commands
 $application->add(new ImportSectionsCommand());
 $application->add(new ImportVolumesCommand());
+$application->add(new ImportRefPpsCommand());
+$application->add(new DownloadRefPpsCommand());
 
 // Stats commands
 $application->add(new UpdateCounterRobotsListCommand());

--- a/src/solr/ref_pps/conf/inc-fieldtype-schema.xml
+++ b/src/solr/ref_pps/conf/inc-fieldtype-schema.xml
@@ -1,0 +1,27 @@
+<types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" indexed="true" stored="true"/>
+    
+    <fieldType name="text" class="solr.TextField" positionIncrementGap="100" indexed="true" stored="false">
+      <analyzer>
+        <charFilter class="solr.HTMLStripCharFilterFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" generateWordParts="1"
+                generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0"
+                splitOnCaseChange="0"/>
+        <filter class="solr.ICUFoldingFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <fieldType name="stringCaseInsensitive" class="solr.TextField" sortMissingLast="true" omitNorms="true"
+               indexed="true" stored="true">
+        <analyzer>
+            <charFilter class="solr.HTMLStripCharFilterFactory"/>
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.TrimFilterFactory"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="long" class="solr.LongPointField" docValues="true"/>
+</types>

--- a/src/solr/ref_pps/conf/schema.xml
+++ b/src/solr/ref_pps/conf/schema.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<schema name="ref_pps" version="1.6">
+    <fields>
+        <!-- Unique identifier for each document -->
+        <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+
+        <field name="detectors" type="string" indexed="true" stored="true" multiValued="false"/>
+        <field name="doi" type="stringCaseInsensitive" indexed="true" stored="true" multiValued="false"/>
+        <field name="title" type="text" indexed="true" stored="true" multiValued="false"/>
+        <field name="pubpeerusers" type="string" indexed="false" stored="true" multiValued="false"/>
+        <field name="pubpeerurl" type="string" indexed="false" stored="true" multiValued="false"/>
+        <field name="status" type="string" indexed="true" stored="true" multiValued="false"/>
+
+        <!-- catchall field -->
+        <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+
+        <field name="_version_" type="long" indexed="true" stored="true"/>
+    </fields>
+
+    <uniqueKey>id</uniqueKey>
+
+    <copyField source="doi" dest="text"/>
+    <copyField source="title" dest="text"/>
+    <copyField source="detectors" dest="text"/>
+    <copyField source="status" dest="text"/>
+
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="inc-fieldtype-schema.xml"/>
+</schema>

--- a/src/solr/ref_pps/conf/solrconfig.xml
+++ b/src/solr/ref_pps/conf/solrconfig.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<config>
+    <luceneMatchVersion>9.10</luceneMatchVersion>
+    <dataDir>${solr.data.dir:}</dataDir>
+    <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+    <codecFactory class="solr.SchemaCodecFactory"/>
+    <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+    <indexConfig>
+        <lockType>${solr.lock.type:native}</lockType>
+    </indexConfig>
+
+    <updateHandler class="solr.DirectUpdateHandler2">
+        <updateLog>
+            <str name="dir">${solr.ulog.dir:}</str>
+        </updateLog>
+        <autoCommit>
+            <maxTime>${solr.autoCommit.maxTime:60000}</maxTime>
+            <maxDocs>1000</maxDocs>
+            <openSearcher>false</openSearcher>
+        </autoCommit>
+        <autoSoftCommit>
+            <maxTime>30000</maxTime>
+        </autoSoftCommit>
+    </updateHandler>
+
+    <query>
+        <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
+        <filterCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>
+        <queryResultCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>
+        <documentCache class="solr.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>
+        <enableLazyFieldLoading>true</enableLazyFieldLoading>
+        <queryResultWindowSize>20</queryResultWindowSize>
+        <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
+        <useColdSearcher>false</useColdSearcher>
+    </query>
+
+    <requestDispatcher>
+        <httpCaching never304="true"/>
+    </requestDispatcher>
+
+    <requestHandler name="/select" class="solr.SearchHandler">
+      <lst name="defaults">
+        <str name="echoParams">explicit</str>
+        <int name="rows">10</int>
+        <str name="df">text</str>
+        <str name="wt">json</str>
+      </lst>
+    </requestHandler>
+
+    <requestHandler name="/update" class="solr.UpdateRequestHandler" />
+
+</config>

--- a/src/solr/ref_pps/conf/stopwords.txt
+++ b/src/solr/ref_pps/conf/stopwords.txt
@@ -1,0 +1,1 @@
+# Empty stopwords file

--- a/tests/unit/scripts/DownloadRefPpsCommandTest.php
+++ b/tests/unit/scripts/DownloadRefPpsCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+declare(strict_types=1);
+
+namespace unit\scripts;
+
+use DownloadRefPpsCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+
+require_once __DIR__ . '/../../../scripts/DownloadRefPpsCommand.php';
+
+/**
+ * Unit tests for DownloadRefPpsCommand.
+ *
+ * Tests pure logic only — no HTTP calls, no filesystem writes.
+ */
+class DownloadRefPpsCommandTest extends TestCase
+{
+    private DownloadRefPpsCommand $command;
+
+    /** @var list<string> */
+    private array $createdFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->command = new DownloadRefPpsCommand();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->createdFiles = [];
+    }
+
+    // -------------------------------------------------------------------------
+    // Command metadata
+    // -------------------------------------------------------------------------
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('download:ref-pps', $this->command->getName());
+    }
+
+    public function testCommandHasForceOption(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertInstanceOf(InputDefinition::class, $definition);
+        $this->assertTrue($definition->hasOption('force'));
+        $this->assertFalse($definition->getOption('force')->acceptValue(), 'force must be a flag');
+    }
+
+    public function testCommandHasForceShortcut(): void
+    {
+        $option = $this->command->getDefinition()->getOption('force');
+        $this->assertSame('f', $option->getShortcut());
+    }
+
+    // -------------------------------------------------------------------------
+    // isRateLimited()
+    // -------------------------------------------------------------------------
+
+    public function testIsRateLimited_RecentDownload_ReturnsTrue(): void
+    {
+        $this->assertTrue($this->command->isRateLimited(24.0));
+    }
+
+    public function testIsRateLimited_OldDownload_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->command->isRateLimited(72.0));
+    }
+
+    public function testIsRateLimited_ExactlyAtLimit_ReturnsFalse(): void
+    {
+        // 48.0 is not < 48: should allow download
+        $this->assertFalse($this->command->isRateLimited(48.0));
+    }
+
+    public function testIsRateLimited_JustUnderLimit_ReturnsTrue(): void
+    {
+        $this->assertTrue($this->command->isRateLimited(47.9));
+    }
+
+    public function testIsRateLimited_JustOverLimit_ReturnsFalse(): void
+    {
+        $this->assertFalse($this->command->isRateLimited(48.1));
+    }
+
+    public function testIsRateLimited_Zero_ReturnsTrue(): void
+    {
+        $this->assertTrue($this->command->isRateLimited(0.0));
+    }
+
+    // -------------------------------------------------------------------------
+    // hoursSince()
+    // -------------------------------------------------------------------------
+
+    public function testHoursSince_OneHourAgo_ReturnsApproxOne(): void
+    {
+        $oneHourAgo = time() - 3600;
+        $hours      = $this->command->hoursSince($oneHourAgo);
+        $this->assertEqualsWithDelta(1.0, $hours, 0.01);
+    }
+
+    public function testHoursSince_FortyEightHoursAgo_ReturnsApproxFortyEight(): void
+    {
+        $fortyEightHoursAgo = time() - (3600 * 48);
+        $hours              = $this->command->hoursSince($fortyEightHoursAgo);
+        $this->assertEqualsWithDelta(48.0, $hours, 0.01);
+    }
+
+    public function testHoursSince_FutureTimestamp_ReturnsNegative(): void
+    {
+        $futureTimestamp = time() + 3600;
+        $this->assertLessThan(0.0, $this->command->hoursSince($futureTimestamp));
+    }
+
+    // -------------------------------------------------------------------------
+    // buildBackupPath()
+    // -------------------------------------------------------------------------
+
+    public function testBuildBackupPath_ContainsDirectory(): void
+    {
+        $path = $this->command->buildBackupPath('/data/ref_pps', mktime(12, 0, 0, 3, 15, 2026));
+        $this->assertStringStartsWith('/data/ref_pps/', $path);
+    }
+
+    public function testBuildBackupPath_ContainsDateTimestamp(): void
+    {
+        $mtime = mktime(14, 30, 0, 6, 1, 2025);
+        $path  = $this->command->buildBackupPath('/data/ref_pps', $mtime);
+        $this->assertStringContainsString('20250601_143000', $path);
+    }
+
+    public function testBuildBackupPath_EndsWithCsvExtension(): void
+    {
+        $path = $this->command->buildBackupPath('/data/ref_pps', mktime(0, 0, 0, 1, 1, 2025));
+        $this->assertStringEndsWith('.csv', $path);
+    }
+
+    public function testBuildBackupPath_StartsWithPpsPrefix(): void
+    {
+        $path     = $this->command->buildBackupPath('/data/ref_pps', mktime(0, 0, 0, 1, 1, 2025));
+        $filename = basename($path);
+        $this->assertStringStartsWith('pps-', $filename);
+    }
+
+    public function testBuildBackupPath_DifferentMtimes_ProduceDifferentPaths(): void
+    {
+        $path1 = $this->command->buildBackupPath('/data', mktime(12, 0, 0, 1, 1, 2025));
+        $path2 = $this->command->buildBackupPath('/data', mktime(13, 0, 0, 1, 1, 2025));
+        $this->assertNotSame($path1, $path2);
+    }
+
+    public function testBuildBackupPath_SameMtime_ProducesSamePath(): void
+    {
+        $mtime = mktime(8, 0, 0, 4, 15, 2026);
+        $this->assertSame(
+            $this->command->buildBackupPath('/data', $mtime),
+            $this->command->buildBackupPath('/data', $mtime)
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Rate-limit integration: isRateLimited + hoursSince
+    // -------------------------------------------------------------------------
+
+    public function testIntegration_RecentMtime_IsRateLimited(): void
+    {
+        $twelveHoursAgo = time() - (3600 * 12);
+        $hours          = $this->command->hoursSince($twelveHoursAgo);
+        $this->assertTrue($this->command->isRateLimited($hours));
+    }
+
+    public function testIntegration_OldMtime_IsNotRateLimited(): void
+    {
+        $threeDaysAgo = time() - (3600 * 72);
+        $hours        = $this->command->hoursSince($threeDaysAgo);
+        $this->assertFalse($this->command->isRateLimited($hours));
+    }
+}

--- a/tests/unit/scripts/ImportRefPpsCommandTest.php
+++ b/tests/unit/scripts/ImportRefPpsCommandTest.php
@@ -1,0 +1,246 @@
+<?php
+declare(strict_types=1);
+
+namespace unit\scripts;
+
+use ImportRefPpsCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+
+require_once __DIR__ . '/../../../scripts/ImportRefPpsCommand.php';
+
+/**
+ * Unit tests for ImportRefPpsCommand.
+ *
+ * Tests pure logic only — no bootstrap, no Solr, no filesystem writes.
+ */
+class ImportRefPpsCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $createdFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdFiles as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+        $this->createdFiles = [];
+    }
+
+    // -------------------------------------------------------------------------
+    // Command metadata
+    // -------------------------------------------------------------------------
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('import:ref-pps', (new ImportRefPpsCommand())->getName());
+    }
+
+    public function testCommandHasCsvFileArgument(): void
+    {
+        $definition = (new ImportRefPpsCommand())->getDefinition();
+        $this->assertInstanceOf(InputDefinition::class, $definition);
+        $this->assertTrue($definition->hasArgument('csv-file'));
+    }
+
+    public function testCsvFileArgumentIsOptional(): void
+    {
+        $arg = (new ImportRefPpsCommand())->getDefinition()->getArgument('csv-file');
+        $this->assertFalse($arg->isRequired(), 'csv-file argument must be optional');
+    }
+
+    public function testCsvFileArgumentDefaultValue(): void
+    {
+        $arg = (new ImportRefPpsCommand())->getDefinition()->getArgument('csv-file');
+        $this->assertSame('data/ref_pps/pps-current.csv', $arg->getDefault());
+    }
+
+    // -------------------------------------------------------------------------
+    // isValidRow()
+    // -------------------------------------------------------------------------
+
+    public function testIsValidRow_ExactlySixFields_ReturnsTrue(): void
+    {
+        $this->assertTrue(ImportRefPpsCommand::isValidRow(['a', 'b', 'c', 'd', 'e', 'f']));
+    }
+
+    public function testIsValidRow_MoreThanSixFields_ReturnsTrue(): void
+    {
+        $this->assertTrue(ImportRefPpsCommand::isValidRow(['a', 'b', 'c', 'd', 'e', 'f', 'g']));
+    }
+
+    public function testIsValidRow_FiveFields_ReturnsFalse(): void
+    {
+        $this->assertFalse(ImportRefPpsCommand::isValidRow(['a', 'b', 'c', 'd', 'e']));
+    }
+
+    public function testIsValidRow_EmptyArray_ReturnsFalse(): void
+    {
+        $this->assertFalse(ImportRefPpsCommand::isValidRow([]));
+    }
+
+    public function testIsValidRow_OneNullField_ReturnsFalse(): void
+    {
+        // fgetcsv returns [null] on blank line
+        $this->assertFalse(ImportRefPpsCommand::isValidRow([null]));
+    }
+
+    // -------------------------------------------------------------------------
+    // mapRowToDocument()
+    // -------------------------------------------------------------------------
+
+    public function testMapRowToDocument_ContainsAllRequiredKeys(): void
+    {
+        $data = ['det1', '10.1234/test', 'Some Title', 'user1', 'https://pubpeer.com/1', 'retracted'];
+        $doc  = ImportRefPpsCommand::mapRowToDocument($data);
+
+        $this->assertArrayHasKey('id', $doc);
+        $this->assertArrayHasKey('detectors', $doc);
+        $this->assertArrayHasKey('doi', $doc);
+        $this->assertArrayHasKey('title', $doc);
+        $this->assertArrayHasKey('pubpeerusers', $doc);
+        $this->assertArrayHasKey('pubpeerurl', $doc);
+        $this->assertArrayHasKey('status', $doc);
+    }
+
+    public function testMapRowToDocument_IdIsLowercasedDoi(): void
+    {
+        $data = ['det', '10.1234/TEST.DOI', 'Title', 'user', 'url', 'ok'];
+        $doc  = ImportRefPpsCommand::mapRowToDocument($data);
+
+        $this->assertSame('10.1234/test.doi', $doc['id']);
+    }
+
+    public function testMapRowToDocument_IdTrimsWhitespaceFromDoi(): void
+    {
+        $data = ['det', '  10.1234/abc  ', 'Title', 'user', 'url', 'ok'];
+        $doc  = ImportRefPpsCommand::mapRowToDocument($data);
+
+        $this->assertSame('10.1234/abc', $doc['id']);
+    }
+
+    public function testMapRowToDocument_PreservesOriginalDoiField(): void
+    {
+        $data = ['det', '10.1234/Original', 'Title', 'user', 'url', 'ok'];
+        $doc  = ImportRefPpsCommand::mapRowToDocument($data);
+
+        $this->assertSame('10.1234/Original', $doc['doi']);
+    }
+
+    public function testMapRowToDocument_MapsColumnsInCorrectOrder(): void
+    {
+        $data = ['DETECTOR_VAL', 'DOI_VAL', 'TITLE_VAL', 'USERS_VAL', 'URL_VAL', 'STATUS_VAL'];
+        $doc  = ImportRefPpsCommand::mapRowToDocument($data);
+
+        $this->assertSame('DETECTOR_VAL', $doc['detectors']);
+        $this->assertSame('DOI_VAL', $doc['doi']);
+        $this->assertSame('TITLE_VAL', $doc['title']);
+        $this->assertSame('USERS_VAL', $doc['pubpeerusers']);
+        $this->assertSame('URL_VAL', $doc['pubpeerurl']);
+        $this->assertSame('STATUS_VAL', $doc['status']);
+    }
+
+    public function testMapRowToDocument_SameDoiProducesSameId(): void
+    {
+        $data1 = ['det1', '10.1234/abc', 'Title A', 'user1', 'url1', 'ok'];
+        $data2 = ['det2', '10.1234/abc', 'Title B', 'user2', 'url2', 'retracted'];
+
+        $this->assertSame(
+            ImportRefPpsCommand::mapRowToDocument($data1)['id'],
+            ImportRefPpsCommand::mapRowToDocument($data2)['id'],
+            'Same DOI must produce the same document ID regardless of other fields'
+        );
+    }
+
+    public function testMapRowToDocument_DifferentDoisProduceDifferentIds(): void
+    {
+        $data1 = ['det', '10.1234/first', 'T', 'u', 'url', 'ok'];
+        $data2 = ['det', '10.1234/second', 'T', 'u', 'url', 'ok'];
+
+        $this->assertNotSame(
+            ImportRefPpsCommand::mapRowToDocument($data1)['id'],
+            ImportRefPpsCommand::mapRowToDocument($data2)['id']
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // countDataLines()
+    // -------------------------------------------------------------------------
+
+    public function testCountDataLines_WithHeaderAndThreeDataRows_ReturnsThree(): void
+    {
+        $tmpFile = $this->createTempCsv(
+            "Detectors,Doi,Title,Pubpeerusers,Pubpeerurl,Status\n" .
+            "d1,10.1/a,T1,u1,url1,ok\n" .
+            "d2,10.1/b,T2,u2,url2,ok\n" .
+            "d3,10.1/c,T3,u3,url3,ok\n"
+        );
+
+        $this->assertSame(3, (new ImportRefPpsCommand())->countDataLines($tmpFile));
+    }
+
+    public function testCountDataLines_HeaderOnly_ReturnsZero(): void
+    {
+        $tmpFile = $this->createTempCsv("Detectors,Doi,Title,Pubpeerusers,Pubpeerurl,Status\n");
+        $this->assertSame(0, (new ImportRefPpsCommand())->countDataLines($tmpFile));
+    }
+
+    public function testCountDataLines_WithTrailingNewline_CountsCorrectly(): void
+    {
+        // File with trailing newline should not add phantom extra line
+        $content = "Header\n" . implode("\n", array_fill(0, 5, 'd,doi,t,u,url,ok')) . "\n";
+        $tmpFile = $this->createTempCsv($content);
+        $this->assertSame(5, (new ImportRefPpsCommand())->countDataLines($tmpFile));
+    }
+
+    public function testCountDataLines_WithoutTrailingNewline_CountsCorrectly(): void
+    {
+        $content = "Header\n" . implode("\n", array_fill(0, 5, 'd,doi,t,u,url,ok'));
+        $tmpFile = $this->createTempCsv($content);
+        $this->assertSame(5, (new ImportRefPpsCommand())->countDataLines($tmpFile));
+    }
+
+    public function testCountDataLines_NonexistentFile_ReturnsNull(): void
+    {
+        $this->assertNull((new ImportRefPpsCommand())->countDataLines('/nonexistent/path/file.csv'));
+    }
+
+    public function testCountDataLines_EmptyFile_ReturnsZero(): void
+    {
+        $tmpFile = $this->createTempCsv('');
+        $this->assertSame(0, (new ImportRefPpsCommand())->countDataLines($tmpFile));
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch boundary: isValidRow + mapRowToDocument contract
+    // -------------------------------------------------------------------------
+
+    public function testMapRowToDocument_StatusChangeSameDoiUpdatesDoc(): void
+    {
+        // When a DOI status changes, the document ID is the same → Solr updates the existing doc
+        $original = ['det', '10.1234/doi', 'Title', 'user', 'url', 'peer_review'];
+        $updated  = ['det', '10.1234/doi', 'Title', 'user', 'url', 'retracted'];
+
+        $docOriginal = ImportRefPpsCommand::mapRowToDocument($original);
+        $docUpdated  = ImportRefPpsCommand::mapRowToDocument($updated);
+
+        $this->assertSame($docOriginal['id'], $docUpdated['id']);
+        $this->assertSame('peer_review', $docOriginal['status']);
+        $this->assertSame('retracted', $docUpdated['status']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function createTempCsv(string $content): string
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'import_ref_pps_test_');
+        $this->assertNotFalse($tmpFile);
+        file_put_contents($tmpFile, $content);
+        $this->createdFiles[] = $tmpFile;
+        return $tmpFile;
+    }
+}


### PR DESCRIPTION
This PR introduces a new Solr core named `ref_pps` and the necessary tools to download and index a large PPS dataset (1.1 million rows) from IRIT.

### Key Changes:
- **Solr Configuration**: Added a dedicated `ref_pps` core configuration (`src/solr/ref_pps/conf/`) with case-insensitive DOI search and full-text search on titles.
- **CLI Commands**:
    - `download:ref-pps`: Securely downloads the CSV from IRIT with a 20-minute timeout, 48-hour rate limiting, and timestamped backups.
    - `import:ref-pps`: Memory-efficient, batch-processed indexing script for handling 1.1M+ rows.
- **Developer Workflow**: Added `make collection-ref-pps`, `make download-ref-pps`, and `make import-ref-pps` for data management.
- **Documentation**: Updated `docs/console-commands.md` and `docs/dev-setup.md` with usage instructions.

### How to test:
1. Run `make collection-ref-pps` to create the core in your local Solr.
2. Run `make download-ref-pps` to fetch the data.
3. Run `make import-ref-pps` to index the data.
4. Verify results by querying Solr: `curl "http://localhost:8983/solr/ref_pps/select?q=doi:10.1155/2022/1254367"`.