### PR TITLE
test(submit): extract and cover resolveVolumeAndSectionTags (hotfix PR #1037)

### DIFF
--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -2073,7 +2073,7 @@ class Episciences_Submit
             $outOfVol   = $translator->translate('Hors volume', $locale);
             $outOfSec   = $translator->translate('Hors rubrique', $locale);
 
-            $adminTags += self::resolveVolumeAndSectionTags($volume, $section, $locale, $noneFemale, $noneMale, $outOfVol, $outOfSec);
+            $adminTags = array_merge($adminTags, self::resolveVolumeAndSectionTags($volume, $section, $locale, $noneFemale, $noneMale, $outOfVol, $outOfSec));
 
             $adminTags [Episciences_Mail_Tags::TAG_SENDER_EMAIL] = Episciences_Auth::getEmail();
             $adminTags [Episciences_Mail_Tags::TAG_SENDER_FULL_NAME] = Episciences_Auth::getFullName();
@@ -2101,7 +2101,7 @@ class Episciences_Submit
      *
      * @param Episciences_Volume|bool|null    $volume
      * @param Episciences_Section|bool|null   $section
-     * @return array<string, string>
+     * @return array<string, string|int>
      */
     private static function resolveVolumeAndSectionTags(
         mixed $volume,

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -2071,33 +2071,14 @@ class Episciences_Submit
             $noneFemale = $translator->translate('Aucune', $locale);
             $noneMale   = $translator->translate('Aucun', $locale);
             $outOfVol   = $translator->translate('Hors volume', $locale);
+            $outOfSec   = $translator->translate('Hors rubrique', $locale);
 
-            $sName = !$section ? $translator->translate('Hors rubrique', $locale) : $section->getName($locale);
-
-            if (!$volume) {
-                $vName = $outOfVol;
-                $vBibRef = $noneFemale;
-                $vYear = $noneFemale;
-                $vNum = $noneMale;
-                $vType = $noneMale;
-            } else {
-                $vName = $volume->getName($locale) ?: $noneMale;
-                $vBibRef = $volume->getBib_reference() ?: $noneFemale;
-                $vNum = $volume->getVol_num() ?: $noneMale;
-                $vYear = $volume->getVol_year() ?: $noneFemale;
-                $vType = $volume->getVol_type() ?: $noneMale;
-            }
+            $adminTags += self::resolveVolumeAndSectionTags($volume, $section, $locale, $noneFemale, $noneMale, $outOfVol, $outOfSec);
 
             $adminTags [Episciences_Mail_Tags::TAG_SENDER_EMAIL] = Episciences_Auth::getEmail();
             $adminTags [Episciences_Mail_Tags::TAG_SENDER_FULL_NAME] = Episciences_Auth::getFullName();
             $adminTags [Episciences_Mail_Tags::TAG_ARTICLE_TITLE] = $paper->getTitle($locale, true);
             $adminTags [Episciences_Mail_Tags::TAG_AUTHORS_NAMES] = $paper->formatAuthorsMetadata($locale);
-            $adminTags [Episciences_Mail_Tags::TAG_VOLUME_NAME] = $vName;
-            $adminTags [Episciences_Mail_Tags::TAG_VOLUME_NUMBER] = $vNum;
-            $adminTags [Episciences_Mail_Tags::TAG_VOLUME_YEAR] = $vYear;
-            $adminTags [Episciences_Mail_Tags::TAG_VOLUME_TYPE] = $vType;
-            $adminTags [Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF] = $vBibRef;
-            $adminTags [Episciences_Mail_Tags::TAG_SECTION_NAME] = $sName;
 
             if (!$canReplace) { // new submission only
                 $rTag = $recipient instanceof Episciences_Editor ? $recipient->getTag() : null;
@@ -2112,6 +2093,46 @@ class Episciences_Submit
 
             Episciences_Mail_Send::sendMailFromReview($recipient, $templateKey, $adminTags, $paper);
         }
+    }
+
+    /**
+     * Resolves volume and section mail tags from their respective objects.
+     * Accepts false/null for $volume and $section (ZF1 find() returns false when not found).
+     *
+     * @param Episciences_Volume|bool|null    $volume
+     * @param Episciences_Section|bool|null   $section
+     * @return array<string, string>
+     */
+    private static function resolveVolumeAndSectionTags(
+        mixed $volume,
+        mixed $section,
+        string $locale,
+        string $noneFemale,
+        string $noneMale,
+        string $outOfVol,
+        string $outOfSection
+    ): array {
+        $sName = !$section ? $outOfSection : $section->getName($locale);
+
+        if (!$volume) {
+            return [
+                Episciences_Mail_Tags::TAG_VOLUME_NAME    => $outOfVol,
+                Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF => $noneFemale,
+                Episciences_Mail_Tags::TAG_VOLUME_YEAR    => $noneFemale,
+                Episciences_Mail_Tags::TAG_VOLUME_NUMBER  => $noneMale,
+                Episciences_Mail_Tags::TAG_VOLUME_TYPE    => $noneMale,
+                Episciences_Mail_Tags::TAG_SECTION_NAME   => $sName,
+            ];
+        }
+
+        return [
+            Episciences_Mail_Tags::TAG_VOLUME_NAME    => $volume->getName($locale) ?: $noneMale,
+            Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF => $volume->getBib_reference() ?: $noneFemale,
+            Episciences_Mail_Tags::TAG_VOLUME_NUMBER  => $volume->getVol_num() ?: $noneMale,
+            Episciences_Mail_Tags::TAG_VOLUME_YEAR    => $volume->getVol_year() ?: $noneFemale,
+            Episciences_Mail_Tags::TAG_VOLUME_TYPE    => $volume->getVol_type() ?: $noneMale,
+            Episciences_Mail_Tags::TAG_SECTION_NAME   => $sName,
+        ];
     }
 
     /**

--- a/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
+++ b/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
@@ -536,4 +536,183 @@ final class Episciences_Submit_PrivateMethodsTest extends TestCase
         // (array)42 = [42] → filter → [42]
         self::assertContains(42, $result);
     }
+
+    // =========================================================================
+    // GROUP D — resolveVolumeAndSectionTags()  (hotfix PR #1037 / feat #930)
+    // =========================================================================
+    //
+    // Before the fix, $volume could be `false` (ZF1 find() returns false when
+    // the row is not found). The nullsafe operator ?-> only skips null, not
+    // false, causing "Call to a member function getVol_num() on bool".
+    // The helper now uses !$volume to handle both null and false.
+
+    /** @return array<string, string> */
+    private function invokeTags(mixed $volume, mixed $section, string $locale = 'en'): array
+    {
+        return $this->invoke(
+            'resolveVolumeAndSectionTags',
+            [$volume, $section, $locale, 'None_F', 'None_M', 'Out_of_vol', 'Out_of_sec']
+        );
+    }
+
+    private function mockVolume(
+        string $name = 'Vol A',
+        ?int   $num  = 3,
+        string $year = '2024',
+        string $type = 'special',
+        string $bib  = 'BIB-1'
+    ): \Episciences_Volume {
+        $v = $this->createMock(\Episciences_Volume::class);
+        $v->method('getName')->willReturn($name);
+        $v->method('getVol_num')->willReturn($num);
+        $v->method('getVol_year')->willReturn($year);
+        $v->method('getVol_type')->willReturn($type);
+        $v->method('getBib_reference')->willReturn($bib);
+        return $v;
+    }
+
+    private function mockSection(string $name = 'Sec A'): \Episciences_Section
+    {
+        $s = $this->createMock(\Episciences_Section::class);
+        $s->method('getName')->willReturn($name);
+        return $s;
+    }
+
+    // --- volume is false (ZF1 find() returns false on no result) ---
+
+    public function testVolumeTagsWhenVolumeIsFalse(): void
+    {
+        $tags = $this->invokeTags(false, false);
+
+        self::assertSame('Out_of_vol', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NAME]);
+        self::assertSame('None_F',     $tags[\Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF]);
+        self::assertSame('None_F',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_YEAR]);
+        self::assertSame('None_M',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_NUMBER]);
+        self::assertSame('None_M',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_TYPE]);
+    }
+
+    // --- volume is null (paper without volume) ---
+
+    public function testVolumeTagsWhenVolumeIsNull(): void
+    {
+        $tags = $this->invokeTags(null, null);
+
+        self::assertSame('Out_of_vol', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NAME]);
+        self::assertSame('None_M',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_NUMBER]);
+        self::assertSame('None_F',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_YEAR]);
+        self::assertSame('None_M',     $tags[\Episciences_Mail_Tags::TAG_VOLUME_TYPE]);
+        self::assertSame('None_F',     $tags[\Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF]);
+    }
+
+    // --- volume object with all fields populated ---
+
+    public function testVolumeTagsWithCompleteVolume(): void
+    {
+        $tags = $this->invokeTags($this->mockVolume('Volume Alpha', 7, '2025', 'proceedings', 'REF-42'), null);
+
+        self::assertSame('Volume Alpha', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NAME]);
+        self::assertSame(7,              $tags[\Episciences_Mail_Tags::TAG_VOLUME_NUMBER]);
+        self::assertSame('2025',         $tags[\Episciences_Mail_Tags::TAG_VOLUME_YEAR]);
+        self::assertSame('proceedings',  $tags[\Episciences_Mail_Tags::TAG_VOLUME_TYPE]);
+        self::assertSame('REF-42',       $tags[\Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF]);
+    }
+
+    // --- volume with empty/null fields falls back to None placeholders ---
+
+    public function testVolumeTagsWithNullSubFieldsFallBackToPlaceholders(): void
+    {
+        $v = $this->createMock(\Episciences_Volume::class);
+        $v->method('getName')->willReturn('');        // empty → ?: None_M
+        $v->method('getVol_num')->willReturn(null);   // null  → ?: None_M
+        $v->method('getVol_year')->willReturn(null);  // null  → ?: None_F
+        $v->method('getVol_type')->willReturn(null);  // null  → ?: None_M
+        $v->method('getBib_reference')->willReturn(''); // ''  → ?: None_F
+
+        $tags = $this->invokeTags($v, null);
+
+        self::assertSame('None_M', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NAME]);
+        self::assertSame('None_M', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NUMBER]);
+        self::assertSame('None_F', $tags[\Episciences_Mail_Tags::TAG_VOLUME_YEAR]);
+        self::assertSame('None_M', $tags[\Episciences_Mail_Tags::TAG_VOLUME_TYPE]);
+        self::assertSame('None_F', $tags[\Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF]);
+    }
+
+    // --- locale is forwarded to getName() ---
+
+    public function testVolumeNameLocaleIsForwarded(): void
+    {
+        $v = $this->createMock(\Episciences_Volume::class);
+        $v->expects(self::once())->method('getName')->with('fr')->willReturn('Nom FR');
+        $v->method('getVol_num')->willReturn(1);
+        $v->method('getVol_year')->willReturn('2024');
+        $v->method('getVol_type')->willReturn('regular');
+        $v->method('getBib_reference')->willReturn('X');
+
+        $tags = $this->invoke(
+            'resolveVolumeAndSectionTags',
+            [$v, null, 'fr', 'None_F', 'None_M', 'Out_of_vol', 'Out_of_sec']
+        );
+
+        self::assertSame('Nom FR', $tags[\Episciences_Mail_Tags::TAG_VOLUME_NAME]);
+    }
+
+    // --- section is false ---
+
+    public function testSectionTagWhenSectionIsFalse(): void
+    {
+        $tags = $this->invokeTags(false, false);
+        self::assertSame('Out_of_sec', $tags[\Episciences_Mail_Tags::TAG_SECTION_NAME]);
+    }
+
+    // --- section is null ---
+
+    public function testSectionTagWhenSectionIsNull(): void
+    {
+        $tags = $this->invokeTags(null, null);
+        self::assertSame('Out_of_sec', $tags[\Episciences_Mail_Tags::TAG_SECTION_NAME]);
+    }
+
+    // --- section object with a name ---
+
+    public function testSectionTagWithValidSection(): void
+    {
+        $tags = $this->invokeTags($this->mockVolume(), $this->mockSection('My Section'));
+        self::assertSame('My Section', $tags[\Episciences_Mail_Tags::TAG_SECTION_NAME]);
+    }
+
+    // --- section locale is forwarded to getName() ---
+
+    public function testSectionNameLocaleIsForwarded(): void
+    {
+        $s = $this->createMock(\Episciences_Section::class);
+        $s->expects(self::once())->method('getName')->with('de')->willReturn('Abschnitt DE');
+
+        $tags = $this->invoke(
+            'resolveVolumeAndSectionTags',
+            [$this->mockVolume(), $s, 'de', 'None_F', 'None_M', 'Out_of_vol', 'Out_of_sec']
+        );
+
+        self::assertSame('Abschnitt DE', $tags[\Episciences_Mail_Tags::TAG_SECTION_NAME]);
+    }
+
+    // --- return array contains all 6 expected keys ---
+
+    public function testAllSixTagKeysAlwaysPresent(): void
+    {
+        $expected = [
+            \Episciences_Mail_Tags::TAG_VOLUME_NAME,
+            \Episciences_Mail_Tags::TAG_VOLUME_NUMBER,
+            \Episciences_Mail_Tags::TAG_VOLUME_YEAR,
+            \Episciences_Mail_Tags::TAG_VOLUME_TYPE,
+            \Episciences_Mail_Tags::TAG_VOL_BIBLIOG_REF,
+            \Episciences_Mail_Tags::TAG_SECTION_NAME,
+        ];
+
+        foreach ([null, false, $this->mockVolume()] as $volume) {
+            $tags = $this->invokeTags($volume, null);
+            foreach ($expected as $key) {
+                self::assertArrayHasKey($key, $tags, "Missing tag $key when volume=" . gettype($volume));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Extrait la logique de résolution des tags volume/section de `notifyManagers()` dans un helper `private static resolveVolumeAndSectionTags()`, testable en isolation
- Ce helper gère correctement `false` **et** `null` pour `$volume`/`$section` (ZF1 `find()` retourne `false` quand la ligne n'existe pas, pas seulement `null` — c'était la cause racine du crash corrigé dans le PR #1037)
- Ajoute 10 tests unitaires (GROUP D dans `Episciences_Submit_PrivateMethodsTest`) couvrant tous les chemins du helper

## Test plan

- [x] `make test-php` : 4110 tests, 0 failure, 18 skips
- [x] Cas `$volume = false` → fallbacks (régression principale du hotfix #1037)
- [x] Cas `$volume = null` → fallbacks
- [x] Volume complet → données utilisées
- [x] Champs vides/null dans le volume → placeholders genre-accordés (`None_M`/`None_F`)
- [x] Locale transmise à `getName()` du volume et de la section
- [x] Section `false`/`null` → `outOfSection`
- [x] Les 6 clés de tags toujours présentes quel que soit l'état du volume