### PR TITLE
feat(sitemap): replace changefreq/priority with real lastmod dates and add page entries

### DIFF
--- a/scripts/GenerateSitemapCommand.php
+++ b/scripts/GenerateSitemapCommand.php
@@ -105,7 +105,8 @@ class GenerateSitemapCommand extends Command
         $entries = array_merge(
             $this->getSitemapGenericEntries($rvcode, $languages),
             $this->getSitemapVolumeAndSectionEntries($rvcode, $rvid, $languages),
-            $this->getSitemapArticleEntries($rvcode, $client, $logger, $languages)
+            $this->getSitemapPageEntries($rvcode, $client, $logger, $languages),
+            $this->getSitemapArticleEntries($rvcode, $client, $logger, $languages),
         );
 
         if (empty($entries)) {
@@ -137,12 +138,14 @@ class GenerateSitemapCommand extends Command
                 $data     = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
 
                 foreach ($data['hydra:member'] as $paper) {
+                    $modDate = $paper['document']['database']['current']['dates']['modification_date']
+                        ?? $paper['modification_date']
+                        ?? null;
+                    $lastmod = $modDate ? date('Y-m-d', strtotime($modDate)) : null;
                     foreach ($this->buildLocUrls($base, '/articles/' . $paper['docid'], $languages) as $loc) {
                         $entries[] = [
-                            'loc'        => $loc,
-                            'lastmod'    => null,
-                            'changefreq' => 'weekly',
-                            'priority'   => '0.9',
+                            'loc'     => $loc,
+                            'lastmod' => $lastmod,
                         ];
                     }
                 }
@@ -157,6 +160,39 @@ class GenerateSitemapCommand extends Command
     }
 
     /**
+     * Fetch visible page entries from the Episciences API.
+     *
+     * @param string[] $languages
+     * @return array<int, array<string, mixed>>
+     */
+    private function getSitemapPageEntries(string $rvcode, Client $client, Logger $logger, array $languages): array
+    {
+        $base    = sprintf('https://%s.%s', $rvcode, DOMAIN);
+        $url     = EPISCIENCES_API_URL . "pages?pagination=false&rvcode={$rvcode}";
+        $entries = [];
+
+        try {
+            $response = $client->get($url);
+            $pages    = json_decode($response->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
+
+            foreach ($pages as $page) {
+                $dateUpdated = $page['date_updated'] ?? null;
+                $lastmod     = $dateUpdated ? date('Y-m-d', strtotime($dateUpdated)) : null;
+                foreach ($this->buildLocUrls($base, '/' . $page['page_code'], $languages) as $loc) {
+                    $entries[] = [
+                        'loc'     => $loc,
+                        'lastmod' => $lastmod,
+                    ];
+                }
+            }
+        } catch (GuzzleException $e) {
+            $logger->error('Error fetching pages from API', ['rvcode' => $rvcode, 'error' => $e->getMessage()]);
+        }
+
+        return $entries;
+    }
+
+    /**
      * Build static generic URL entries (home, articles, authors, volumes, sections, about).
      *
      * @param string[] $languages
@@ -164,26 +200,13 @@ class GenerateSitemapCommand extends Command
      */
     private function getSitemapGenericEntries(string $rvcode, array $languages): array
     {
-        $base = sprintf('https://%s.%s', $rvcode, DOMAIN);
-
-        $specs = [
-            ['path' => '/',         'changefreq' => 'daily',  'priority' => '1'],
-            ['path' => '/articles', 'changefreq' => 'daily',  'priority' => '0.8'],
-            ['path' => '/authors',  'changefreq' => 'daily',  'priority' => '0.8'],
-            ['path' => '/volumes',  'changefreq' => 'weekly', 'priority' => '0.8'],
-            ['path' => '/sections', 'changefreq' => 'weekly', 'priority' => '0.8'],
-            ['path' => '/about',    'changefreq' => 'weekly', 'priority' => '0.8'],
-        ];
+        $base  = sprintf('https://%s.%s', $rvcode, DOMAIN);
+        $paths = ['/', '/articles', '/authors', '/volumes', '/sections', '/about'];
 
         $entries = [];
-        foreach ($specs as $spec) {
-            foreach ($this->buildLocUrls($base, $spec['path'], $languages) as $loc) {
-                $entries[] = [
-                    'loc'        => $loc,
-                    'lastmod'    => null,
-                    'changefreq' => $spec['changefreq'],
-                    'priority'   => $spec['priority'],
-                ];
+        foreach ($paths as $path) {
+            foreach ($this->buildLocUrls($base, $path, $languages) as $loc) {
+                $entries[] = ['loc' => $loc];
             }
         }
 
@@ -205,14 +228,14 @@ class GenerateSitemapCommand extends Command
         $vids = $db->fetchCol($db->select()->from(T_VOLUMES, 'VID')->where('RVID = ?', $rvid));
         foreach ($vids as $vid) {
             foreach ($this->buildLocUrls($base, '/volumes/' . $vid, $languages) as $loc) {
-                $entries[] = ['loc' => $loc, 'lastmod' => null, 'changefreq' => 'weekly', 'priority' => '0.8'];
+                $entries[] = ['loc' => $loc];
             }
         }
 
         $sids = $db->fetchCol($db->select()->from(T_SECTIONS, 'SID')->where('RVID = ?', $rvid));
         foreach ($sids as $sid) {
             foreach ($this->buildLocUrls($base, '/sections/' . $sid, $languages) as $loc) {
-                $entries[] = ['loc' => $loc, 'lastmod' => null, 'changefreq' => 'weekly', 'priority' => '0.8'];
+                $entries[] = ['loc' => $loc];
             }
         }
 

--- a/tests/unit/scripts/GenerateSitemapCommandTest.php
+++ b/tests/unit/scripts/GenerateSitemapCommandTest.php
@@ -3,6 +3,10 @@
 namespace unit\scripts;
 
 use GenerateSitemapCommand;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -17,6 +21,16 @@ require_once __DIR__ . '/../../../scripts/GenerateSitemapCommand.php';
 class GenerateSitemapCommandTest extends TestCase
 {
     private GenerateSitemapCommand $command;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('DOMAIN')) {
+            define('DOMAIN', 'episciences.org');
+        }
+        if (!defined('EPISCIENCES_API_URL')) {
+            define('EPISCIENCES_API_URL', 'https://api.episciences.org/api/');
+        }
+    }
 
     protected function setUp(): void
     {
@@ -55,7 +69,7 @@ class GenerateSitemapCommandTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // getSitemapGenericEntries() — tested via reflection (pure, no HTTP/DB)
+    // Helpers
     // -------------------------------------------------------------------------
 
     /** @return array<int, array<string, mixed>> */
@@ -72,6 +86,20 @@ class GenerateSitemapCommandTest extends TestCase
         $method = new ReflectionMethod(GenerateSitemapCommand::class, 'buildLocUrls');
         $method->setAccessible(true);
         return $method->invoke($this->command, $base, $path, $languages);
+    }
+
+    private function makeClient(array $responses): Client
+    {
+        $mock    = new MockHandler($responses);
+        $handler = HandlerStack::create($mock);
+        return new Client(['handler' => $handler]);
+    }
+
+    private function callPrivate(string $method, array $args): mixed
+    {
+        $ref = new ReflectionMethod(GenerateSitemapCommand::class, $method);
+        $ref->setAccessible(true);
+        return $ref->invokeArgs($this->command, $args);
     }
 
     // -------------------------------------------------------------------------
@@ -116,12 +144,12 @@ class GenerateSitemapCommandTest extends TestCase
         $this->assertCount(6, $entries);
     }
 
-    public function testGetSitemapGenericEntries_AllEntriesHaveRequiredKeys(): void
+    public function testGetSitemapGenericEntries_AllEntriesHaveLocOnly(): void
     {
         foreach ($this->getSitemapGenericEntries('dmtcs') as $entry) {
             $this->assertArrayHasKey('loc', $entry);
-            $this->assertArrayHasKey('changefreq', $entry);
-            $this->assertArrayHasKey('priority', $entry);
+            $this->assertArrayNotHasKey('changefreq', $entry);
+            $this->assertArrayNotHasKey('priority', $entry);
         }
     }
 
@@ -132,35 +160,22 @@ class GenerateSitemapCommandTest extends TestCase
         }
     }
 
-    public function testGetSitemapGenericEntries_HomePageHasPriorityOneAndDailyFreq(): void
+    public function testGetSitemapGenericEntries_HomePageIsPresent(): void
     {
         $entries = $this->getSitemapGenericEntries('dmtcs');
-        $home    = array_filter($entries, fn($e) => str_ends_with($e['loc'], '/'));
-        $this->assertCount(1, $home);
-
-        $home = array_values($home)[0];
-        $this->assertSame('1', $home['priority']);
-        $this->assertSame('daily', $home['changefreq']);
+        $homes   = array_filter($entries, fn($e) => str_ends_with($e['loc'], '/'));
+        $this->assertCount(1, $homes);
     }
 
-    public function testGetSitemapGenericEntries_ArticlesAndAuthorsHaveDailyFreq(): void
+    public function testGetSitemapGenericEntries_AllExpectedPathsPresent(): void
     {
         $entries = $this->getSitemapGenericEntries('dmtcs');
-        $daily   = array_filter($entries, fn($e) => $e['changefreq'] === 'daily' && $e['priority'] === '0.8');
-        $locs    = array_column(array_values($daily), 'loc');
+        $locs    = array_column($entries, 'loc');
 
-        $this->assertCount(2, $daily);
-        $hasArticles = (bool) array_filter($locs, fn($l) => str_ends_with($l, '/articles'));
-        $hasAuthors  = (bool) array_filter($locs, fn($l) => str_ends_with($l, '/authors'));
-        $this->assertTrue($hasArticles, '/articles should have daily changefreq');
-        $this->assertTrue($hasAuthors,  '/authors should have daily changefreq');
-    }
-
-    public function testGetSitemapGenericEntries_VolumesHaveWeeklyFreq(): void
-    {
-        $entries = $this->getSitemapGenericEntries('dmtcs');
-        $weekly  = array_filter($entries, fn($e) => $e['changefreq'] === 'weekly');
-        $this->assertCount(3, $weekly);
+        foreach (['/articles', '/authors', '/volumes', '/sections', '/about'] as $path) {
+            $found = array_filter($locs, fn($l) => str_ends_with($l, $path));
+            $this->assertCount(1, $found, "Missing path {$path}");
+        }
     }
 
     public function testGetSitemapGenericEntries_AllLocsStartWithHttps(): void
@@ -198,14 +213,151 @@ class GenerateSitemapCommandTest extends TestCase
         $this->assertCount(6, $entries);
     }
 
-    public function testGetSitemapGenericEntries_WithLanguages_HomeHasPriorityOne(): void
+    public function testGetSitemapGenericEntries_WithLanguages_NoChangefreqOrPriority(): void
     {
         $entries = $this->getSitemapGenericEntries('jtcam', ['fr', 'en']);
-        $homes   = array_filter($entries, fn($e) => str_ends_with($e['loc'], '/en/') || str_ends_with($e['loc'], '/fr/'));
-        $this->assertCount(2, $homes);
-        foreach ($homes as $home) {
-            $this->assertSame('1', $home['priority']);
-            $this->assertSame('daily', $home['changefreq']);
+        foreach ($entries as $entry) {
+            $this->assertArrayNotHasKey('changefreq', $entry);
+            $this->assertArrayNotHasKey('priority', $entry);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // getSitemapArticleEntries() — lastmod from modification_date
+    // -------------------------------------------------------------------------
+
+    public function testGetSitemapArticleEntries_UsesModificationDateAsLastmod(): void
+    {
+        $body = json_encode([
+            'hydra:member' => [
+                [
+                    'docid'    => 42,
+                    'document' => [
+                        'database' => [
+                            'current' => [
+                                'dates' => ['modification_date' => '2026-06-01 15:26:04'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'hydra:view' => [],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapArticleEntries', ['jfp', $client, $logger, []]);
+
+        $this->assertCount(1, $entries);
+        $this->assertSame('2026-06-01', $entries[0]['lastmod']);
+        $this->assertStringEndsWith('/articles/42', $entries[0]['loc']);
+        $this->assertArrayNotHasKey('changefreq', $entries[0]);
+        $this->assertArrayNotHasKey('priority', $entries[0]);
+    }
+
+    public function testGetSitemapArticleEntries_NullModificationDate_OmitsLastmod(): void
+    {
+        $body = json_encode([
+            'hydra:member' => [['docid' => 7]],
+            'hydra:view'   => [],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapArticleEntries', ['ops', $client, $logger, []]);
+
+        $this->assertCount(1, $entries);
+        $this->assertNull($entries[0]['lastmod']);
+    }
+
+    public function testGetSitemapArticleEntries_WithLanguages_GeneratesOneUrlPerLang(): void
+    {
+        $body = json_encode([
+            'hydra:member' => [['docid' => 5]],
+            'hydra:view'   => [],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapArticleEntries', ['jtcam', $client, $logger, ['fr', 'en']]);
+
+        $this->assertCount(2, $entries);
+        $this->assertStringContainsString('/fr/articles/5', $entries[0]['loc']);
+        $this->assertStringContainsString('/en/articles/5', $entries[1]['loc']);
+    }
+
+    // -------------------------------------------------------------------------
+    // getSitemapPageEntries()
+    // -------------------------------------------------------------------------
+
+    public function testGetSitemapPageEntries_ReturnsPageCodeAsPath(): void
+    {
+        $body = json_encode([
+            ['page_code' => 'about',   'date_updated' => '2026-05-25T10:30:51+02:00'],
+            ['page_code' => 'contact', 'date_updated' => null],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapPageEntries', ['jfp', $client, $logger, []]);
+
+        $this->assertCount(2, $entries);
+        $this->assertStringEndsWith('/about', $entries[0]['loc']);
+        $this->assertStringEndsWith('/contact', $entries[1]['loc']);
+    }
+
+    public function testGetSitemapPageEntries_UsesDateUpdatedAsLastmod(): void
+    {
+        $body = json_encode([
+            ['page_code' => 'about', 'date_updated' => '2026-05-25T10:30:51+02:00'],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapPageEntries', ['jfp', $client, $logger, []]);
+
+        $this->assertSame('2026-05-25', $entries[0]['lastmod']);
+    }
+
+    public function testGetSitemapPageEntries_NullDateUpdated_OmitsLastmod(): void
+    {
+        $body = json_encode([
+            ['page_code' => 'about', 'date_updated' => null],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapPageEntries', ['jfp', $client, $logger, []]);
+
+        $this->assertNull($entries[0]['lastmod']);
+    }
+
+    public function testGetSitemapPageEntries_WithLanguages_GeneratesOneUrlPerLang(): void
+    {
+        $body = json_encode([
+            ['page_code' => 'about', 'date_updated' => '2026-01-01T00:00:00+00:00'],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapPageEntries', ['jtcam', $client, $logger, ['fr', 'en']]);
+
+        $this->assertCount(2, $entries);
+        $this->assertStringContainsString('/fr/about', $entries[0]['loc']);
+        $this->assertStringContainsString('/en/about', $entries[1]['loc']);
+    }
+
+    public function testGetSitemapPageEntries_NoChangefreqOrPriority(): void
+    {
+        $body = json_encode([
+            ['page_code' => 'about', 'date_updated' => '2026-01-01T00:00:00+00:00'],
+        ]);
+
+        $client  = $this->makeClient([new Response(200, [], $body)]);
+        $logger  = $this->createMock(\Monolog\Logger::class);
+        $entries = $this->callPrivate('getSitemapPageEntries', ['jfp', $client, $logger, []]);
+
+        $this->assertArrayNotHasKey('changefreq', $entries[0]);
+        $this->assertArrayNotHasKey('priority', $entries[0]);
     }
 }


### PR DESCRIPTION
## Summary

- Remove static `<changefreq>` and `<priority>` tags from all sitemap entries in favour of the minimal format recommended by Google
- Add real `<lastmod>` for articles from `document.database.current.dates.modification_date` (omitted when unavailable)
- Add a new `getSitemapPageEntries()` method that fetches visible journal pages via `pages?pagination=false&rvcode=…` and uses `date_updated` as `<lastmod>`
- Individual volume and section URLs (`/volumes/{vid}`, `/sections/{sid}`) are included without `<lastmod>`

## Test plan

- [ ] Existing `buildLocUrls` tests still pass
- [ ] Generic entries tests updated: no `changefreq` / `priority`, all 6 paths present
- [ ] New `getSitemapArticleEntries` tests: `lastmod` set from `modification_date`, `null` when absent, language prefixes
- [ ] New `getSitemapPageEntries` tests: `page_code` as path, `date_updated` as `lastmod`, `null` when absent, language prefixes, no `changefreq`/`priority`
- [ ] `make test-php -- --filter GenerateSitemapCommandTest`
- [ ] Manual run: `php scripts/console.php sitemap:generate --rvcode=ops --pretty` → pages have `<lastmod>`, articles without dates have no `<lastmod>`