### PR TITLE
feat: align relationship types with HAL and refactor configurations (#1059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1059](https://github.com/CCSDForge/episciences/issues/1059) Fixed method naming inconsistency (`RelationsShips` → `RelationShips`) in `Episciences\Paper\Relationship` and its callers; added missing `string` type hint on closure parameter to comply with PHPStan level 6.
 - [#1035](https://github.com/CCSDForge/episciences/issues/1035) Fixed an issue where editors were unable to proceed to the "copy editing" stage because the transition button was hidden behind an incorrect conditional block in the status dropdown menu.
 - Prevent the submission of a dataset or software that does not include a descriptor.
 - [#1048](https://github.com/CCSDForge/episciences/issues/1048) Volume metadata: quotes in preface/content caused JSON parsing error when editing. Removed `double_encode=false` from `form.phtml` display while keeping it in `Volume.php` save to prevent double-encoding (#962).

--- a/application/modules/journal/controllers/AdministratelinkeddataController.php
+++ b/application/modules/journal/controllers/AdministratelinkeddataController.php
@@ -215,7 +215,7 @@ class AdministratelinkeddataController extends Zend_Controller_Action
             }
             $this->view->supportedRelationShips = array_merge(
                 \Episciences\Paper\Relationship::getSupportedRelationShips(),
-                \Episciences\Paper\Relationship::getDisplayedRelationsShipsIntraWorkRelation()
+                \Episciences\Paper\Relationship::getDisplayedRelationShipsIntraWorkRelation()
             );
             $this->view->disabledValue = $disabledValue;
             $this->view->valueLd = $valueLd;

--- a/application/modules/journal/controllers/AdministratelinkeddataController.php
+++ b/application/modules/journal/controllers/AdministratelinkeddataController.php
@@ -213,7 +213,10 @@ class AdministratelinkeddataController extends Zend_Controller_Action
                     $idLd = $ldOptions['idLd'];
                 }
             }
-            $this->view->supportedRelationShips = Episciences_Paper_Dataset::getSupportedRelationShips();
+            $this->view->supportedRelationShips = array_merge(
+                \Episciences\Paper\Relationship::getSupportedRelationShips(),
+                \Episciences\Paper\Relationship::getDisplayedRelationsShipsIntraWorkRelation()
+            );
             $this->view->disabledValue = $disabledValue;
             $this->view->valueLd = $valueLd;
             $this->view->formId = $idForm;

--- a/application/modules/journal/views/scripts/export/crossref.phtml
+++ b/application/modules/journal/views/scripts/export/crossref.phtml
@@ -49,7 +49,8 @@ $enrichmentFundings = $paper->getFundings();
 $enrichmentLinkedData = $paper->getLinkedData();
 $bibliographicalRef = $paper->getBibRef();
 
-$interWorkRelationship = Episciences_Paper_Dataset::getFlattenedRelationships();
+$interWorkRelationship = \Episciences\Paper\Relationship::getFlattenedRelationships();
+$intraWorkRelationship = \Episciences\Paper\Relationship::getFlattenedRelationshipsIntraWorkRelation();
 
 $issn = Ccsd_View_Helper_FormatIssn::FormatIssn($journal->getSetting(Episciences_Review::SETTING_ISSN));
 
@@ -317,9 +318,12 @@ $paperLanguageRaw = $this->paperLanguage;
                         if (!isset($linkedData['relationship'])) {
                             $linkedData['relationship'] = 'references';
                         }
+                        $relationshipType = lcfirst($linkedData['relationship']);
+                        $isIntra = in_array($relationshipType, $intraWorkRelationship, true);
+                        $isInter = in_array($relationshipType, $interWorkRelationship, true);
                         ?>
 
-                        <?php if (in_array(lcfirst($linkedData['relationship']), $interWorkRelationship, true)) : ?>
+                        <?php if ($isIntra || $isInter) : ?>
                             <related_item>
                                 <?php
                                 $identifierType = strtolower($linkedData['link']);
@@ -339,9 +343,15 @@ $paperLanguageRaw = $this->paperLanguage;
                                     $linkedData['value'] = Episciences_DoiTools::cleanDoi( $linkedData['value']);
                                 }
                                 ?>
-                                <inter_work_relation
-                                        identifier-type="<?= $this->escape($identifierType) ?>"
-                                        relationship-type="<?= $this->escape(lcfirst($linkedData['relationship'])) ?>"><?php echo $this->escape($linkedData['value']) ?></inter_work_relation>
+                                <?php if ($isIntra) : ?>
+                                    <intra_work_relation
+                                            identifier-type="<?= $this->escape($identifierType) ?>"
+                                            relationship-type="<?= $this->escape($relationshipType) ?>"><?php echo $this->escape($linkedData['value']) ?></intra_work_relation>
+                                <?php else : ?>
+                                    <inter_work_relation
+                                            identifier-type="<?= $this->escape($identifierType) ?>"
+                                            relationship-type="<?= $this->escape($relationshipType) ?>"><?php echo $this->escape($linkedData['value']) ?></inter_work_relation>
+                                <?php endif; ?>
                             </related_item>
                         <?php endif; ?>
                     <?php } ?>

--- a/application/modules/journal/views/scripts/export/crossref.phtml
+++ b/application/modules/journal/views/scripts/export/crossref.phtml
@@ -50,6 +50,8 @@ $enrichmentLinkedData = $paper->getLinkedData();
 $bibliographicalRef = $paper->getBibRef();
 
 $interWorkRelationship = \Episciences\Paper\Relationship::getFlattenedRelationships();
+// Use the full intra list (including UI-hidden types) so that records stored via import
+// (e.g. isVersionOf, isFormatOf from HAL) are correctly classified in CrossRef XML.
 $intraWorkRelationship = \Episciences\Paper\Relationship::getFlattenedRelationshipsIntraWorkRelation();
 
 $issn = Ccsd_View_Helper_FormatIssn::FormatIssn($journal->getSetting(Episciences_Review::SETTING_ISSN));

--- a/library/Episciences/Paper/Dataset.php
+++ b/library/Episciences/Paper/Dataset.php
@@ -113,17 +113,17 @@ class Episciences_Paper_Dataset
     /**
      * @return array<string, array<int, string>>
      */
-    public static function getSupportedRelationsShipsIntraWorkRelation(): array
+    public static function getSupportedRelationShipsIntraWorkRelation(): array
     {
-        return \Episciences\Paper\Relationship::getSupportedRelationsShipsIntraWorkRelation();
+        return \Episciences\Paper\Relationship::getSupportedRelationShipsIntraWorkRelation();
     }
 
     /**
      * @return array<string, array<int, string>>
      */
-    public static function getDisplayedRelationsShipsIntraWorkRelation(): array
+    public static function getDisplayedRelationShipsIntraWorkRelation(): array
     {
-        return \Episciences\Paper\Relationship::getDisplayedRelationsShipsIntraWorkRelation();
+        return \Episciences\Paper\Relationship::getDisplayedRelationShipsIntraWorkRelation();
     }
 
     public function getMetatextCitation($format = 'rawText'): string

--- a/library/Episciences/Paper/Dataset.php
+++ b/library/Episciences/Paper/Dataset.php
@@ -103,6 +103,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::getSupportedRelationShips() directly.
      * @return array<string, array<int, string>>
      */
     public static function getSupportedRelationShips(): array
@@ -111,6 +112,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::getSupportedRelationShipsIntraWorkRelation() directly.
      * @return array<string, array<int, string>>
      */
     public static function getSupportedRelationShipsIntraWorkRelation(): array
@@ -119,6 +121,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::getDisplayedRelationShipsIntraWorkRelation() directly.
      * @return array<string, array<int, string>>
      */
     public static function getDisplayedRelationShipsIntraWorkRelation(): array
@@ -441,6 +444,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::removeFirstLevel() directly.
      * @param array<string|int, array<int, string>> $inputArray
      * @return array<int, string>
      */
@@ -450,6 +454,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::getFlattenedRelationships() directly.
      * @return array<int, string>
      */
     public static function getFlattenedRelationships(): array
@@ -458,6 +463,7 @@ class Episciences_Paper_Dataset
     }
 
     /**
+     * @deprecated Use \Episciences\Paper\Relationship::getFlattenedRelationshipsIntraWorkRelation() directly.
      * @return array<int, string>
      */
     public static function getFlattenedRelationshipsIntraWorkRelation(): array

--- a/library/Episciences/Paper/Dataset.php
+++ b/library/Episciences/Paper/Dataset.php
@@ -39,65 +39,7 @@ class Episciences_Paper_Dataset
         self::DOI_CODE => self::DOI_CODE,
         self::HAL_LINKED_DATA_SOFTWARE_HERITAGE_CODE => 'SWHID'
     ];
-    protected static array $supportedRelationShips = [
-        "Basis" => [
-            "isBasedOn",
-            "isBasisFor",
-            "basedOnData",
-            "isDataBasisFor"
-        ],
-        "Comment" => [
-            "isCommentOn",
-            "hasComment"
-        ],
-        "Continuation" => [
-            "isContinuedBy",
-            "continues"
-        ],
-        "Derivation" => [
-            "isDerivedFrom",
-            "hasDerivation"
-        ],
-        "Documentation" => [
-            "isDocumentedBy",
-            "documents"
-        ],
-        "Funding" => [
-            "isFinancedBy"
-        ],
-        "Part" => [
-            "isPartOf",
-            "hasPart"
-        ],
-        "Peer review" => [
-            "isReviewOf",
-            "hasReview"
-        ],
-        "References" => [
-            "references",
-            "isReferencedBy"
-        ],
-        "Related material" => [
-            "hasRelatedMaterial",
-            "isRelatedMaterial"
-        ],
-        "Reply" => [
-            "isReplyTo",
-            "hasReply"
-        ],
-        "Requirement" => [
-            "requires",
-            "isRequiredBy"
-        ],
-        "Software compilation" => [
-            "isCompiledBy",
-            "compiles"
-        ],
-        "Supplement" => [
-            "isSupplementTo",
-            "isSupplementedBy"
-        ]
-    ];
+
     /**
      * @var int
      */
@@ -161,11 +103,27 @@ class Episciences_Paper_Dataset
     }
 
     /**
-     * @return array
+     * @return array<string, array<int, string>>
      */
     public static function getSupportedRelationShips(): array
     {
-        return self::$supportedRelationShips;
+        return \Episciences\Paper\Relationship::getSupportedRelationShips();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function getSupportedRelationsShipsIntraWorkRelation(): array
+    {
+        return \Episciences\Paper\Relationship::getSupportedRelationsShipsIntraWorkRelation();
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function getDisplayedRelationsShipsIntraWorkRelation(): array
+    {
+        return \Episciences\Paper\Relationship::getDisplayedRelationsShipsIntraWorkRelation();
     }
 
     public function getMetatextCitation($format = 'rawText'): string
@@ -482,13 +440,29 @@ class Episciences_Paper_Dataset
         return $metaDataSource->getName();
     }
 
-    public static function removeFirstLevel(array $inputArray): array {
-        // Flatten the first level, only keeping the sub-level values
-        return array_merge(...array_values($inputArray));
+    /**
+     * @param array<string|int, array<int, string>> $inputArray
+     * @return array<int, string>
+     */
+    public static function removeFirstLevel(array $inputArray): array
+    {
+        return \Episciences\Paper\Relationship::removeFirstLevel($inputArray);
     }
 
-    public static function getFlattenedRelationships(): array {
-        return self::removeFirstLevel(self::$supportedRelationShips);
+    /**
+     * @return array<int, string>
+     */
+    public static function getFlattenedRelationships(): array
+    {
+        return \Episciences\Paper\Relationship::getFlattenedRelationships();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getFlattenedRelationshipsIntraWorkRelation(): array
+    {
+        return \Episciences\Paper\Relationship::getFlattenedRelationshipsIntraWorkRelation();
     }
 
 }

--- a/library/Episciences/Paper/Relationship.php
+++ b/library/Episciences/Paper/Relationship.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Episciences\Paper;
+
+class Relationship
+{
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected static array $supportedRelationShips = [
+        "Basis" => [
+            "isBasedOn",
+            "isBasisFor",
+            "basedOnData",
+            "isDataBasisFor"
+        ],
+        "Comment" => [
+            "isCommentOn",
+            "hasComment"
+        ],
+        "Continuation" => [
+            "isContinuedBy",
+            "continues"
+        ],
+        "Derivation" => [
+            "isDerivedFrom",
+            "hasDerivation"
+        ],
+        "Documentation" => [
+            "isDocumentedBy",
+            "documents"
+        ],
+        "Funding" => [
+            "isFinancedBy"
+        ],
+        "Part" => [
+            "isPartOf",
+            "hasPart"
+        ],
+        "Peer review" => [
+            "isReviewOf",
+            "hasReview"
+        ],
+        "References" => [
+            "references",
+            "isReferencedBy"
+        ],
+        "Related material" => [
+            "hasRelatedMaterial",
+            "isRelatedMaterial"
+        ],
+        "Reply" => [
+            "isReplyTo",
+            "hasReply"
+        ],
+        "Requirement" => [
+            "requires",
+            "isRequiredBy"
+        ],
+        "Software compilation" => [
+            "isCompiledBy",
+            "compiles"
+        ],
+        "Supplement" => [
+            "isSupplementTo",
+            "isSupplementedBy"
+        ]
+    ];
+
+    /**
+     * @var array<string, array<int, string>>
+     */
+    protected static array $supportedRelationsShips_intra_work_relation = [
+        "Translation" => [
+            "isTranslationOf",
+            "hasTranslation"
+        ],
+        "Preprint" => [
+            "isPreprintOf",
+            "hasPreprint"
+        ],
+        "Manuscript" => [
+            "isManuscriptOf",
+            "hasManuscript"
+        ],
+        "Expression" => [
+            "isExpressionOf",
+            "hasExpression"
+        ],
+        "Manifestation" => [
+            "isManifestationOf",
+            "hasManifestation"
+        ],
+        "Replacement" => [
+            "isReplacedBy",
+            "replaces"
+        ],
+        "Same as" => [
+            "isSameAs"
+        ],
+        "Identical" => [
+            "isIdenticalTo"
+        ],
+        "Variant form" => [
+            "isVariantFormOf",
+            "isOriginalFormOf"
+        ],
+        "Version" => [
+            "isVersionOf",
+            "hasVersion"
+        ],
+        "Format" => [
+            "isFormatOf",
+            "hasFormat"
+        ]
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    protected static array $hiddenRelations = [
+        "isPreprintOf", "hasPreprint",
+        "isManuscriptOf", "hasManuscript",
+        "isExpressionOf", "hasExpression",
+        "isManifestationOf", "hasManifestation",
+        "isIdenticalTo",
+        "isVariantFormOf", "isOriginalFormOf",
+        "isVersionOf", "hasVersion",
+        "isFormatOf", "hasFormat"
+    ];
+
+    /**
+     * @param array<string|int, array<int, string>> $inputArray
+     * @return array<int, string>
+     */
+    public static function removeFirstLevel(array $inputArray): array
+    {
+        if (empty($inputArray)) {
+            return [];
+        }
+        return array_merge(...array_values($inputArray));
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function getSupportedRelationShips(): array
+    {
+        return self::$supportedRelationShips;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function getSupportedRelationsShipsIntraWorkRelation(): array
+    {
+        return self::$supportedRelationsShips_intra_work_relation;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function getDisplayedRelationsShipsIntraWorkRelation(): array
+    {
+        $displayed = [];
+        foreach (self::$supportedRelationsShips_intra_work_relation as $group => $relations) {
+            $filteredRelations = array_filter($relations, function($relation) {
+                return !in_array($relation, self::$hiddenRelations, true);
+            });
+            if (!empty($filteredRelations)) {
+                $displayed[$group] = array_values($filteredRelations);
+            }
+        }
+        return $displayed;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getFlattenedRelationships(): array
+    {
+        return self::removeFirstLevel(self::$supportedRelationShips);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getFlattenedRelationshipsIntraWorkRelation(): array
+    {
+        return self::removeFirstLevel(self::$supportedRelationsShips_intra_work_relation);
+    }
+}

--- a/library/Episciences/Paper/Relationship.php
+++ b/library/Episciences/Paper/Relationship.php
@@ -118,6 +118,10 @@ class Relationship
     ];
 
     /**
+     * Relations excluded from the UI form dropdown but still valid in CrossRef XML exports.
+     * Use getFlattenedRelationshipsIntraWorkRelation() (full list) for export classification,
+     * and getDisplayedRelationShipsIntraWorkRelation() (filtered list) for form rendering.
+     *
      * @var array<int, string>
      */
     protected static array $hiddenRelations = [

--- a/library/Episciences/Paper/Relationship.php
+++ b/library/Episciences/Paper/Relationship.php
@@ -72,7 +72,7 @@ class Relationship
     /**
      * @var array<string, array<int, string>>
      */
-    protected static array $supportedRelationsShips_intra_work_relation = [
+    protected static array $supportedRelationShips_intra_work_relation = [
         "Translation" => [
             "isTranslationOf",
             "hasTranslation"
@@ -154,19 +154,19 @@ class Relationship
     /**
      * @return array<string, array<int, string>>
      */
-    public static function getSupportedRelationsShipsIntraWorkRelation(): array
+    public static function getSupportedRelationShipsIntraWorkRelation(): array
     {
-        return self::$supportedRelationsShips_intra_work_relation;
+        return self::$supportedRelationShips_intra_work_relation;
     }
 
     /**
      * @return array<string, array<int, string>>
      */
-    public static function getDisplayedRelationsShipsIntraWorkRelation(): array
+    public static function getDisplayedRelationShipsIntraWorkRelation(): array
     {
         $displayed = [];
-        foreach (self::$supportedRelationsShips_intra_work_relation as $group => $relations) {
-            $filteredRelations = array_filter($relations, function($relation) {
+        foreach (self::$supportedRelationShips_intra_work_relation as $group => $relations) {
+            $filteredRelations = array_filter($relations, function(string $relation) {
                 return !in_array($relation, self::$hiddenRelations, true);
             });
             if (!empty($filteredRelations)) {
@@ -189,6 +189,6 @@ class Relationship
      */
     public static function getFlattenedRelationshipsIntraWorkRelation(): array
     {
-        return self::removeFirstLevel(self::$supportedRelationsShips_intra_work_relation);
+        return self::removeFirstLevel(self::$supportedRelationShips_intra_work_relation);
     }
 }

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_DatasetTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_DatasetTest.php
@@ -153,11 +153,11 @@ final class Episciences_Paper_DatasetTest extends TestCase
     }
 
     /**
-     * Test getSupportedRelationsShipsIntraWorkRelation
+     * Test getSupportedRelationShipsIntraWorkRelation
      */
-    public function testGetSupportedRelationsShipsIntraWorkRelation(): void
+    public function testGetSupportedRelationShipsIntraWorkRelation(): void
     {
-        $result = Episciences_Paper_Dataset::getSupportedRelationsShipsIntraWorkRelation();
+        $result = Episciences_Paper_Dataset::getSupportedRelationShipsIntraWorkRelation();
         
         self::assertIsArray($result);
         self::assertNotEmpty($result);
@@ -198,11 +198,11 @@ final class Episciences_Paper_DatasetTest extends TestCase
     }
 
     /**
-     * Test getDisplayedRelationsShipsIntraWorkRelation
+     * Test getDisplayedRelationShipsIntraWorkRelation
      */
-    public function testGetDisplayedRelationsShipsIntraWorkRelation(): void
+    public function testGetDisplayedRelationShipsIntraWorkRelation(): void
     {
-        $result = Episciences_Paper_Dataset::getDisplayedRelationsShipsIntraWorkRelation();
+        $result = Episciences_Paper_Dataset::getDisplayedRelationShipsIntraWorkRelation();
         
         self::assertIsArray($result);
         self::assertNotEmpty($result);

--- a/tests/unit/library/Episciences/paper/RelationshipTest.php
+++ b/tests/unit/library/Episciences/paper/RelationshipTest.php
@@ -143,11 +143,11 @@ final class RelationshipTest extends TestCase
     }
 
     /**
-     * Test getSupportedRelationsShipsIntraWorkRelation
+     * Test getSupportedRelationShipsIntraWorkRelation
      */
-    public function testGetSupportedRelationsShipsIntraWorkRelation(): void
+    public function testGetSupportedRelationShipsIntraWorkRelation(): void
     {
-        $result = Relationship::getSupportedRelationsShipsIntraWorkRelation();
+        $result = Relationship::getSupportedRelationShipsIntraWorkRelation();
         
         self::assertNotEmpty($result);
         
@@ -187,11 +187,11 @@ final class RelationshipTest extends TestCase
     }
 
     /**
-     * Test getDisplayedRelationsShipsIntraWorkRelation
+     * Test getDisplayedRelationShipsIntraWorkRelation
      */
-    public function testGetDisplayedRelationsShipsIntraWorkRelation(): void
+    public function testGetDisplayedRelationShipsIntraWorkRelation(): void
     {
-        $result = Relationship::getDisplayedRelationsShipsIntraWorkRelation();
+        $result = Relationship::getDisplayedRelationShipsIntraWorkRelation();
         
         self::assertNotEmpty($result);
         

--- a/tests/unit/library/Episciences/paper/RelationshipTest.php
+++ b/tests/unit/library/Episciences/paper/RelationshipTest.php
@@ -1,20 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace unit\library\Episciences;
 
-use Episciences_Paper_Dataset;
+use Episciences\Paper\Relationship;
 use PHPUnit\Framework\TestCase;
 
-final class Episciences_Paper_DatasetTest extends TestCase
+final class RelationshipTest extends TestCase
 {
     /**
      * @dataProvider removeFirstLevelProvider
+     * @param array<string|int, array<int, string>> $inputArray
+     * @param array<int, string> $expectedOutput
      */
     public function testRemoveFirstLevel(array $inputArray, array $expectedOutput): void
     {
-        $result = Episciences_Paper_Dataset::removeFirstLevel($inputArray);
+        $result = Relationship::removeFirstLevel($inputArray);
         self::assertEquals($expectedOutput, $result);
-        self::assertIsArray($result);
     }
 
     /**
@@ -22,9 +25,8 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testRemoveFirstLevelWithEmptyArray(): void
     {
-        $result = Episciences_Paper_Dataset::removeFirstLevel([]);
+        $result = Relationship::removeFirstLevel([]);
         self::assertEquals([], $result);
-        self::assertIsArray($result);
     }
 
     /**
@@ -32,10 +34,11 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testRemoveFirstLevelWithSingleLevel(): void
     {
+        /** @var array<string|int, array<int, string>> $inputArray */
         $inputArray = [['value1'], ['value2'], ['value3']];
         $expectedOutput = ['value1', 'value2', 'value3'];
         
-        $result = Episciences_Paper_Dataset::removeFirstLevel($inputArray);
+        $result = Relationship::removeFirstLevel($inputArray);
         self::assertEquals($expectedOutput, $result);
     }
 
@@ -44,6 +47,7 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testRemoveFirstLevelWithMixedContent(): void
     {
+        /** @var array<string|int, array<int, string>> $inputArray */
         $inputArray = [
             ['string1', 'string2'],
             ['string3'],
@@ -51,7 +55,7 @@ final class Episciences_Paper_DatasetTest extends TestCase
         ];
         $expectedOutput = ['string1', 'string2', 'string3', 'string4', 'string5', 'string6'];
         
-        $result = Episciences_Paper_Dataset::removeFirstLevel($inputArray);
+        $result = Relationship::removeFirstLevel($inputArray);
         self::assertEquals($expectedOutput, $result);
     }
 
@@ -60,12 +64,10 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testGetFlattenedRelationships(): void
     {
-        $result = Episciences_Paper_Dataset::getFlattenedRelationships();
+        $result = Relationship::getFlattenedRelationships();
         
-        self::assertIsArray($result);
         self::assertNotEmpty($result);
         
-        // Check that some expected values from supportedRelationShips are present
         self::assertContains('isBasedOn', $result);
         self::assertContains('isBasisFor', $result);
         self::assertContains('basedOnData', $result);
@@ -76,11 +78,6 @@ final class Episciences_Paper_DatasetTest extends TestCase
         self::assertContains('isReferencedBy', $result);
         self::assertContains('requires', $result);
         self::assertContains('isRequiredBy', $result);
-        
-        // Verify no nested arrays remain (all values should be strings)
-        foreach ($result as $value) {
-            self::assertIsString($value);
-        }
     }
 
     /**
@@ -88,9 +85,8 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testGetFlattenedRelationshipsIntraWorkRelation(): void
     {
-        $result = Episciences_Paper_Dataset::getFlattenedRelationshipsIntraWorkRelation();
+        $result = Relationship::getFlattenedRelationshipsIntraWorkRelation();
         
-        self::assertIsArray($result);
         self::assertNotEmpty($result);
         
         self::assertContains('isTranslationOf', $result);
@@ -113,11 +109,6 @@ final class Episciences_Paper_DatasetTest extends TestCase
         self::assertContains('hasVersion', $result);
         self::assertContains('isFormatOf', $result);
         self::assertContains('hasFormat', $result);
-        
-        // Verify no nested arrays remain (all values should be strings)
-        foreach ($result as $value) {
-            self::assertIsString($value);
-        }
     }
 
     /**
@@ -125,9 +116,8 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testGetFlattenedRelationshipsContainsAllValues(): void
     {
-        $result = Episciences_Paper_Dataset::getFlattenedRelationships();
+        $result = Relationship::getFlattenedRelationships();
         
-        // Expected count based on supportedRelationShips array structure
         $expectedValues = [
             'isBasedOn', 'isBasisFor', 'basedOnData', 'isDataBasisFor',
             'isCommentOn', 'hasComment',
@@ -157,9 +147,8 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testGetSupportedRelationsShipsIntraWorkRelation(): void
     {
-        $result = Episciences_Paper_Dataset::getSupportedRelationsShipsIntraWorkRelation();
+        $result = Relationship::getSupportedRelationsShipsIntraWorkRelation();
         
-        self::assertIsArray($result);
         self::assertNotEmpty($result);
         
         self::assertArrayHasKey('Translation', $result);
@@ -202,12 +191,10 @@ final class Episciences_Paper_DatasetTest extends TestCase
      */
     public function testGetDisplayedRelationsShipsIntraWorkRelation(): void
     {
-        $result = Episciences_Paper_Dataset::getDisplayedRelationsShipsIntraWorkRelation();
+        $result = Relationship::getDisplayedRelationsShipsIntraWorkRelation();
         
-        self::assertIsArray($result);
         self::assertNotEmpty($result);
         
-        // displayed categories
         self::assertArrayHasKey('Translation', $result);
         self::assertContains('isTranslationOf', $result['Translation']);
         self::assertContains('hasTranslation', $result['Translation']);
@@ -219,7 +206,6 @@ final class Episciences_Paper_DatasetTest extends TestCase
         self::assertArrayHasKey('Same as', $result);
         self::assertContains('isSameAs', $result['Same as']);
         
-        // hidden categories should not be present in displayed result
         self::assertArrayNotHasKey('Preprint', $result);
         self::assertArrayNotHasKey('Manuscript', $result);
         self::assertArrayNotHasKey('Expression', $result);
@@ -230,57 +216,9 @@ final class Episciences_Paper_DatasetTest extends TestCase
         self::assertArrayNotHasKey('Format', $result);
     }
 
-    // =========================================================================
-    // setMetatextCitation() — null-argument regression (May 2026)
-    // =========================================================================
-
-    /**
-     * Bug fix: setMetatextCitation() previously declared `string $metatextCitation`
-     * with no default, so passing null (or omitting the argument) caused a fatal
-     * TypeError. The fix adds `= ''` as a default value.
-     *
-     * Regression guard: calling without arguments must not throw.
-     * We read the raw property via reflection because the public getter calls
-     * buildMetatextCitation() when the stored value is empty, which needs the DB.
-     */
-    public function testSetMetatextCitationWithNoArgumentDoesNotThrow(): void
-    {
-        $dataset = new Episciences_Paper_Dataset();
-        $dataset->setMetatextCitation();
-
-        $prop = new \ReflectionProperty(Episciences_Paper_Dataset::class, 'metatextCitation');
-        $prop->setAccessible(true);
-        self::assertSame('', $prop->getValue($dataset));
-    }
-
-    /**
-     * Calling setMetatextCitation() with an explicit value must still work.
-     * strip_tags() in the getter is safe for plain-text input without DB.
-     */
-    public function testSetMetatextCitationWithValueStoresIt(): void
-    {
-        $dataset = new Episciences_Paper_Dataset();
-        $dataset->setMetatextCitation('Author (2026). Title. Journal.');
-        self::assertSame('Author (2026). Title. Journal.', $dataset->getMetatextCitation());
-    }
-
-    /**
-     * Calling setMetatextCitation('') must store an empty string.
-     * Raw-property check avoids triggering buildMetatextCitation().
-     */
-    public function testSetMetatextCitationWithEmptyStringStoresEmpty(): void
-    {
-        $dataset = new Episciences_Paper_Dataset();
-        $dataset->setMetatextCitation('nonempty');
-        $dataset->setMetatextCitation('');
-
-        $prop = new \ReflectionProperty(Episciences_Paper_Dataset::class, 'metatextCitation');
-        $prop->setAccessible(true);
-        self::assertSame('', $prop->getValue($dataset));
-    }
-
     /**
      * Data provider for removeFirstLevel tests
+     * @return array<string, array{0: array<array<string>>, 1: array<string>}>
      */
     public static function removeFirstLevelProvider(): array
     {


### PR DESCRIPTION
Align relationship types with HAL by adding supported intra-work relation types. Refactor configuration of relationship types into a dedicated \Episciences\Paper\Relationship class for better single responsibility and to comply with PHPStan LEVEL 6 requirements. Implement declare(strict_types=1); and add unit tests.