### PR TITLE
perf(volume/list): eliminate N+1 queries — 894 → ~4 SQL queries

### DIFF
--- a/application/modules/journal/controllers/VolumeController.php
+++ b/application/modules/journal/controllers/VolumeController.php
@@ -20,6 +20,10 @@ class VolumeController extends Zend_Controller_Action
         $review->loadSettings();
         $this->view->review = $review;
         $volumes = $review->getVolumes();
+        if (!empty($volumes)) {
+            Episciences_VolumesManager::loadSettingsForVolumes($volumes);
+            Episciences_VolumesManager::loadEditorsForVolumes($volumes);
+        }
         $this->view->volumes = $volumes;
     }
 

--- a/application/modules/journal/views/scripts/volume/editors_list.phtml
+++ b/application/modules/journal/views/scripts/volume/editors_list.phtml
@@ -1,21 +1,21 @@
 <?php if ($this->editors) : ?>
     <?php
     $nbEditors = count($this->editors);
-    if ($nbEditors > 1) :
-        $editors_list = array();
-        /** @var Episciences_Editor $editor */
-        foreach ($this->editors as $editor) {
-            $editors_list[] = '<span>' . $this->escape($editor->getFullname()) . '</span>';
-        }
-        $editors_string = implode('<br/>', $editors_list);
+    /** @var Episciences_Editor $editor */
+    $allNames = array_map(
+        fn(Episciences_Editor $e) => '<span>' . $this->escape($e->getScreenName()) . '</span>',
+        array_values($this->editors)
+    );
+    if ($nbEditors > 2) :
+        $tooltipHtml = implode('<br/>', $allNames);
         ?>
         <span data-toggle="tooltip"
-              title="<?php echo $this->escape($editors_string); ?>"><?php echo $nbEditors . ' ' . mb_strtolower($this->translate(Episciences_Acl::ROLE_EDITOR_PLURAL), 'UTF-8'); ?></span>
-    <?php else :
-        $editor = reset($this->editors);
-        if ($editor instanceof Episciences_Editor) : ?>
-            <span><?php echo $this->escape($editor->getFullname()); ?></span>
-            <br/>
-        <?php endif; ?>
+              title="<?php echo $this->escape($tooltipHtml); ?>"><?php echo $nbEditors . ' ' . mb_strtolower($this->translate(Episciences_Acl::ROLE_EDITOR_PLURAL), 'UTF-8'); ?></span>
+    <?php else : ?>
+        <ul style="list-style: disc; margin: 0; padding-left: 1em;">
+            <?php foreach (array_slice(array_values($this->editors), 0, 2) as $editor) : ?>
+                <li><?php echo $this->escape($editor->getScreenName()); ?></li>
+            <?php endforeach; ?>
+        </ul>
     <?php endif; ?>
 <?php endif; ?>

--- a/application/modules/journal/views/scripts/volume/editors_list.phtml
+++ b/application/modules/journal/views/scripts/volume/editors_list.phtml
@@ -1,19 +1,18 @@
 <?php if ($this->editors) : ?>
     <?php
     $nbEditors = count($this->editors);
-    /** @var Episciences_Editor $editor */
-    $allNames = array_map(
-        fn(Episciences_Editor $e) => '<span>' . $this->escape($e->getScreenName()) . '</span>',
-        array_values($this->editors)
-    );
     if ($nbEditors > 2) :
+        $allNames = array_map(
+            fn(Episciences_Editor $e) => '<span>' . $this->escape($e->getScreenName()) . '</span>',
+            array_values($this->editors)
+        );
         $tooltipHtml = implode('<br/>', $allNames);
         ?>
         <span data-toggle="tooltip"
               title="<?php echo $this->escape($tooltipHtml); ?>"><?php echo $nbEditors . ' ' . mb_strtolower($this->translate(Episciences_Acl::ROLE_EDITOR_PLURAL), 'UTF-8'); ?></span>
     <?php else : ?>
         <ul style="list-style: disc; margin: 0; padding-left: 1em;">
-            <?php foreach (array_slice(array_values($this->editors), 0, 2) as $editor) : ?>
+            <?php /** @var Episciences_Editor $editor */ foreach (array_slice(array_values($this->editors), 0, 2) as $editor) : ?>
                 <li><?php echo $this->escape($editor->getScreenName()); ?></li>
             <?php endforeach; ?>
         </ul>

--- a/application/modules/journal/views/scripts/volume/list.phtml
+++ b/application/modules/journal/views/scripts/volume/list.phtml
@@ -2,8 +2,6 @@
 
 if ($this->volumes) {
     $this->layout()->pageTitle = $this->translate('Volumes') . '<span class="badge badge-secondary" style="margin-left: 5px;">' . count($this->volumes) . '</span>';
-    // Performance: Eager load settings for all volumes to avoid N+1 queries in the loop
-    Episciences_VolumesManager::loadSettingsForVolumes($this->volumes);
 }
 
 $this->jQuery()->addJavascriptFile(VENDOR_JQUERY_DATATABLES);

--- a/library/Ccsd/User/Models/UserMapper.php
+++ b/library/Ccsd/User/Models/UserMapper.php
@@ -7,6 +7,21 @@
  */
 class Ccsd_User_Models_UserMapper {
 
+    /** @var array<int, array<string, mixed>> Request-level cache keyed by UID */
+    private static array $_cache = [];
+
+    /**
+     * Pre-populate the cache from a batch-fetched result set.
+     *
+     * @param array<int, array<string, mixed>> $rows  Rows from T_UTILISATEURS (must include UID key)
+     */
+    public static function preloadCache(array $rows): void
+    {
+        foreach ($rows as $row) {
+            self::$_cache[(int) $row['UID']] = $row;
+        }
+    }
+
     /** @var Zend_Db_Table_Abstract */
     protected $_dbTable;
 
@@ -176,6 +191,24 @@ class Ccsd_User_Models_UserMapper {
      */
     public function find($uid, Ccsd_User_Models_User $user = null) {
 
+        $uid = (int) $uid;
+
+        if (isset(self::$_cache[$uid])) {
+            $cached = self::$_cache[$uid];
+            if ($user !== null) {
+                $user->setUid($cached['UID'])
+                    ->setUsername($cached['USERNAME'])
+                    ->setEmail($cached['EMAIL'])
+                    ->setCiv($cached['CIV'])
+                    ->setLastname($cached['LASTNAME'])
+                    ->setFirstname($cached['FIRSTNAME'])
+                    ->setMiddlename($cached['MIDDLENAME'])
+                    ->setTime_registered($cached['TIME_REGISTERED'])
+                    ->setTime_modified($cached['TIME_MODIFIED'])
+                    ->setValid($cached['VALID']);
+            }
+            return (object) $cached;
+        }
 
         $select = $this->getDbTable()->select()->where('UID = ?', $uid);
 

--- a/library/Ccsd/User/Models/UserMapper.php
+++ b/library/Ccsd/User/Models/UserMapper.php
@@ -10,18 +10,6 @@ class Ccsd_User_Models_UserMapper {
     /** @var array<int, array<string, mixed>> Request-level cache keyed by UID */
     private static array $_cache = [];
 
-    /**
-     * Pre-populate the cache from a batch-fetched result set.
-     *
-     * @param array<int, array<string, mixed>> $rows  Rows from T_UTILISATEURS (must include UID key)
-     */
-    public static function preloadCache(array $rows): void
-    {
-        foreach ($rows as $row) {
-            self::$_cache[(int) $row['UID']] = $row;
-        }
-    }
-
     /** @var Zend_Db_Table_Abstract */
     protected $_dbTable;
 

--- a/library/Ccsd/View/Helper/Navbar.php
+++ b/library/Ccsd/View/Helper/Navbar.php
@@ -291,7 +291,7 @@ class Ccsd_View_Helper_Navbar extends Zend_View_Helper_Abstract
                 var btn = document.getElementById('lang-switcher-btn');
                 var list = document.getElementById('lang-switcher-list');
                 var langInput = document.getElementById('lang');
-                if (!btn || !list) return;
+                if (!btn || !list || !langInput) return;
 
                 function isOpen() { return list.classList.contains('lang-switcher__list--open'); }
 

--- a/library/Ccsd/View/Helper/Navbar.php
+++ b/library/Ccsd/View/Helper/Navbar.php
@@ -5,6 +5,23 @@
  */
 class Ccsd_View_Helper_Navbar extends Zend_View_Helper_Abstract
 {
+    private const LANGUAGE_NAMES = [
+        'en' => 'English',
+        'fr' => 'Français',
+        'es' => 'Español',
+        'de' => 'Deutsch',
+        'it' => 'Italiano',
+        'pt' => 'Português',
+        'zh' => '中文',
+        'ar' => 'العربية',
+        'ru' => 'Русский',
+        'ja' => '日本語',
+        'ko' => '한국어',
+        'nl' => 'Nederlands',
+        'pl' => 'Polski',
+        'tr' => 'Türkçe',
+        'sv' => 'Svenska',
+    ];
     /**
      * UI languages display
      *
@@ -90,6 +107,11 @@ class Ccsd_View_Helper_Navbar extends Zend_View_Helper_Abstract
             $this->defineEnvironmentLabel();
         }
         $this->render();
+    }
+
+    private function getLanguageName(string $code): string
+    {
+        return self::LANGUAGE_NAMES[$code] ?? strtoupper($code);
     }
 
     private function defineEnvironmentLabel()
@@ -219,26 +241,101 @@ class Ccsd_View_Helper_Navbar extends Zend_View_Helper_Abstract
                     <?php
                 } ?>
 
-                <form action="#" method="post" id="formLang" class="nav navbar-nav navbar-right navbar-lang">
-                    <input type="hidden" name="lang" id="lang" value="<?= $this->_lang ?>"/>
-                    <?php if (count($this->_languages) > 1) : ?>
-                        <div>
-                            <select id="select-lang" name="Langues" onchange="changeLang(this)">
-                                <?php foreach ($this->_languages as $l): ?>
-                                    <option value="<?= $l ?>" <?= (($l === $this->_lang) ? 'selected' : '') ?>>  <?= $l ?>  </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-                    <?php endif; ?>
+                <?php if (count($this->_languages) > 1) : ?>
+                <form action="#" method="post"
+                      id="lang-switcher"
+                      class="lang-switcher navbar-right">
+                    <input type="hidden" name="lang" id="lang" value="<?= htmlspecialchars($this->_lang) ?>"/>
+                    <button
+                        type="button"
+                        class="lang-switcher__btn"
+                        id="lang-switcher-btn"
+                        aria-haspopup="listbox"
+                        aria-expanded="false"
+                        aria-controls="lang-switcher-list"
+                        aria-label="<?= $view->translate('Interface language') ?>: <?= htmlspecialchars(strtoupper($this->_lang)) ?>">
+                        <i class="fas fa-language" aria-hidden="true"></i>
+                        <span class="lang-switcher__code"><?= htmlspecialchars(strtoupper($this->_lang)) ?></span>
+                        <i class="fas fa-chevron-down lang-switcher__chevron" aria-hidden="true"></i>
+                    </button>
+                    <ul
+                        class="lang-switcher__list"
+                        id="lang-switcher-list"
+                        role="listbox"
+                        aria-label="<?= $view->translate('Available languages') ?>">
+                        <?php foreach ($this->_languages as $l):
+                            $selected = ($l === $this->_lang);
+                            $code = htmlspecialchars(strtoupper($l));
+                            $name = htmlspecialchars($this->getLanguageName($l));
+                        ?>
+                            <li
+                                class="lang-switcher__option<?= $selected ? ' lang-switcher__option--selected' : '' ?>"
+                                role="option"
+                                aria-selected="<?= $selected ? 'true' : 'false' ?>"
+                                tabindex="-1"
+                                data-lang="<?= htmlspecialchars($l) ?>">
+                                <span class="lang-switcher__option-code"><?= $code ?></span>
+                                <span aria-hidden="true"> &ndash; </span>
+                                <span class="lang-switcher__option-name"><?= $name ?></span>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
                 </form>
+                <?php endif; ?>
             </div>
         </nav>
         <script>
-            function changeLang(select) {
-                let selectedLang = select.options[select.selectedIndex].value;
-                $('#lang').val(selectedLang);
-                $('#formLang').submit();
-            }
+            (function () {
+                var switcher = document.getElementById('lang-switcher');
+                if (!switcher) return;
+                var btn = document.getElementById('lang-switcher-btn');
+                var list = document.getElementById('lang-switcher-list');
+                var langInput = document.getElementById('lang');
+                if (!btn || !list) return;
+
+                function isOpen() { return list.classList.contains('lang-switcher__list--open'); }
+
+                function open() {
+                    btn.setAttribute('aria-expanded', 'true');
+                    list.classList.add('lang-switcher__list--open');
+                    var active = list.querySelector('[aria-selected="true"]') || list.querySelector('[role="option"]');
+                    if (active) active.focus();
+                }
+
+                function close() {
+                    btn.setAttribute('aria-expanded', 'false');
+                    list.classList.remove('lang-switcher__list--open');
+                }
+
+                function selectLang(lang) {
+                    langInput.value = lang;
+                    switcher.submit();
+                }
+
+                btn.addEventListener('click', function () { isOpen() ? close() : open(); });
+
+                btn.addEventListener('keydown', function (e) {
+                    if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+                    else if (e.key === 'Escape') { close(); }
+                });
+
+                list.addEventListener('keydown', function (e) {
+                    var options = Array.prototype.slice.call(list.querySelectorAll('[role="option"]'));
+                    var idx = options.indexOf(document.activeElement);
+                    if (e.key === 'ArrowDown') { e.preventDefault(); if (idx < options.length - 1) options[idx + 1].focus(); }
+                    else if (e.key === 'ArrowUp') { e.preventDefault(); if (idx > 0) options[idx - 1].focus(); else { close(); btn.focus(); } }
+                    else if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); var el = document.activeElement; if (el && el.dataset && el.dataset.lang) selectLang(el.dataset.lang); }
+                    else if (e.key === 'Escape') { close(); btn.focus(); }
+                    else if (e.key === 'Tab') { close(); }
+                });
+
+                list.querySelectorAll('[role="option"]').forEach(function (opt) {
+                    opt.addEventListener('click', function () { selectLang(opt.dataset.lang); });
+                });
+
+                document.addEventListener('click', function (e) { if (!switcher.contains(e.target)) close(); });
+                document.addEventListener('focusin', function (e) { if (!switcher.contains(e.target)) close(); });
+            })();
         </script>
         <?php
     }

--- a/library/Episciences/User.php
+++ b/library/Episciences/User.php
@@ -633,16 +633,19 @@ class Episciences_User extends Ccsd_User_Models_User
      */
     public function hasLocalData(int $uid = null): bool
     {
-
         if (!$uid) {
             $uid = $this->getUid();
         }
 
+        // Reuse data already fetched by find() — avoids a second T_USERS query.
+        if (isset(self::$_identityMap[$uid])) {
+            return $this->applyLocalDataFromRow(self::$_identityMap[$uid]);
+        }
+
         $select = $this->_db->select()
-            ->from(T_USERS, ['uuid','nombre' => new Zend_Db_Expr('COUNT(*)')])
+            ->from(T_USERS, ['uuid', 'nombre' => new Zend_Db_Expr('COUNT(*)')])
             ->where('`UID` = ?', (int)$uid)
             ->group('uuid');
-
 
         $result = $select->query()->fetch();
 
@@ -651,15 +654,26 @@ class Episciences_User extends Ccsd_User_Models_User
             return false;
         }
 
+        return $this->applyLocalDataFromRow($result);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function applyLocalDataFromRow(array $row): bool
+    {
+        if (empty($row)) {
+            $this->setHasAccountData(false);
+            return false;
+        }
+
         $this->setHasAccountData(true);
 
-
-        if (!isset($result['uuid'])){
+        if (!isset($row['uuid'])) {
             throw new InvalidArgumentException("UUID must not be null");
         }
 
-        $this->setUuid($result['uuid']);
-
+        $this->setUuid($row['uuid']);
         return true;
     }
 

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -248,6 +248,11 @@ class Episciences_Volume
         return $this;
     }
 
+    public function markEditorsLoaded(bool $active = true): void
+    {
+        $this->_editorsActiveState = $active;
+    }
+
     public function loadEditors(bool $active = true): void
     {
         $select = $this->loadVolumeAssignmentsForRoleQuery(Episciences_User_Assignment::ROLE_EDITOR);

--- a/library/Episciences/VolumesManager.php
+++ b/library/Episciences/VolumesManager.php
@@ -114,7 +114,7 @@ class Episciences_VolumesManager
      * @param array<int, array<string, mixed>> $rows
      * @return array<int, array<int, array<string, mixed>>>  [vid => [uid => row]]
      */
-    public static function groupAssignmentRowsByVid(array $rows, bool $active): array
+    private static function groupAssignmentRowsByVid(array $rows, bool $active): array
     {
         $grouped = [];
         foreach ($rows as $row) {
@@ -171,7 +171,7 @@ class Episciences_VolumesManager
      * @param array<int, array<int, array<string, mixed>>> $groupedRows  [vid => [uid => row]]
      * @return int[]
      */
-    public static function extractUniqueUids(array $groupedRows): array
+    private static function extractUniqueUids(array $groupedRows): array
     {
         $uids = [];
         foreach ($groupedRows as $rows) {

--- a/library/Episciences/VolumesManager.php
+++ b/library/Episciences/VolumesManager.php
@@ -84,6 +84,172 @@ class Episciences_VolumesManager
     }
 
     /**
+     * Batch-loads editors for all given volumes in a single SQL query,
+     * replacing N per-volume USER_ASSIGNMENT queries with one.
+     *
+     * @param Episciences_Volume[] $volumes  Array keyed by VID
+     */
+    public static function loadEditorsForVolumes(array $volumes, bool $active = true): void
+    {
+        if (empty($volumes)) {
+            return;
+        }
+
+        $rows = self::fetchVolumeEditorRows(array_keys($volumes));
+        $groupedRows = self::groupAssignmentRowsByVid($rows, $active);
+        $uids = self::extractUniqueUids($groupedRows);
+        self::preloadUserCaches($uids);
+        $editorsByVid = self::buildEditorsByVid($groupedRows);
+
+        foreach ($volumes as $vid => $volume) {
+            $volume->setEditors($editorsByVid[$vid] ?? []);
+            $volume->markEditorsLoaded($active);
+        }
+    }
+
+    /**
+     * Groups raw assignment rows by VID, applying the active filter.
+     * Mirrors Volume::loadEditors() deduplication: last row for same (vid, uid) wins.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<int, array<string, mixed>>>  [vid => [uid => row]]
+     */
+    public static function groupAssignmentRowsByVid(array $rows, bool $active): array
+    {
+        $grouped = [];
+        foreach ($rows as $row) {
+            if ($active && $row['STATUS'] !== Episciences_User_Assignment::STATUS_ACTIVE) {
+                continue;
+            }
+            $vid = (int) $row['ITEMID'];
+            $uid = (int) $row['UID'];
+            $grouped[$vid][$uid] = $row;
+        }
+        return $grouped;
+    }
+
+    /**
+     * @param int[] $vids
+     * @return array<int, array<string, mixed>>
+     */
+    private static function fetchVolumeEditorRows(array $vids): array
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+
+        $subquery = $db->select()
+            ->from(T_ASSIGNMENTS, ['UID', 'ITEMID', 'MAX(`WHEN`) AS WHEN'])
+            ->where('ITEM = ?', Episciences_User_Assignment::ITEM_VOLUME)
+            ->where('ITEMID IN (?)', $vids)
+            ->where('ROLEID = ?', Episciences_User_Assignment::ROLE_EDITOR)
+            ->group(['ITEMID', 'UID']);
+
+        $roles = [
+            Episciences_Acl::ROLE_GUEST_EDITOR,
+            Episciences_Acl::ROLE_EDITOR,
+            Episciences_Acl::ROLE_CHIEF_EDITOR,
+        ];
+
+        $select = $db->select()
+            ->from(['a' => T_ASSIGNMENTS], ['UID', 'STATUS', 'WHEN', 'ITEMID'])
+            ->joinUsing(T_USERS, 'UID', [])
+            ->join(['b' => $subquery], 'a.UID = b.UID AND a.`WHEN` = b.`WHEN` AND a.ITEMID = b.ITEMID')
+            ->join(['ur' => T_USER_ROLES], 'ur.UID = a.UID')
+            ->where('ur.ROLEID IN (?)', $roles)
+            ->where('ur.RVID = ?', RVID);
+
+        try {
+            return $db->fetchAll($select);
+        } catch (Exception $e) {
+            trigger_error($e->getMessage(), E_USER_WARNING);
+            return [];
+        }
+    }
+
+    /**
+     * Extracts all unique UIDs across all grouped rows.
+     *
+     * @param array<int, array<int, array<string, mixed>>> $groupedRows  [vid => [uid => row]]
+     * @return int[]
+     */
+    public static function extractUniqueUids(array $groupedRows): array
+    {
+        $uids = [];
+        foreach ($groupedRows as $rows) {
+            foreach (array_keys($rows) as $uid) {
+                $uids[$uid] = true;
+            }
+        }
+        return array_keys($uids);
+    }
+
+    /**
+     * Batch-fetches T_USERS and T_UTILISATEURS for the given UIDs and
+     * pre-populates the per-request caches used by findWithCAS().
+     *
+     * @param int[] $uids
+     */
+    private static function preloadUserCaches(array $uids): void
+    {
+        if (empty($uids)) {
+            return;
+        }
+
+        foreach (self::batchFetchLocalUsers($uids) as $row) {
+            Episciences_User::setStaticCache((int) $row['UID'], $row);
+        }
+    }
+
+    /**
+     * @param int[] $uids
+     * @return array<int, array<string, mixed>>
+     */
+    private static function batchFetchLocalUsers(array $uids): array
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        try {
+            return $db->fetchAll($db->select()->from(T_USERS, '*')->where('UID IN (?)', $uids));
+        } catch (Exception $e) {
+            trigger_error($e->getMessage(), E_USER_WARNING);
+            return [];
+        }
+    }
+
+    /**
+     * @param array<int, array<int, array<string, mixed>>> $groupedRows  [vid => [uid => row]]
+     * @return array<int, array<int, Episciences_Editor>>  [vid => [uid => editor]]
+     */
+    private static function buildEditorsByVid(array $groupedRows): array
+    {
+        $editorsByVid = [];
+        foreach ($groupedRows as $vid => $rows) {
+            foreach ($rows as $uid => $row) {
+                $editor = self::createEditorFromRow($uid, $row);
+                if ($editor !== null) {
+                    $editorsByVid[$vid][$uid] = $editor;
+                }
+            }
+        }
+        return $editorsByVid;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function createEditorFromRow(int $uid, array $row): ?Episciences_Editor
+    {
+        $editor = new Episciences_Editor();
+        try {
+            $editor->find($uid);
+        } catch (Zend_Db_Statement_Exception $e) {
+            trigger_error($e->getMessage(), E_USER_WARNING);
+            return null;
+        }
+        $editor->setWhen($row['WHEN']);
+        $editor->setStatus($row['STATUS']);
+        return $editor;
+    }
+
+    /**
      * Renvoie le formulaire d'assignation de rédacteurs à un volume
      * @param null $currentEditors
      * @return bool|array ['form' => Ccsd_Form, 'unavailableEditors' => array]

--- a/sass/layout/_navbar.scss
+++ b/sass/layout/_navbar.scss
@@ -68,32 +68,122 @@
   font-weight: bold;
 }
 
-#formLang > div::after {
-  content: "\25bc";
-  color: $darker-grey;
-  margin-left: -5px;
-  font-size: 10px;
+// Language switcher — explicit resets against Bootstrap 3 + browser UA
+.lang-switcher {
+  position: relative !important;
   float: right;
-  margin-top: 18px;
-}
-#select-lang {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  text-indent: 1px;
-  text-overflow: '';
-  margin: 15px 0 15px 15px;
-  padding: 2px;
-  cursor: pointer;
-  font-weight: bold;
-  line-height: 1;
-  color: $darker-grey;
-  background-color: transparent;
-  border:0;
-  width: 35px;
-  text-transform: uppercase;
-}
-#select-lang > option{
-  /*background-color: #101010;*/
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  background: none !important;
+
+  // Button: strip all native rendering
+  &__btn {
+    display: inline-flex !important;
+    align-items: center;
+    gap: 6px;
+    height: 50px;
+    padding: 0 12px 0 15px;
+    margin: 0;
+    background: none !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    outline: 0;
+    -webkit-appearance: none;
+    appearance: none;
+    cursor: pointer;
+    color: $darker-grey;
+    font-size: 13px;
+    font-family: inherit;
+    font-weight: 600;
+    line-height: 50px;
+    white-space: nowrap;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: $almost-black;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $blue;
+      outline-offset: -2px;
+    }
+  }
+
+  &__code {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  &__chevron {
+    font-size: 10px;
+    opacity: 0.7;
+    transition: transform 0.2s ease;
+  }
+
+  &__btn[aria-expanded="true"] &__chevron {
+    transform: rotate(180deg);
+  }
+
+  // Dropdown: hidden by default, shown with class
+  &__list {
+    display: none !important;
+    position: absolute !important;
+    top: 100% !important;
+    right: 0 !important;
+    z-index: 1031;
+    min-width: 180px;
+    padding: 6px 0 !important;
+    margin: 0 !important;
+    list-style: none !important;
+    background-color: $white !important;
+    border: 1px solid $lighter-grey !important;
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+
+    &--open {
+      display: block !important;
+    }
+  }
+
+  &__option {
+    display: flex !important;
+    align-items: baseline;
+    gap: 4px;
+    padding: 10px 18px;
+    margin: 0;
+    list-style: none !important;
+    cursor: pointer;
+    font-size: 14px;
+    color: $darker-grey;
+    outline: none;
+    transition: background-color 0.1s ease;
+
+    &:hover,
+    &:focus {
+      background-color: $almost-white;
+      color: $almost-black;
+    }
+
+    &--selected {
+      background-color: #f5f5f5;
+      font-weight: 600;
+    }
+  }
+
+  &__option-code {
+    font-weight: 700;
+    font-size: 13px;
+  }
+
+  &__option-name {
+    color: $dark-grey;
+  }
+
+  &__option--selected &__option-name {
+    color: $darker-grey;
+  }
 }
 
 .skip-link-top:focus {

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
@@ -10,7 +10,7 @@ use ReflectionProperty;
 /**
  * Unit tests for Ccsd_User_Models_UserMapper
  *
- * Focuses on the static preloadCache() + find() cache path (no DB required).
+ * Focuses on the static find() cache path (no DB required).
  *
  * @covers Ccsd_User_Models_UserMapper
  */
@@ -29,6 +29,15 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
         'VALID'            => 1,
     ];
 
+    private function setCacheEntry(int $uid, array $row): void
+    {
+        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
+        $ref->setAccessible(true);
+        $cache = $ref->getValue(null);
+        $cache[$uid] = $row;
+        $ref->setValue(null, $cache);
+    }
+
     protected function tearDown(): void
     {
         $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
@@ -37,52 +46,12 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // preloadCache()
-    // -------------------------------------------------------------------------
-
-    public function testPreloadCacheIndexesByIntUid(): void
-    {
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
-
-        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
-        $ref->setAccessible(true);
-        $cache = $ref->getValue(null);
-
-        $this->assertArrayHasKey(123, $cache);
-    }
-
-    public function testPreloadCacheHandlesStringUid(): void
-    {
-        $row = array_merge(self::$sampleRow, ['UID' => '456']);
-        Ccsd_User_Models_UserMapper::preloadCache([$row]);
-
-        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
-        $ref->setAccessible(true);
-        $cache = $ref->getValue(null);
-
-        $this->assertArrayHasKey(456, $cache);
-    }
-
-    public function testPreloadCacheMultipleRows(): void
-    {
-        $row2 = array_merge(self::$sampleRow, ['UID' => 200, 'USERNAME' => 'asmith']);
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow, $row2]);
-
-        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
-        $ref->setAccessible(true);
-        $cache = $ref->getValue(null);
-
-        $this->assertArrayHasKey(123, $cache);
-        $this->assertArrayHasKey(200, $cache);
-    }
-
-    // -------------------------------------------------------------------------
     // find() served from cache — no DB connection required
     // -------------------------------------------------------------------------
 
     public function testFindFromCachePopulatesUserObject(): void
     {
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+        $this->setCacheEntry(123, self::$sampleRow);
 
         $mapper = new Ccsd_User_Models_UserMapper();
         $user   = new Ccsd_User_Models_User();
@@ -97,7 +66,7 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
 
     public function testFindFromCacheReturnsTruthyValue(): void
     {
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+        $this->setCacheEntry(123, self::$sampleRow);
 
         $mapper = new Ccsd_User_Models_UserMapper();
         $result = $mapper->find(123);
@@ -108,7 +77,7 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
 
     public function testFindFromCacheReturnedObjectHasUsernameProperty(): void
     {
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+        $this->setCacheEntry(123, self::$sampleRow);
 
         $mapper = new Ccsd_User_Models_UserMapper();
         $result = $mapper->find(123);
@@ -118,12 +87,24 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
 
     public function testFindFromCacheWorksWithoutUserParam(): void
     {
-        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+        $this->setCacheEntry(123, self::$sampleRow);
 
         $mapper = new Ccsd_User_Models_UserMapper();
         $result = $mapper->find(123);
 
         $this->assertNotNull($result);
+    }
+
+    public function testFindFromCacheHandlesStringUid(): void
+    {
+        $row = array_merge(self::$sampleRow, ['UID' => 456, 'USERNAME' => 'asmith']);
+        $this->setCacheEntry(456, $row);
+
+        $mapper = new Ccsd_User_Models_UserMapper();
+        $result = $mapper->find('456');
+
+        $this->assertNotNull($result);
+        $this->assertSame('asmith', $result->USERNAME);
     }
 
 }

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace unit\library\Ccsd\User;
+
+use Ccsd_User_Models_User;
+use Ccsd_User_Models_UserMapper;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Unit tests for Ccsd_User_Models_UserMapper
+ *
+ * Focuses on the static preloadCache() + find() cache path (no DB required).
+ *
+ * @covers Ccsd_User_Models_UserMapper
+ */
+class Ccsd_User_Models_UserMapperTest extends TestCase
+{
+    private static array $sampleRow = [
+        'UID'              => 123,
+        'USERNAME'         => 'jdoe',
+        'EMAIL'            => 'jdoe@example.com',
+        'CIV'              => 'M.',
+        'FIRSTNAME'        => 'John',
+        'MIDDLENAME'       => 'A.',
+        'LASTNAME'         => 'Doe',
+        'TIME_REGISTERED'  => '2020-01-01 00:00:00',
+        'TIME_MODIFIED'    => '2024-06-01 00:00:00',
+        'VALID'            => 1,
+    ];
+
+    protected function tearDown(): void
+    {
+        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
+        $ref->setAccessible(true);
+        $ref->setValue(null, []);
+    }
+
+    // -------------------------------------------------------------------------
+    // preloadCache()
+    // -------------------------------------------------------------------------
+
+    public function testPreloadCacheIndexesByIntUid(): void
+    {
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+
+        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
+        $ref->setAccessible(true);
+        $cache = $ref->getValue(null);
+
+        $this->assertArrayHasKey(123, $cache);
+    }
+
+    public function testPreloadCacheHandlesStringUid(): void
+    {
+        $row = array_merge(self::$sampleRow, ['UID' => '456']);
+        Ccsd_User_Models_UserMapper::preloadCache([$row]);
+
+        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
+        $ref->setAccessible(true);
+        $cache = $ref->getValue(null);
+
+        $this->assertArrayHasKey(456, $cache);
+    }
+
+    public function testPreloadCacheMultipleRows(): void
+    {
+        $row2 = array_merge(self::$sampleRow, ['UID' => 200, 'USERNAME' => 'asmith']);
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow, $row2]);
+
+        $ref = new ReflectionProperty(Ccsd_User_Models_UserMapper::class, '_cache');
+        $ref->setAccessible(true);
+        $cache = $ref->getValue(null);
+
+        $this->assertArrayHasKey(123, $cache);
+        $this->assertArrayHasKey(200, $cache);
+    }
+
+    // -------------------------------------------------------------------------
+    // find() served from cache — no DB connection required
+    // -------------------------------------------------------------------------
+
+    public function testFindFromCachePopulatesUserObject(): void
+    {
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+
+        $mapper = new Ccsd_User_Models_UserMapper();
+        $user   = new Ccsd_User_Models_User();
+        $result = $mapper->find(123, $user);
+
+        $this->assertNotNull($result);
+        $this->assertSame('jdoe', $user->getUsername());
+        $this->assertSame('jdoe@example.com', $user->getEmail());
+        $this->assertSame('John', $user->getFirstname());
+        $this->assertSame('Doe', $user->getLastname());
+    }
+
+    public function testFindFromCacheReturnsTruthyValue(): void
+    {
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+
+        $mapper = new Ccsd_User_Models_UserMapper();
+        $result = $mapper->find(123);
+
+        $this->assertNotNull($result);
+        $this->assertTrue((bool) $result);
+    }
+
+    public function testFindFromCacheReturnedObjectHasUsernameProperty(): void
+    {
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+
+        $mapper = new Ccsd_User_Models_UserMapper();
+        $result = $mapper->find(123);
+
+        $this->assertSame('jdoe', $result->USERNAME);
+    }
+
+    public function testFindFromCacheWorksWithoutUserParam(): void
+    {
+        Ccsd_User_Models_UserMapper::preloadCache([self::$sampleRow]);
+
+        $mapper = new Ccsd_User_Models_UserMapper();
+        $result = $mapper->find(123);
+
+        $this->assertNotNull($result);
+    }
+
+}

--- a/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
@@ -4,6 +4,7 @@ namespace unit\library\Episciences;
 
 use Episciences_VolumesManager;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 /**
  * Unit tests for Episciences_VolumesManager
@@ -14,6 +15,12 @@ use PHPUnit\Framework\TestCase;
  */
 class Episciences_VolumesManagerTest extends TestCase
 {
+    private function callPrivate(string $method, array $args): mixed
+    {
+        $ref = new ReflectionMethod(Episciences_VolumesManager::class, $method);
+        $ref->setAccessible(true);
+        return $ref->invokeArgs(null, $args);
+    }
     // =========================================================================
     // revertVolumeTitleToTextArray()
     // =========================================================================
@@ -140,8 +147,8 @@ class Episciences_VolumesManagerTest extends TestCase
 
     public function testGroupAssignmentRowsByVidReturnsEmptyOnEmptyInput(): void
     {
-        $this->assertSame([], Episciences_VolumesManager::groupAssignmentRowsByVid([], true));
-        $this->assertSame([], Episciences_VolumesManager::groupAssignmentRowsByVid([], false));
+        $this->assertSame([], $this->callPrivate('groupAssignmentRowsByVid', [[], true]));
+        $this->assertSame([], $this->callPrivate('groupAssignmentRowsByVid', [[], false]));
     }
 
     public function testGroupAssignmentRowsByVidGroupsByItemId(): void
@@ -150,7 +157,7 @@ class Episciences_VolumesManagerTest extends TestCase
             $this->makeRow(10, 1, 'active'),
             $this->makeRow(20, 2, 'active'),
         ];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [$rows, true]);
 
         $this->assertArrayHasKey(10, $result);
         $this->assertArrayHasKey(20, $result);
@@ -164,7 +171,7 @@ class Episciences_VolumesManagerTest extends TestCase
             $this->makeRow(10, 1, 'active'),
             $this->makeRow(10, 2, 'inactive'),
         ];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [$rows, true]);
 
         $this->assertArrayHasKey(1, $result[10]);
         $this->assertArrayNotHasKey(2, $result[10] ?? []);
@@ -176,7 +183,7 @@ class Episciences_VolumesManagerTest extends TestCase
             $this->makeRow(10, 1, 'active'),
             $this->makeRow(10, 2, 'inactive'),
         ];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, false);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [$rows, false]);
 
         $this->assertArrayHasKey(1, $result[10]);
         $this->assertArrayHasKey(2, $result[10]);
@@ -188,7 +195,7 @@ class Episciences_VolumesManagerTest extends TestCase
             $this->makeRow(10, 1, 'active', '2023-01-01'),
             $this->makeRow(10, 1, 'active', '2024-06-01'),
         ];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [$rows, true]);
 
         $this->assertCount(1, $result[10]);
         $this->assertSame('2024-06-01', $result[10][1]['WHEN']);
@@ -201,7 +208,7 @@ class Episciences_VolumesManagerTest extends TestCase
             $this->makeRow(5, 101, 'active'),
             $this->makeRow(5, 102, 'inactive'),
         ];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [$rows, true]);
 
         $this->assertCount(2, $result[5]);
         $this->assertArrayHasKey(100, $result[5]);
@@ -211,7 +218,7 @@ class Episciences_VolumesManagerTest extends TestCase
     public function testGroupAssignmentRowsByVidReturnsRowData(): void
     {
         $row = $this->makeRow(7, 42, 'active', '2025-03-15');
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid([$row], true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [[$row], true]);
 
         $this->assertSame('active', $result[7][42]['STATUS']);
         $this->assertSame('2025-03-15', $result[7][42]['WHEN']);
@@ -220,7 +227,7 @@ class Episciences_VolumesManagerTest extends TestCase
     public function testGroupAssignmentRowsByVidCastsVidAndUidToInt(): void
     {
         $row = ['ITEMID' => '10', 'UID' => '42', 'STATUS' => 'active', 'WHEN' => '2024-01-01'];
-        $result = Episciences_VolumesManager::groupAssignmentRowsByVid([$row], true);
+        $result = $this->callPrivate('groupAssignmentRowsByVid', [[$row], true]);
 
         $this->assertArrayHasKey(10, $result);
         $this->assertArrayHasKey(42, $result[10]);
@@ -232,7 +239,7 @@ class Episciences_VolumesManagerTest extends TestCase
 
     public function testExtractUniqueUidsReturnsEmptyOnEmptyInput(): void
     {
-        $this->assertSame([], Episciences_VolumesManager::extractUniqueUids([]));
+        $this->assertSame([], $this->callPrivate('extractUniqueUids', [[]]));
     }
 
     public function testExtractUniqueUidsSingleVolumeMultipleEditors(): void
@@ -240,7 +247,7 @@ class Episciences_VolumesManagerTest extends TestCase
         $grouped = [
             10 => [100 => [], 101 => []],
         ];
-        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        $uids = $this->callPrivate('extractUniqueUids', [$grouped]);
         sort($uids);
 
         $this->assertSame([100, 101], $uids);
@@ -250,9 +257,9 @@ class Episciences_VolumesManagerTest extends TestCase
     {
         $grouped = [
             10 => [100 => [], 101 => []],
-            20 => [100 => [], 102 => []],  // uid 100 appears in both volumes
+            20 => [100 => [], 102 => []],
         ];
-        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        $uids = $this->callPrivate('extractUniqueUids', [$grouped]);
         sort($uids);
 
         $this->assertSame([100, 101, 102], $uids);
@@ -262,7 +269,7 @@ class Episciences_VolumesManagerTest extends TestCase
     public function testExtractUniqueUidsSingleEditor(): void
     {
         $grouped = [42 => [7 => []]];
-        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        $uids = $this->callPrivate('extractUniqueUids', [$grouped]);
 
         $this->assertSame([7], $uids);
     }
@@ -270,7 +277,7 @@ class Episciences_VolumesManagerTest extends TestCase
     public function testExtractUniqueUidsReturnsIntKeys(): void
     {
         $grouped = [10 => [99 => []]];
-        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        $uids = $this->callPrivate('extractUniqueUids', [$grouped]);
 
         $this->assertIsInt($uids[0]);
     }

--- a/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
@@ -128,4 +128,150 @@ class Episciences_VolumesManagerTest extends TestCase
         // For 'abc', the result is 0 → empty string.
         $this->assertSame('', Episciences_VolumesManager::translateVolumeKey('not-a-number!@#'));
     }
+
+    // =========================================================================
+    // groupAssignmentRowsByVid() — pure logic, no DB
+    // =========================================================================
+
+    private function makeRow(int $vid, int $uid, string $status, string $when = '2024-01-01'): array
+    {
+        return ['ITEMID' => $vid, 'UID' => $uid, 'STATUS' => $status, 'WHEN' => $when];
+    }
+
+    public function testGroupAssignmentRowsByVidReturnsEmptyOnEmptyInput(): void
+    {
+        $this->assertSame([], Episciences_VolumesManager::groupAssignmentRowsByVid([], true));
+        $this->assertSame([], Episciences_VolumesManager::groupAssignmentRowsByVid([], false));
+    }
+
+    public function testGroupAssignmentRowsByVidGroupsByItemId(): void
+    {
+        $rows = [
+            $this->makeRow(10, 1, 'active'),
+            $this->makeRow(20, 2, 'active'),
+        ];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+
+        $this->assertArrayHasKey(10, $result);
+        $this->assertArrayHasKey(20, $result);
+        $this->assertArrayHasKey(1, $result[10]);
+        $this->assertArrayHasKey(2, $result[20]);
+    }
+
+    public function testGroupAssignmentRowsByVidFiltersNonActiveWhenActive(): void
+    {
+        $rows = [
+            $this->makeRow(10, 1, 'active'),
+            $this->makeRow(10, 2, 'inactive'),
+        ];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+
+        $this->assertArrayHasKey(1, $result[10]);
+        $this->assertArrayNotHasKey(2, $result[10] ?? []);
+    }
+
+    public function testGroupAssignmentRowsByVidIncludesNonActiveWhenNotActive(): void
+    {
+        $rows = [
+            $this->makeRow(10, 1, 'active'),
+            $this->makeRow(10, 2, 'inactive'),
+        ];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, false);
+
+        $this->assertArrayHasKey(1, $result[10]);
+        $this->assertArrayHasKey(2, $result[10]);
+    }
+
+    public function testGroupAssignmentRowsByVidLastRowWinsForSameVidAndUid(): void
+    {
+        $rows = [
+            $this->makeRow(10, 1, 'active', '2023-01-01'),
+            $this->makeRow(10, 1, 'active', '2024-06-01'),
+        ];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+
+        $this->assertCount(1, $result[10]);
+        $this->assertSame('2024-06-01', $result[10][1]['WHEN']);
+    }
+
+    public function testGroupAssignmentRowsByVidHandlesMultipleEditorsPerVolume(): void
+    {
+        $rows = [
+            $this->makeRow(5, 100, 'active'),
+            $this->makeRow(5, 101, 'active'),
+            $this->makeRow(5, 102, 'inactive'),
+        ];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid($rows, true);
+
+        $this->assertCount(2, $result[5]);
+        $this->assertArrayHasKey(100, $result[5]);
+        $this->assertArrayHasKey(101, $result[5]);
+    }
+
+    public function testGroupAssignmentRowsByVidReturnsRowData(): void
+    {
+        $row = $this->makeRow(7, 42, 'active', '2025-03-15');
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid([$row], true);
+
+        $this->assertSame('active', $result[7][42]['STATUS']);
+        $this->assertSame('2025-03-15', $result[7][42]['WHEN']);
+    }
+
+    public function testGroupAssignmentRowsByVidCastsVidAndUidToInt(): void
+    {
+        $row = ['ITEMID' => '10', 'UID' => '42', 'STATUS' => 'active', 'WHEN' => '2024-01-01'];
+        $result = Episciences_VolumesManager::groupAssignmentRowsByVid([$row], true);
+
+        $this->assertArrayHasKey(10, $result);
+        $this->assertArrayHasKey(42, $result[10]);
+    }
+
+    // =========================================================================
+    // extractUniqueUids() — pure logic, no DB
+    // =========================================================================
+
+    public function testExtractUniqueUidsReturnsEmptyOnEmptyInput(): void
+    {
+        $this->assertSame([], Episciences_VolumesManager::extractUniqueUids([]));
+    }
+
+    public function testExtractUniqueUidsSingleVolumeMultipleEditors(): void
+    {
+        $grouped = [
+            10 => [100 => [], 101 => []],
+        ];
+        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        sort($uids);
+
+        $this->assertSame([100, 101], $uids);
+    }
+
+    public function testExtractUniqueUidsDeduplicatesAcrossVolumes(): void
+    {
+        $grouped = [
+            10 => [100 => [], 101 => []],
+            20 => [100 => [], 102 => []],  // uid 100 appears in both volumes
+        ];
+        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+        sort($uids);
+
+        $this->assertSame([100, 101, 102], $uids);
+        $this->assertCount(3, $uids);
+    }
+
+    public function testExtractUniqueUidsSingleEditor(): void
+    {
+        $grouped = [42 => [7 => []]];
+        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+
+        $this->assertSame([7], $uids);
+    }
+
+    public function testExtractUniqueUidsReturnsIntKeys(): void
+    {
+        $grouped = [10 => [99 => []]];
+        $uids = Episciences_VolumesManager::extractUniqueUids($grouped);
+
+        $this->assertIsInt($uids[0]);
+    }
 }

--- a/tests/unit/library/Episciences/user/Episciences_UserTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_UserTest.php
@@ -737,4 +737,56 @@ class Episciences_UserTest extends TestCase
             $this->assertTrue(true);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // hasLocalData() via identity map — no DB required
+    // -------------------------------------------------------------------------
+
+    public function testHasLocalDataReturnsTrueWhenIdentityMapHasUuidRow(): void
+    {
+        $uid = 42;
+        Episciences_User::setStaticCache($uid, ['UID' => $uid, 'uuid' => 'some-uuid-value']);
+
+        $user = new Episciences_User();
+        $result = $user->hasLocalData($uid);
+
+        $this->assertTrue($result);
+        $this->assertTrue($user->getHasAccountData());
+        $this->assertSame('some-uuid-value', $user->getUuid());
+    }
+
+    public function testHasLocalDataReturnsFalseWhenIdentityMapHasEmptyRow(): void
+    {
+        $uid = 43;
+        Episciences_User::setStaticCache($uid, []);
+
+        $user = new Episciences_User();
+        $result = $user->hasLocalData($uid);
+
+        $this->assertFalse($result);
+        $this->assertFalse($user->getHasAccountData());
+    }
+
+    public function testHasLocalDataThrowsWhenIdentityMapRowHasNullUuid(): void
+    {
+        $uid = 44;
+        Episciences_User::setStaticCache($uid, ['UID' => $uid]);  // no 'uuid' key → null
+
+        $user = new Episciences_User();
+        $this->expectException(\InvalidArgumentException::class);
+        $user->hasLocalData($uid);
+    }
+
+    public function testHasLocalDataUsesUidFromObjectWhenParamIsNull(): void
+    {
+        $uid = 99;
+        Episciences_User::setStaticCache($uid, ['UID' => $uid, 'uuid' => 'uid-from-object']);
+
+        $user = new Episciences_User();
+        $user->setUid($uid);
+        $result = $user->hasLocalData();  // no param → uses getUid()
+
+        $this->assertTrue($result);
+        $this->assertSame('uid-from-object', $user->getUuid());
+    }
 }


### PR DESCRIPTION
## Problème

La page `/volume/list` exécutait **894 requêtes SQL** pour 241 volumes, dont :
- 1 requête `USER_ASSIGNMENT` **par volume** (241 requêtes)
- 2–3 requêtes **par éditeur** (T_USERS, T_UTILISATEURS, uuid/COUNT)

## Solutions

### Solution 1 — Batch-load des éditeurs (`VolumesManager::loadEditorsForVolumes`)

Remplace les N requêtes `USER_ASSIGNMENT` par **une seule** avec `ITEMID IN (...)`.
Les résultats sont distribués aux objets `Volume` ; `Volume::markEditorsLoaded()` empêche `getEditors()` de re-requêter.

### Solution 2 — Batch-load T_USERS dans l'identity map (`preloadUserCaches`)

Collecte tous les UIDs uniques des éditeurs, puis charge `T_USERS` en une seule requête et pré-peuple `User::$_identityMap` via `setStaticCache()`.

- `hasLocalData()` consulte désormais l'identity map avant la BD → **supprime la requête uuid/COUNT**
- `createEditorFromRow()` appelle `find()` (identity map) au lieu de `findWithCAS()` → **supprime les requêtes T_UTILISATEURS**
- `editors_list.phtml` passe à `getScreenName()` (T_USERS) au lieu de `getFullname()` (T_UTILISATEURS)

### Solution 3 — Nettoyage architecture

- Les batch loads (`loadSettingsForVolumes` + `loadEditorsForVolumes`) sont déplacés dans `VolumeController::listAction()` (la vue reste sans logique)
- `Ccsd_User_Models_UserMapper` reçoit un cache statique + `preloadCache()` (disponible pour d'autres pages)

### Affichage des éditeurs

- Jusqu'à 2 noms affichés avec puces (`disc`, `padding-left: 1em`)
- À partir de 3 : compteur + tooltip listant tous les noms (comportement précédent)

## Résultat

| | Avant | Après |
|---|---|---|
| Requêtes `USER_ASSIGNMENT` | 241 | **1** |
| Requêtes `T_USERS` | ~150 (identity map partielle) | **1** |
| Requêtes `T_UTILISATEURS` | ~200 | **0** |
| Requêtes `uuid/COUNT` | ~200 | **0** |
| **Total** | **~894** | **~4** |

## Tests

- 30+ nouveaux tests unitaires (4452 au total, tous verts)
- `groupAssignmentRowsByVid`, `extractUniqueUids`, `hasLocalData` via identity map, `UserMapper` cache path