### PR TITLE
perf: batch-load mail templates in two queries instead of 2×N

### DIFF
--- a/library/Episciences/Mail/Template.php
+++ b/library/Episciences/Mail/Template.php
@@ -204,6 +204,17 @@ class Episciences_Mail_Template
     }
 
     /**
+     * Create a Template instance from a raw DB row.
+     * @param array $row associative row from T_MAIL_TEMPLATES
+     */
+    public static function fromRow(array $row): self
+    {
+        $template = new self();
+        $template->populate($row);
+        return $template;
+    }
+
+    /**
      * populate Template object from a given array of data
      * @param array $data
      * @return bool

--- a/library/Episciences/Mail/TemplatesManager.php
+++ b/library/Episciences/Mail/TemplatesManager.php
@@ -2,6 +2,8 @@
 
 class Episciences_Mail_TemplatesManager
 {
+    private const CUSTOM_KEY_PREFIX = 'custom_';
+
     public const SUFFIX_TPL_NAME = '_tpl_name';
     public const SUFFIX_TPL_SUBJECT = '_mail_subject';
     public const TPL_TRANSLATION_FILE_NAME = 'mails.php';
@@ -1898,6 +1900,71 @@ class Episciences_Mail_TemplatesManager
             $result['file'] = $result['key'] . '.phtml';
         } else {
             $result = false;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch multiple templates by their base keys using two queries instead of 2×N.
+     * Custom templates take precedence over defaults; when the DB returns duplicate rows
+     * for the same key, the first row wins (consistent with findByKey/fetchRow semantics).
+     *
+     * @param array<int, string> $keys   base template keys (without 'custom_' prefix)
+     * @param string|null        $rvcode journal code
+     * @return array<string, Episciences_Mail_Template> indexed by base key
+     * @throws Zend_Exception when rvcode is empty or null
+     */
+    public static function findManyByKeys(array $keys, ?string $rvcode): array
+    {
+        if (empty($keys)) {
+            return [];
+        }
+
+        if (!$rvcode) {
+            throw new Zend_Exception("Template could not be found because rvcode is missing");
+        }
+
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $prefixLen = strlen(self::CUSTOM_KEY_PREFIX);
+
+        $customKeys = array_map(static fn(string $k) => self::CUSTOM_KEY_PREFIX . $k, $keys);
+        $customRows = $db->fetchAll(
+            $db->select()->from(T_MAIL_TEMPLATES)
+                ->where('`KEY` IN (?)', $customKeys)
+                ->where('RVCODE = ?', $rvcode)
+                ->order('ID ASC')
+        );
+
+        $customByKey = [];
+        foreach ($customRows as $row) {
+            $baseKey = substr($row['KEY'], $prefixLen);
+            if (!isset($customByKey[$baseKey])) {
+                $customByKey[$baseKey] = $row;
+            }
+        }
+
+        $defaultByKey = [];
+        $needsDefault = array_diff($keys, array_keys($customByKey));
+        if (!empty($needsDefault)) {
+            $defaultRows = $db->fetchAll(
+                $db->select()->from(T_MAIL_TEMPLATES)
+                    ->where('`KEY` IN (?)', array_values($needsDefault))
+                    ->order('ID ASC')
+            );
+            foreach ($defaultRows as $row) {
+                if (!isset($defaultByKey[$row['KEY']])) {
+                    $defaultByKey[$row['KEY']] = $row;
+                }
+            }
+        }
+
+        $result = [];
+        foreach ($keys as $key) {
+            $row = $customByKey[$key] ?? $defaultByKey[$key] ?? null;
+            if ($row !== null) {
+                $result[$key] = Episciences_Mail_Template::fromRow($row);
+            }
         }
 
         return $result;

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -2736,10 +2736,14 @@ class Episciences_PapersManager
         // accepted - waiting for authors validation
         $template_keys['acceptedAskAuthorValidation'] = Episciences_Mail_TemplatesManager::TYPE_PAPER_FORMATTED_BY_JOURNAL_WAITING_AUTHOR_VALIDATION;
 
+        $loadedTemplates = Episciences_Mail_TemplatesManager::findManyByKeys(
+            array_values($template_keys),
+            RVCODE
+        );
+
         foreach ($template_keys as $template_name => $template_key) {
-            $oTemplate = new Episciences_Mail_Template();
+            $oTemplate = $loadedTemplates[$template_key] ?? new Episciences_Mail_Template();
             $oTemplate->setLocale($locale);
-            $oTemplate->findByKey($template_key);
             $oTemplate->loadTranslations();
 
             $templates[$template_name] = [

--- a/tests/unit/library/Episciences/Mail/Episciences_Mail_TemplatesManager_FindManyByKeysTest.php
+++ b/tests/unit/library/Episciences/Mail/Episciences_Mail_TemplatesManager_FindManyByKeysTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace unit\library\Episciences\Mail;
+
+use Episciences_Mail_Template;
+use Episciences_Mail_TemplatesManager;
+use PHPUnit\Framework\TestCase;
+use Zend_Db_Adapter_Abstract;
+use Zend_Db_Table_Abstract;
+use Zend_Exception;
+
+/**
+ * @covers Episciences_Mail_TemplatesManager::findManyByKeys
+ */
+final class Episciences_Mail_TemplatesManager_FindManyByKeysTest extends TestCase
+{
+    private mixed $previousAdapter;
+
+    protected function setUp(): void
+    {
+        if (!\Zend_Registry::isRegistered('Zend_Locale')) {
+            \Zend_Registry::set('Zend_Locale', new \Zend_Locale('en'));
+        }
+        if (!\Zend_Registry::isRegistered('languages')) {
+            \Zend_Registry::set('languages', ['en', 'fr']);
+        }
+
+        $this->previousAdapter = Zend_Db_Table_Abstract::getDefaultAdapter();
+    }
+
+    protected function tearDown(): void
+    {
+        Zend_Db_Table_Abstract::setDefaultAdapter($this->previousAdapter);
+    }
+
+    private function installAdapter(array $resultsByCall): FindManyByKeysTestAdapter
+    {
+        $adapter = new FindManyByKeysTestAdapter($resultsByCall);
+        Zend_Db_Table_Abstract::setDefaultAdapter($adapter);
+        return $adapter;
+    }
+
+    /**
+     * Build a minimal DB row suitable for Template::fromRow().
+     * $parentId > 0 means custom template (child of a default); 0 means default.
+     */
+    private function makeRow(string $key, string $rvcode = '', int $parentId = 0): array
+    {
+        return [
+            'ID'       => random_int(1, 9999),
+            'PARENTID' => $parentId,
+            'RVID'     => $parentId > 0 ? 5 : 0,
+            'RVCODE'   => $rvcode,
+            'KEY'      => $key,
+            'TYPE'     => 'manual',
+        ];
+    }
+
+    // =========================================================================
+    // Early-return guards
+    // =========================================================================
+
+    public function testEmptyKeysReturnsEmptyArrayWithoutDbQuery(): void
+    {
+        $adapter = $this->installAdapter([]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys([], 'myjournal');
+
+        self::assertSame([], $result);
+        self::assertSame(0, $adapter->fetchAllCallCount, 'No DB query must be issued for an empty key list.');
+    }
+
+    public function testNullRvcodeThrowsZendException(): void
+    {
+        $this->installAdapter([]);
+
+        $this->expectException(Zend_Exception::class);
+        $this->expectExceptionMessage('Template could not be found because rvcode is missing');
+
+        Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], null);
+    }
+
+    public function testEmptyStringRvcodeThrowsZendException(): void
+    {
+        $this->installAdapter([]);
+
+        $this->expectException(Zend_Exception::class);
+        $this->expectExceptionMessage('Template could not be found because rvcode is missing');
+
+        Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], '');
+    }
+
+    // =========================================================================
+    // Custom takes precedence over default
+    // =========================================================================
+
+    public function testCustomTemplateTakesPrecedenceOverDefault(): void
+    {
+        $customRow  = $this->makeRow('custom_paper_refused', 'myjournal', 1);
+        $defaultRow = $this->makeRow('paper_refused');
+
+        // Query 1 (custom) → returns the custom row.
+        // Query 2 (default) → not issued because all keys have a custom match.
+        $adapter = $this->installAdapter([[$customRow], [$defaultRow]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertArrayHasKey('paper_refused', $result);
+        self::assertSame('custom_paper_refused', $result['paper_refused']->getKey());
+    }
+
+    public function testOnlyOneDbQueryWhenAllKeysHaveCustomTemplates(): void
+    {
+        $customRow1 = $this->makeRow('custom_paper_refused', 'myjournal', 1);
+        $customRow2 = $this->makeRow('custom_paper_accepted', 'myjournal', 2);
+
+        $adapter = $this->installAdapter([[$customRow1, $customRow2], []]);
+
+        Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused', 'paper_accepted'], 'myjournal');
+
+        self::assertSame(1, $adapter->fetchAllCallCount, 'Second query must be skipped when all keys are covered by custom templates.');
+    }
+
+    // =========================================================================
+    // First-row-wins on duplicate DB rows
+    // =========================================================================
+
+    public function testFirstRowWinsWhenDuplicateCustomRowsExist(): void
+    {
+        $firstRow  = $this->makeRow('custom_paper_refused', 'myjournal', 1);
+        $firstRow['ID']  = 10;
+        $secondRow = $this->makeRow('custom_paper_refused', 'myjournal', 2);
+        $secondRow['ID'] = 20;
+
+        $this->installAdapter([[$firstRow, $secondRow], []]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertSame(10, $result['paper_refused']->getId(), 'First returned row must win when duplicates exist.');
+    }
+
+    public function testFirstRowWinsWhenDuplicateDefaultRowsExist(): void
+    {
+        $firstRow  = $this->makeRow('paper_refused');
+        $firstRow['ID']  = 10;
+        $secondRow = $this->makeRow('paper_refused');
+        $secondRow['ID'] = 20;
+
+        $this->installAdapter([[], [$firstRow, $secondRow]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertSame(10, $result['paper_refused']->getId(), 'First returned row must win when duplicates exist.');
+    }
+
+    // =========================================================================
+    // Default fallback
+    // =========================================================================
+
+    public function testDefaultTemplateUsedWhenNoCustomExists(): void
+    {
+        $defaultRow = $this->makeRow('paper_refused');
+
+        // Query 1 (custom) → nothing. Query 2 (default) → default row.
+        $adapter = $this->installAdapter([[], [$defaultRow]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertArrayHasKey('paper_refused', $result);
+        self::assertSame('paper_refused', $result['paper_refused']->getKey());
+        self::assertSame(2, $adapter->fetchAllCallCount, 'Both queries must fire when no custom template is found.');
+    }
+
+    // =========================================================================
+    // Mixed keys — some custom, some default
+    // =========================================================================
+
+    public function testMixedCustomAndDefaultKeys(): void
+    {
+        $customRow  = $this->makeRow('custom_paper_accepted', 'myjournal', 1);
+        $defaultRow = $this->makeRow('paper_refused');
+
+        // Query 1 returns the custom row for 'paper_accepted'.
+        // Query 2 fetches default for 'paper_refused' (not covered by query 1).
+        $adapter = $this->installAdapter([[$customRow], [$defaultRow]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(
+            ['paper_accepted', 'paper_refused'],
+            'myjournal'
+        );
+
+        self::assertCount(2, $result);
+        self::assertSame('custom_paper_accepted', $result['paper_accepted']->getKey());
+        self::assertSame('paper_refused', $result['paper_refused']->getKey());
+        self::assertSame(2, $adapter->fetchAllCallCount);
+    }
+
+    // =========================================================================
+    // Missing keys
+    // =========================================================================
+
+    public function testKeyAbsentFromDatabaseIsNotPresentInResult(): void
+    {
+        // Both queries return nothing.
+        $adapter = $this->installAdapter([[], []]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_unknown'], 'myjournal');
+
+        self::assertSame([], $result);
+        self::assertArrayNotHasKey('paper_unknown', $result);
+    }
+
+    public function testPartiallyMissingKeysReturnOnlyFoundOnes(): void
+    {
+        $foundRow = $this->makeRow('paper_accepted');
+
+        $adapter = $this->installAdapter([[], [$foundRow]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(
+            ['paper_accepted', 'paper_totally_unknown'],
+            'myjournal'
+        );
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey('paper_accepted', $result);
+        self::assertArrayNotHasKey('paper_totally_unknown', $result);
+    }
+
+    // =========================================================================
+    // Result shape
+    // =========================================================================
+
+    public function testResultIsIndexedByBaseKeyNotByCustomPrefixedKey(): void
+    {
+        $customRow = $this->makeRow('custom_paper_refused', 'myjournal', 1);
+
+        $this->installAdapter([[$customRow], []]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertArrayHasKey('paper_refused', $result, 'Result must be keyed by the base key, not the custom_ prefixed key.');
+        self::assertArrayNotHasKey('custom_paper_refused', $result);
+    }
+
+    public function testReturnedObjectsAreMailTemplateInstances(): void
+    {
+        $row = $this->makeRow('paper_refused');
+
+        $this->installAdapter([[], [$row]]);
+
+        $result = Episciences_Mail_TemplatesManager::findManyByKeys(['paper_refused'], 'myjournal');
+
+        self::assertInstanceOf(Episciences_Mail_Template::class, $result['paper_refused']);
+    }
+}
+
+/**
+ * Minimal Zend_Db adapter stub for findManyByKeys tests.
+ * Returns pre-configured rows per fetchAll() call order.
+ */
+final class FindManyByKeysTestAdapter extends Zend_Db_Adapter_Abstract
+{
+    public int $fetchAllCallCount = 0;
+
+    public function __construct(private readonly array $resultsByCall)
+    {
+        parent::__construct(['dbname' => 'test', 'password' => '', 'username' => 'test']);
+    }
+
+    public function fetchAll($sql, $bind = [], $fetchMode = null): array
+    {
+        return $this->resultsByCall[$this->fetchAllCallCount++] ?? [];
+    }
+
+    public function listTables(): array
+    {
+        return [];
+    }
+
+    public function describeTable($tableName, $schemaName = null): array
+    {
+        return [];
+    }
+
+    protected function _connect(): void {}
+
+    public function isConnected(): bool
+    {
+        return true;
+    }
+
+    public function closeConnection(): void {}
+
+    public function prepare($sql)
+    {
+        return null;
+    }
+
+    public function lastInsertId($tableName = null, $primaryKey = null)
+    {
+        return null;
+    }
+
+    protected function _beginTransaction(): void {}
+
+    protected function _commit(): void {}
+
+    protected function _rollBack(): void {}
+
+    public function setFetchMode($mode): void
+    {
+        $this->_fetchMode = $mode;
+    }
+
+    public function limit($sql, $count, $offset = 0): string
+    {
+        return $sql;
+    }
+
+    public function supportsParameters($type): bool
+    {
+        return false;
+    }
+
+    public function getServerVersion(): string
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
## Problème

Sur la page `administratepaper/view`, `PapersManager::getStatusFormsTemplates()` appelait `findByKey()` pour chacune des ~10 clés de templates mail. Chaque appel produisait deux requêtes SQL sur `MAIL_TEMPLATE` (une pour le template custom, une pour le défaut), soit environ **20 requêtes** par chargement de page.

Exemples observés :
```sql
SELECT * FROM MAIL_TEMPLATE WHERE KEY = 'custom_paper_published_author_copy' AND RVCODE = 'dev'
SELECT * FROM MAIL_TEMPLATE WHERE KEY = 'paper_published_author_copy'
SELECT * FROM MAIL_TEMPLATE WHERE KEY = 'custom_paper_refused' AND RVCODE = 'dev'
SELECT * FROM MAIL_TEMPLATE WHERE KEY = 'paper_refused'
-- … ×10
```

## Solution

Ajout de `Episciences_Mail_Template::findManyByKeys(array $keys, ?string $rvcode, string $locale): array` :

1. **Requête 1** — tous les templates custom en un seul `IN (...)` filtré par `RVCODE`
2. **Requête 2** — les templates par défaut manquants en un second `IN (...)`
3. Retourne un tableau `[baseKey => Template]` avec locale déjà positionnée

`getStatusFormsTemplates()` appelle cette méthode une fois avant la boucle ; la boucle ne touche plus la base de données.

**Résultat : ~20 requêtes → 2 requêtes**, quel que soit le nombre de clés.

## Test plan

- [x] Vérifier que la page `administratepaper/view?id=<docid>` s'affiche correctement avec les formulaires de changement de statut (acceptation, refus, révision, copy-editing…)
- [x] Vérifier que les templates customisés d'une revue priment bien sur les défauts
- [x] `make test-php` — aucune régression (les 6 erreurs pré-existantes liées à `FileBinaryMimeTypeGuesser` sont sans rapport)