### PR TITLE
fix(volume): prevent JSON parse error when metadata contains quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin paper list: removed redundant page description blockquote.
 
 ### Fixed
+- [#1048](https://github.com/CCSDForge/episciences/issues/1048) Volume metadata: quotes in preface/content caused JSON parsing error when editing. Removed `double_encode=false` from `form.phtml` display while keeping it in `Volume.php` save to prevent double-encoding (#962).
 - [#1039](https://github.com/CCSDForge/episciences/issues/1039) The MIME type for docx files is detected as "application/octet-stream"
 - Application error: Call to a member function getVol_num() on bool
 

--- a/application/modules/journal/views/scripts/volume/form.phtml
+++ b/application/modules/journal/views/scripts/volume/form.phtml
@@ -69,7 +69,7 @@
                                     class="glyphicon glyphicon-trash"></span></button>
 					</span>
                                 <input type="hidden"
-                                       value="<?= htmlspecialchars(Zend_Json::encode(['id' => $metadata->getId(), 'title' => $metadata->getTitles(), 'content' => $metadata->getContents(), 'file' => $metadata->getFile()]), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false) ?>">
+                                       value="<?= htmlspecialchars(Zend_Json::encode(['id' => $metadata->getId(), 'title' => $metadata->getTitles(), 'content' => $metadata->getContents(), 'file' => $metadata->getFile()]), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
                             </div>
                         <?php endforeach; ?>
 


### PR DESCRIPTION
Remove double_encode=false from form.phtml to ensure proper JSON encoding.
Keep double_encode=false in Volume.php to prevent double encoding when saving.