### PR TITLE
fix(codeql): resolve JS warning-level CodeQL alerts

### DIFF
--- a/public/js/administratepaper/reassign-editor.js
+++ b/public/js/administratepaper/reassign-editor.js
@@ -24,7 +24,7 @@ function set_editor(uid) {
             locale = 'en';
         } else {
             // Sinon, on sélectionne la première langue disponible
-            for (i in available_languages) {
+            for (var i in available_languages) {
                 locale = i;
                 break;
             }
@@ -101,7 +101,7 @@ function replaceTags(string, reviewer, locale) {
     if ($.type(paper.title) == 'object') {
         if (paper.title[locale]) paper_title = paper.title[locale];
         else
-            for (i in paper.title) {
+            for (var i in paper.title) {
                 paper_title = paper.title[i];
                 break;
             }

--- a/public/js/forms/form.js
+++ b/public/js/forms/form.js
@@ -33,25 +33,20 @@ form.validate = function () {
 
             // var tag = $(element).get(0).tagName.toLowerCase();
             var message = required[i].message;
-            var validated = false;
 
             // Element TinyMCE
             if ($(element).is('textarea') && tinyMCE.editors[name]) {
                 if (tinyMCE.editors[name].getContent()) {
-                    validated = true;
                     continue;
                 }
             }
             // Autres types d'élément
             else if ($(element).val()) {
-                validated = true;
                 continue;
             }
 
             // En cas d'erreur
-            if (!validated) {
-                this.errors.push(translate(message));
-            }
+            this.errors.push(translate(message));
         }
     }
 

--- a/public/js/grid/initGridTable.js
+++ b/public/js/grid/initGridTable.js
@@ -2,7 +2,7 @@ $(document).ready(function () {
     $('.dataTable').each(function () {
         var nbCols = $(this).find('th').length;
         var targets = new Array();
-        for (i = 1; i < nbCols; i++) {
+        for (var i = 1; i < nbCols; i++) {
             targets.push(i);
         }
 

--- a/public/js/submit/index.js
+++ b/public/js/submit/index.js
@@ -34,7 +34,7 @@ $(document).ready(function () {
             if (oResponse) {
                 // initialized in submit/index.phtml
                 hasHook = oResponse.hasHook;
-                isRequiredVersion = oResponse.isRequiredVersion.result;
+                let isRequiredVersion = oResponse.isRequiredVersion.result;
 
                 if (!isRequiredVersion) {
                     $versionBloc.hide();
@@ -71,7 +71,7 @@ $(document).ready(function () {
     // Extracting the ID from URL
 
     $searchDocDocId.change(function () {
-        input = $(this).val().trim();
+        let input = $(this).val().trim();
         if (!input) {
             return;
         }

--- a/public/js/tinymce/tinymce_patch.js
+++ b/public/js/tinymce/tinymce_patch.js
@@ -83,13 +83,13 @@ function __initEditor(selectorName, context, options) {
 }
 
 function __pasteContentMCE() {
-    tiny = tinyMCE.activeEditor;
+    const tiny = tinyMCE.activeEditor;
 
     tiny.getElement().value = tiny.getContent({ format: 'html' });
 }
 
 function __destroyActiveMCE() {
-    tiny = tinyMCE.activeEditor;
+    const tiny = tinyMCE.activeEditor;
     $(tiny.getElement()).tinymce().remove();
 }
 


### PR DESCRIPTION
## Summary

Fixes 10 warning-level CodeQL alerts (`js/missing-variable-declaration`, `js/useless-assignment-to-local`, `js/trivial-conditional`) across 5 JS files.

- **`forms/form.js`** — removed redundant `validated` flag; both branches that set it to `true` immediately called `continue`, making the final `if (!validated)` always true
- **`tinymce/tinymce_patch.js`** — added `const` declaration for `tiny` in `__pasteContentMCE()` and `__destroyActiveMCE()`
- **`submit/index.js`** — added `let` for `isRequiredVersion` (inside `.done()` callback) and `input` (inside `.change()` handler)
- **`grid/initGridTable.js`** — added `var` to loop variable `i`
- **`administratepaper/reassign-editor.js`** — added `var` to loop variable `i` in `fillModal()` and `replaceTags()`

Note-level alerts (unused functions called from `.phtml` onclick handlers) were intentionally left as-is — CodeQL cannot see those template references.

## Test plan

- [ ] Verify form validation still works on a paper submission form (required field error messages appear correctly)
- [ ] Verify TinyMCE paste/destroy still works in the editor
- [ ] Verify submit page repository selector still shows/hides the version block
- [ ] Verify DataTable column sorting still works on admin list pages
- [ ] Verify reassign-editor modal still populates locale/title correctly