### PR TITLE
feat: add Tom Select search to admin paper list filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Admin paper list: Tom Select search on all 7 filter selects (Status, Volume, Section, Editors, Reviewers, DOI, Repositories) — type to filter within long lists, animated chevron indicates dropdown, placeholder shows "All" when nothing is selected.
+
+### Changed
+
+- Admin paper list: filter panel reorganised into 3 rows — Status/Editors/Reviewers on the first row, Volume+DOI on the second, Section+Repositories on the third; Volume and Section are wider (`col-sm-8`) to accommodate long titles.
+- Admin paper list: removed redundant page description blockquote.
+
+### Fixed
+
+- Admin paper list: `checkFilterParams` crashed with `TypeError: Cannot read properties of null (reading 'length')` when clicking "Filter" with Tom Select multiselects returning `null` for empty selections; fallback to `['']` restores expected behaviour.
+
 - Mailing lists: added `created_at` and `updated_at` columns to the `mailing_lists` table.
 - Mailing lists: four MySQL triggers propagate `updated_at` to the parent row when individual members or roles are modified.
 - Mailing lists: `v_mailing_lists_resolved` view now exposes `list_created_at` and `list_updated_at`.

--- a/application/modules/journal/views/scripts/administratepaper/list.phtml
+++ b/application/modules/journal/views/scripts/administratepaper/list.phtml
@@ -1,6 +1,5 @@
 <?php
 $this->layout()->pageTitle = $this->translate("Gérer les articles");
-$this->layout()->description = ($this->pageDescription) ?: $this->translate("Gestion des articles de la revue.");
 
 $controller = Zend_Controller_Front::getInstance()->getRequest()->getControllerName();
 $action = Zend_Controller_Front::getInstance()->getRequest()->getActionName();
@@ -26,6 +25,8 @@ $this->jQuery()->addJavascriptFile("/js/datepicker/datepicker.js");
 $this->jQuery()->addJavascriptFile(VENDOR_TINYMCE_JQUERY);
 $this->jQuery()->addJavascriptFile(VENDOR_TINYMCE);
 $this->jQuery()->addJavascriptFile(TINYMCE_DIR . "tinymce_patch.js");
+$this->jQuery()->addStylesheet('https://cdn.jsdelivr.net/npm/tom-select@2/dist/css/tom-select.min.css');
+$this->jQuery()->addJavascriptFile('https://cdn.jsdelivr.net/npm/tom-select@2/dist/js/tom-select.complete.min.js');
 ?>
 
 <table class="table table-bordered dataTable table-responsive-lg" id="papers" style="width: 100%;">
@@ -79,13 +80,51 @@ try {
 ?>
 
 
-<script type="text/javascript">
+<style>
+    select.tomselected, select.ts-hidden-accessible { display: none !important; }
+    .ts-wrapper { position: relative; }
+    .ts-wrapper.form-control { height: auto !important; padding: 0 !important; border: none !important; box-shadow: none !important; background: transparent !important; }
+    .ts-wrapper.multi .ts-control { min-height: 34px; border: 1px solid #ccc; border-radius: 4px; padding: 4px 28px 4px 8px; cursor: pointer; background: #fff; position: relative; }
+    .ts-wrapper.multi .ts-control::after { content: '▾'; position: absolute; right: 8px; top: 50%; transform: translateY(-50%); color: #777; pointer-events: none; font-size: 14px; line-height: 1; transition: transform 0.15s; }
+    .ts-wrapper.multi.focus .ts-control::after { transform: translateY(-50%) rotate(180deg); }
+    .ts-dropdown { position: absolute !important; z-index: 1050 !important; }
+    .ts-dropdown .option { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .ts-dropdown .option.active,
+    .ts-dropdown .option:hover { background-color: #337ab7; color: #fff; }
+    .ts-wrapper.multi .ts-control > .item { background-color: #337ab7; color: #fff; border-color: #2e6da4; border-radius: 3px; padding: 2px 6px; }
+    .ts-wrapper.multi .ts-control > .item .remove { color: rgba(255,255,255,0.7); border-left-color: rgba(255,255,255,0.3); }
+    .ts-wrapper.multi .ts-control > .item .remove:hover { color: #fff; }
+</style>
 
+<script type="text/javascript">
 
     let selfController = <?= "'$controller'" ?>;
     let selfAction = <?= "'$action'" ?>;
 
     const editableWithoutEditorsData = <?= $editableWithoutEditorsData ?>;
+
+    function initTomSelects() {
+        ['status', 'vid', 'sid', 'editors', 'reviewers', 'doi', 'repositories'].forEach(function (id) {
+            const el = document.getElementById(id);
+            if (!el || el.tomselect) return;
+            const firstOption = el.querySelector('option[value=""]');
+            const placeholder = firstOption ? firstOption.textContent.trim() : '';
+            const ts = new TomSelect(el, {
+                plugins: ['remove_button'],
+                maxOptions: null,
+                placeholder: placeholder,
+                onItemAdd: function () { this.setTextboxValue(''); },
+            });
+            el.style.setProperty('display', 'none', 'important');
+            ts.wrapper.classList.remove('form-control');
+        });
+    }
+
+    if (typeof TomSelect !== 'undefined') {
+        initTomSelects();
+    } else {
+        document.addEventListener('DOMContentLoaded', initTomSelects);
+    }
 
     $.getScript("/js/paper/submitted.js?_=v<?= APPLICATION_VERSION ?>;");
     $.getScript("/js/administratepaper/section-assignment.js?_=v<?= APPLICATION_VERSION ?>");

--- a/application/modules/journal/views/scripts/paper/filters.phtml
+++ b/application/modules/journal/views/scripts/paper/filters.phtml
@@ -1,5 +1,4 @@
 <?php
-$class = 'col-sm-4';
 $actionName = Zend_Controller_Front::getInstance()->getRequest()->getActionName();
 ?>
 <div class="panel panel-default collapsable">
@@ -11,54 +10,58 @@ $actionName = Zend_Controller_Front::getInstance()->getRequest()->getActionName(
               action="<?= $this->escape($this->element->getAction()) ?>"
               method="<?= $this->escape($this->element->getMethod()) ?>">
 
-            <?php if (isset($this->element->status)) : ?>
-                <div class="row">
-                    <div class="col-sm-12">
+            <!-- Ligne 1 : Article Status | Editors | Reviewers -->
+            <div class="row">
+                <?php if (isset($this->element->status)) : ?>
+                    <div class="col-sm-4">
                         <?= $this->element->status ?>
                     </div>
-                </div>
-            <?php endif; ?>
-
-            <div class="row">
+                <?php endif; ?>
 
                 <?php if (isset($this->element->ratingStatus) && $actionName === 'ratings') : ?>
-                    <div class="<?= $class ?>">
+                    <div class="col-sm-4">
                         <?= $this->element->ratingStatus ?>
                     </div>
                 <?php endif; ?>
 
-                <?php if (isset($this->element->vid)) : ?>
-                    <div class="<?= $class ?>">
-                        <?= $this->element->vid ?>
-                    </div>
-                <?php endif; ?>
-
-                <?php if (isset($this->element->sid)) : ?>
-                    <div class="<?= $class ?>">
-                        <?= $this->element->sid ?>
-                    </div>
-                <?php endif; ?>
-
                 <?php if (isset($this->element->editors)) : ?>
-                    <div class="<?= $class ?>">
+                    <div class="col-sm-4">
                         <?= $this->element->editors ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if (isset($this->element->reviewers)) : ?>
-                    <div class="<?= $class ?>">
+                    <div class="col-sm-4">
                         <?= $this->element->reviewers ?>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <!-- Ligne 2 : Volume (large) | DOI -->
+            <div class="row">
+                <?php if (isset($this->element->vid)) : ?>
+                    <div class="col-sm-8">
+                        <?= $this->element->vid ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if (isset($this->element->doi)) : ?>
-                    <div class="<?= $class ?>">
+                    <div class="col-sm-4">
                         <?= $this->element->doi ?>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <!-- Ligne 3 : Section (large) | Repositories -->
+            <div class="row">
+                <?php if (isset($this->element->sid)) : ?>
+                    <div class="col-sm-8">
+                        <?= $this->element->sid ?>
                     </div>
                 <?php endif; ?>
 
                 <?php if (isset($this->element->repositories)) : ?>
-                    <div class="<?= $class ?>">
+                    <div class="col-sm-4">
                         <?= $this->element->repositories ?>
                     </div>
                 <?php endif; ?>

--- a/public/js/paper/submitted.js
+++ b/public/js/paper/submitted.js
@@ -34,17 +34,17 @@ $(document).ready(function () {
         }
 
         $('#submit').on('click', function () {
-            let filter_status = $status.length > 0 ? $status.val() : [''];
-            let filter_volume = $volume.length > 0 ? $volume.val() : [''];
-            let filter_section = $section.length > 0 ? $section.val() : [''];
-            let filter_editors = $editors.length > 0 ? $editors.val() : [''];
+            let filter_status = $status.length > 0 ? ($status.val() ?? ['']) : [''];
+            let filter_volume = $volume.length > 0 ? ($volume.val() ?? ['']) : [''];
+            let filter_section = $section.length > 0 ? ($section.val() ?? ['']) : [''];
+            let filter_editors = $editors.length > 0 ? ($editors.val() ?? ['']) : [''];
             let filter_ratingStatus =
-                $ratingStatus.length > 0 ? $ratingStatus.val() : [''];
+                $ratingStatus.length > 0 ? ($ratingStatus.val() ?? ['']) : [''];
             let filter_reviewers =
-                $reviewers.length > 0 ? $reviewers.val() : [''];
-            let filter_doi = $doi.length > 0 ? $doi.val() : [''];
+                $reviewers.length > 0 ? ($reviewers.val() ?? ['']) : [''];
+            let filter_doi = $doi.length > 0 ? ($doi.val() ?? ['']) : [''];
             let filter_repositories =
-                $repositories.length > 0 ? $repositories.val() : [''];
+                $repositories.length > 0 ? ($repositories.val() ?? ['']) : [''];
 
             let filters = {
                 status: filter_status,


### PR DESCRIPTION
## Summary

- Replace native multiselects in the admin **paper/list** filter panel with **Tom Select 2** (CDN, default theme), enabling search/filtering within long lists (Volume, Section, Editors, Reviewers, Status, DOI, Repositories)
- Reorganise filter layout into 3 purposeful rows (Status/Editors/Reviewers | Volume+DOI | Section+Repositories)
- Fix a `null.length` crash in `checkFilterParams` when Tom Select returns `null` from an empty multiselect

## Changes

### `administratepaper/list.phtml`
- Load Tom Select CSS + JS from jsDelivr CDN
- `initTomSelects()` initialises all 7 filter selects: `remove_button` plugin, animated `▾` chevron, placeholder from the existing "All" option
- CSS overrides: hide native select (`display:none !important`), fix Bootstrap `form-control` height conflict on the wrapper, force dropdown to `position:absolute` + `z-index:1050` so it floats over content, apply Bootstrap brand-primary `#337ab7` for hover/selected states
- Remove the unused `layout()->description` that rendered a redundant blockquote

### `paper/filters.phtml`
- Reorganised into 3 rows matching the requested layout:
  - **Row 1**: Article Status `col-sm-4` | Editors `col-sm-4` | Reviewers `col-sm-4`
  - **Row 2**: Volume `col-sm-8` | DOI `col-sm-4`
  - **Row 3**: Section `col-sm-8` | Repositories `col-sm-4`

### `public/js/paper/submitted.js`
- All `.val()` calls now use `?? ['']` fallback — Tom Select returns `null` when nothing is selected in a multiselect; `checkFilterParams` requires arrays, causing a `TypeError` without this fix

## Test plan

- [ ] Open admin paper list (`/administratepaper/list`)
- [ ] Verify all 7 selects render as Tom Select controls with chevron and "All" placeholder
- [ ] Type in Volume/Section/Editors/Reviewers to confirm search filtering works
- [ ] Select one or more values and click **Filter these articles** — results should be filtered correctly
- [ ] Deselect all values and click **Filter** — all articles should be shown
- [ ] Open a dropdown and confirm elements below are not pushed down
- [ ] Confirm the redundant blockquote description no longer appears on the page