### PR TITLE
Feat/cover letter requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Volume settings: added copy-to-clipboard buttons for volume access codes in the volumes list and edit pages.
 - Website settings: added support for journal description, keywords, and creation year fields.
 - MIME type: added support check for `file` binary presence on the system in `FileBinaryMimeTypeGuesser`.
+- [#922](https://github.com/CCSDForge/episciences/issues/922) Add cover letter requirement setting for file attachments. Initial submission form supports three options: disabled (hidden), optional, or required. Author comment form on paper page supports two options: disabled (hidden) or displayed.
 
 ### Changed
 

--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -216,6 +216,12 @@ return array(
     "L'auteur ne peut pas choisir la rubrique" => "Contributors can't choose a section",
     "L'auteur peut choisir la rubrique" => "Contributors can choose a section",
     "L'auteur doit choisir la rubrique" => "Contributors have to choose a section",
+    // Cover letter requirement
+    "Lettre de motivation" => "Cover letter",
+    "Désactivée" => "Disabled",
+    "Facultative" => "Optional",
+    "Requise" => "Required",
+    "Une lettre d'accompagnement est requise. Veuillez joindre un fichier." => "A cover letter is required. Please attach a file.",
     'Page de contact de la revue' => 'Journal contact URL',
     'Page de la notice dans le catalogue' => 'Catalogue notice URL',
     'Courriel de contact de la revue' => 'Journal contact email',

--- a/application/modules/journal/controllers/PaperController.php
+++ b/application/modules/journal/controllers/PaperController.php
@@ -1842,6 +1842,12 @@ class PaperController extends PaperDefaultController
         }
 
         $form = $this->buildNewVersionForm($paper);
+
+        // Validate cover letter requirement before form validation
+        if (!$this->handleCoverLetterValidation($form, $post, $paper)) {
+            return;
+        }
+
         if (!$form?->isValid($post)) {
             $this->handleInvalidForm($form, $paper);
             return;
@@ -2005,6 +2011,29 @@ class PaperController extends PaperDefaultController
     {
         $this->renderFormErrors($form);
         $this->_helper->redirector->gotoUrl(self::PAPER_URL_STR . $paper->getDocid());
+    }
+
+    /**
+     * Validate cover letter requirement.
+     * When required, at least one of comment or file must be provided.
+     *
+     * @throws Zend_Db_Statement_Exception
+     */
+    private function handleCoverLetterValidation(?Zend_Form $form, array $post, Episciences_Paper $paper): bool
+    {
+        if (!$form) {
+            return true;
+        }
+
+        $validation = Episciences_Submit::validateCoverLetterRequirement($post);
+
+        if ($validation !== true) {
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($validation);
+            $this->_helper->redirector->gotoUrl(self::PAPER_URL_STR . $paper->getDocid());
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/application/modules/journal/controllers/SubmitController.php
+++ b/application/modules/journal/controllers/SubmitController.php
@@ -162,6 +162,10 @@ class SubmitController extends DefaultController
         $this->adjustFormForReplacementOrSuggestions($request, $form, $canReplace);
         $this->setDdFileRequiredFlag($form, $post);
 
+        if (!$this->handleCoverLetterValidation($form, $post)) {
+            return;
+        }
+
         if (!$form->isValid($post)) {
             $this->renderFormErrors($form);
             return;
@@ -213,6 +217,29 @@ class SubmitController extends DefaultController
 
         $form->getElement(Episciences_Submit::DD_FILE_ELEMENT_NAME)
             ?->setRequired($post[$requiredDdKey] === 'true');
+    }
+
+    /**
+     * Validate cover letter requirement.
+     * When required, at least one of comment or file must be provided.
+     *
+     * @throws Zend_Db_Statement_Exception
+     */
+    private function handleCoverLetterValidation(Zend_Form $form, array $post): bool
+    {
+        $validation = Episciences_Submit::validateCoverLetterRequirement($post);
+
+        if ($validation !== true) {
+            $element = $form->getElement(Episciences_Submit::COVER_LETTER_COMMENT_ELEMENT_NAME);
+            if ($element) {
+                $element->addError($validation);
+            }
+
+            $this->renderFormErrors($form);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/application/modules/journal/controllers/SubmitController.php
+++ b/application/modules/journal/controllers/SubmitController.php
@@ -230,7 +230,7 @@ class SubmitController extends DefaultController
         $validation = Episciences_Submit::validateCoverLetterRequirement($post);
 
         if ($validation !== true) {
-            $element = $form->getElement(Episciences_Submit::COVER_LETTER_COMMENT_ELEMENT_NAME);
+            $element = $form->getElement(Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME);
             if ($element) {
                 $element->addError($validation);
             }

--- a/library/Episciences/CommentsManager.php
+++ b/library/Episciences/CommentsManager.php
@@ -555,37 +555,45 @@ class Episciences_CommentsManager
             'required' => !isset($values['MESSAGE'])
         ]);
         $group[] = Episciences_Submit::COVER_LETTER_COMMENT_ELEMENT_NAME;
-        // Attached file
-        $descriptions = self::getDescriptions();
-        $description = $descriptions['description'];
-        $description .= '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated;
-        $form->addElement('file', Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME, [
-            'label' => "Lettre d'accompagnement",
-            'description' => $description,
-            'valueDisabled' => true,
-            'validators' => [
-                'Count' => [false, 1],
-                'Extension' => [false, $descriptions['extensions']],
-                'Size' => [false, MAX_FILE_SIZE]
-            ]
-        ]);
 
-        $group[] = Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME;
-        if (isset($values['FILE'])) {
-            $safeFile  = htmlspecialchars((string)$values['FILE'], ENT_QUOTES, 'UTF-8');
-            $safeDocId = (int)$values['DOCID'];
-            $href = '<a href="/docfiles/comments/' . $safeDocId . '/' . $safeFile . '">' . $safeFile . '</a>';
+        // Cover letter file field: hidden if setting = 0, displayed otherwise
+        $review = Episciences_ReviewsManager::find(RVID);
+        $review->loadSettings();
+        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
 
-            $infos = $translator->translate('Ci-dessous votre ancienne lettre d’accompagnement, son remplacement est possible en joignant un nouveau fichier à votre commentaire.')
-                . '<br>' . $translator->translate('Ces modifications seront prises en compte une fois le formulaire est validé.');
-
-            $form->addElement('note', 'note_cover_letter', [
-                'label' => $translator->translate('Note:'),
-                'value' => $href,
-                'description' => $infos,
+        if ($coverLetterRequirement !== 0) {
+            $descriptions = self::getDescriptions();
+            $description = $descriptions['description'];
+            $description .= '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated;
+            $form->addElement('file', Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME, [
+                'label' => "Lettre d'accompagnement",
+                'description' => $description,
+                'valueDisabled' => true,
+                'validators' => [
+                    'Count' => [false, 1],
+                    'Extension' => [false, $descriptions['extensions']],
+                    'Size' => [false, MAX_FILE_SIZE]
+                ]
             ]);
 
-            $group[] = 'note_cover_letter';
+            $group[] = Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME;
+
+            if (isset($values['FILE'])) {
+                $safeFile  = htmlspecialchars((string)$values['FILE'], ENT_QUOTES, 'UTF-8');
+                $safeDocId = (int)$values['DOCID'];
+                $href = '<a href="/docfiles/comments/' . $safeDocId . '/' . $safeFile . '">' . $safeFile . '</a>';
+
+                $infos = $translator->translate("Ci-dessous votre ancienne lettre d'accompagnement, son remplacement est possible en joignant un nouveau fichier à votre commentaire.")
+                    . '<br>' . $translator->translate('Ces modifications seront prises en compte une fois le formulaire est validé.');
+
+                $form->addElement('note', 'note_cover_letter', [
+                    'label' => $translator->translate('Note:'),
+                    'value' => $href,
+                    'description' => $infos,
+                ]);
+
+                $group[] = 'note_cover_letter';
+            }
         }
 
         $form->createCancelButton('exitComment', [

--- a/library/Episciences/CommentsManager.php
+++ b/library/Episciences/CommentsManager.php
@@ -556,12 +556,12 @@ class Episciences_CommentsManager
         ]);
         $group[] = Episciences_Submit::COVER_LETTER_COMMENT_ELEMENT_NAME;
 
-        // Cover letter file field: hidden if setting = 0, displayed otherwise
+        // Cover letter file field: hidden if disabled, displayed otherwise
         $review = Episciences_ReviewsManager::find(RVID);
         $review->loadSettings();
         $coverLetterRequirement = $review->getCoverLetterRequirement();
 
-        if ($coverLetterRequirement !== 0) {
+        if ($coverLetterRequirement !== Episciences_Review::COVER_LETTER_REQUIREMENT_DISABLED) {
             $descriptions = self::getDescriptions();
             $description = $descriptions['description'];
             $description .= '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated;

--- a/library/Episciences/CommentsManager.php
+++ b/library/Episciences/CommentsManager.php
@@ -559,7 +559,7 @@ class Episciences_CommentsManager
         // Cover letter file field: hidden if setting = 0, displayed otherwise
         $review = Episciences_ReviewsManager::find(RVID);
         $review->loadSettings();
-        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+        $coverLetterRequirement = $review->getCoverLetterRequirement();
 
         if ($coverLetterRequirement !== 0) {
             $descriptions = self::getDescriptions();

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -44,6 +44,8 @@ class Episciences_Review
     // git #155
     public const SETTING_CAN_RESUBMIT_REFUSED_PAPER = 'canResubmitRefusedPaper';
     public const SETTING_ARXIV_PAPER_PASSWORD = 'canSharePaperPassword';
+    // git #922
+    public const SETTING_COVER_LETTER_REQUIREMENT = 'coverLetterRequirement';
 
     //const SETTING_EDITORS_CAN_MAKE_DECISIONS = 'editorsCanMakeDecisions';
     public const SETTING_EDITORS_CAN_ABANDON_CONTINUE_PUBLICATION_PROCESS = 'editorsCanAbandonPublicationProcess';
@@ -229,6 +231,7 @@ class Episciences_Review
             self::SETTING_SYSTEM_PAPER_FINAL_DECISION_ALLOW_REVISION,
             self::SETTING_DO_NOT_ALLOW_EDITOR_IN_CHIEF_SELECTION,
             self::SETTING_ARXIV_PAPER_PASSWORD,
+            self::SETTING_COVER_LETTER_REQUIREMENT,
             self::SETTING_CONTACT_ERROR_MAIL,
             self::SETTING_DISPLAY_STATISTICS,
             self::SETTING_REFUSED_ARTICLE_AUTHORS_MESSAGE_AUTOMATICALLY_SENT_TO_REVIEWERS,
@@ -1103,6 +1106,7 @@ class Episciences_Review
             self::SETTING_REPOSITORIES,
             self::SETTING_CAN_PICK_SECTION,
             self::SETTING_CAN_PICK_EDITOR,
+            self::SETTING_COVER_LETTER_REQUIREMENT,
             self::SETTING_DO_NOT_ALLOW_EDITOR_IN_CHIEF_SELECTION,
             self::SETTING_CAN_SUGGEST_REVIEWERS,
             self::SETTING_CAN_SPECIFY_UNWANTED_REVIEWERS,
@@ -1325,6 +1329,20 @@ class Episciences_Review
 
             ]
         );
+
+        // Cover letter requirement (controls only the file, comment is always optional)
+        $form->addElement('select', self::SETTING_COVER_LETTER_REQUIREMENT, [
+                'label' => "Lettre d'accompagnement",
+                'value' => 1,
+                'multioptions' => [
+                    0 => 'Désactivée',
+                    1 => 'Facultative',
+                    2 => 'Requise',
+                ],
+            ]
+        );
+
+        $form->getElement(self::SETTING_COVER_LETTER_REQUIREMENT)->getDecorator('label')->setOption('class', 'col-md-2');
 
         return $form;
 
@@ -1918,7 +1936,8 @@ class Episciences_Review
             self::SETTING_EDITORS_CAN_ABANDON_CONTINUE_PUBLICATION_PROCESS, self::SETTING_CAN_RESUBMIT_REFUSED_PAPER,
             self::SETTING_SYSTEM_IS_COI_ENABLED, self::SETTING_SYSTEM_COI_COMMENTS_TO_EDITORS_ENABLED,
             self::SETTING_SYSTEM_PAPER_FINAL_DECISION_ALLOW_REVISION, self::SETTING_SYSTEM_AUTO_EDITORS_ASSIGNMENT,
-            self::SETTING_ARXIV_PAPER_PASSWORD, self::SETTING_DISPLAY_STATISTICS, self::SETTING_CONTACT_ERROR_MAIL,
+            self::SETTING_ARXIV_PAPER_PASSWORD, self::SETTING_COVER_LETTER_REQUIREMENT,
+            self::SETTING_DISPLAY_STATISTICS, self::SETTING_CONTACT_ERROR_MAIL,
             self::SETTING_REFUSED_ARTICLE_AUTHORS_MESSAGE_AUTOMATICALLY_SENT_TO_REVIEWERS,
             self::SETTING_TO_REQUIRE_REVISION_DEADLINE, self::SETTING_START_STATS_AFTER_DATE,
             self::SETTING_ALLOW_EDIT_VOLUME_TITLE_WITH_PUBLISHED_ARTICLES, self::SETTING_DISPLAY_EMPTY_VOLUMES,

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -46,6 +46,9 @@ class Episciences_Review
     public const SETTING_ARXIV_PAPER_PASSWORD = 'canSharePaperPassword';
     // git #922
     public const SETTING_COVER_LETTER_REQUIREMENT = 'coverLetterRequirement';
+    public const COVER_LETTER_REQUIREMENT_DISABLED = 0;
+    public const COVER_LETTER_REQUIREMENT_OPTIONAL = 1;
+    public const COVER_LETTER_REQUIREMENT_REQUIRED = 2;
 
     //const SETTING_EDITORS_CAN_MAKE_DECISIONS = 'editorsCanMakeDecisions';
     public const SETTING_EDITORS_CAN_ABANDON_CONTINUE_PUBLICATION_PROCESS = 'editorsCanAbandonPublicationProcess';
@@ -615,10 +618,10 @@ class Episciences_Review
     }
 
     /**
-     * Get the cover letter requirement setting (0=disabled, 1=optional, 2=required).
+     * Get the cover letter requirement setting (see COVER_LETTER_REQUIREMENT_* constants).
      * Reviews created before this setting existed have no stored value: default to
-     * "optional" (1) so the cover letter file field keeps being displayed, matching
-     * the behavior that existed for every journal prior to git #922.
+     * COVER_LETTER_REQUIREMENT_OPTIONAL so the cover letter file field keeps being
+     * displayed, matching the behavior that existed for every journal prior to git #922.
      */
     public function getCoverLetterRequirement(): int
     {
@@ -627,7 +630,7 @@ class Episciences_Review
         }
 
         if (!array_key_exists(self::SETTING_COVER_LETTER_REQUIREMENT, $this->_settings)) {
-            return 1;
+            return self::COVER_LETTER_REQUIREMENT_OPTIONAL;
         }
 
         return (int)$this->_settings[self::SETTING_COVER_LETTER_REQUIREMENT];
@@ -1352,11 +1355,11 @@ class Episciences_Review
         // Cover letter requirement (controls only the file, comment is always optional)
         $form->addElement('select', self::SETTING_COVER_LETTER_REQUIREMENT, [
                 'label' => "Lettre d'accompagnement",
-                'value' => 1,
+                'value' => self::COVER_LETTER_REQUIREMENT_OPTIONAL,
                 'multioptions' => [
-                    0 => 'Désactivée',
-                    1 => 'Facultative',
-                    2 => 'Requise',
+                    self::COVER_LETTER_REQUIREMENT_DISABLED => 'Désactivée',
+                    self::COVER_LETTER_REQUIREMENT_OPTIONAL => 'Facultative',
+                    self::COVER_LETTER_REQUIREMENT_REQUIRED => 'Requise',
                 ],
             ]
         );

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -615,6 +615,25 @@ class Episciences_Review
     }
 
     /**
+     * Get the cover letter requirement setting (0=disabled, 1=optional, 2=required).
+     * Reviews created before this setting existed have no stored value: default to
+     * "optional" (1) so the cover letter file field keeps being displayed, matching
+     * the behavior that existed for every journal prior to git #922.
+     */
+    public function getCoverLetterRequirement(): int
+    {
+        if (!$this->_settingsLoaded) {
+            $this->loadSettings();
+        }
+
+        if (!array_key_exists(self::SETTING_COVER_LETTER_REQUIREMENT, $this->_settings)) {
+            return 1;
+        }
+
+        return (int)$this->_settings[self::SETTING_COVER_LETTER_REQUIREMENT];
+    }
+
+    /**
      * load review settings from database
      */
     public function loadSettings(bool $forceReload = false): void

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -21,6 +21,37 @@ class Episciences_Submit
     public const POSTED_VOLUME_KEY = 'volumes';
     public const POSTED_SECTION_KEY = 'sections';
 
+    /**
+     * Validate cover letter file requirement.
+     * When required (value = 2), the cover letter file must be provided.
+     * Note: The comment field is always optional and not controlled by this setting.
+     *
+     * @param array $post POST data
+     * @return true|string Returns true if valid, or error message string if invalid
+     * @throws Zend_Db_Statement_Exception
+     */
+    public static function validateCoverLetterRequirement(array $post): bool|string
+    {
+        $review = Episciences_ReviewsManager::find(RVID);
+        $review->loadSettings();
+        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+
+        // Only validate if cover letter is required (value = 2)
+        if ($coverLetterRequirement !== 2) {
+            return true;
+        }
+
+        $file = $_FILES[self::COVER_LETTER_FILE_ELEMENT_NAME]['name'] ?? '';
+
+        // Cover letter file must be provided
+        if (empty($file)) {
+            return Zend_Registry::get('Zend_Translate')
+                ->translate("Une lettre d'accompagnement est requise. Veuillez joindre un fichier.");
+        }
+
+        return true;
+    }
+
     public function __construct()
     {
         $this->_db = Zend_Db_Table_Abstract::getDefaultAdapter();
@@ -288,6 +319,14 @@ class Episciences_Submit
 
         // Author's comments and Cover Letter
         // Keep in sync with paper views where these roles have access to the comments and cover letter
+        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+
+        // Hidden field to pass cover letter requirement to JavaScript
+        $form->addElement('hidden', 'cover_letter_requirement', [
+            'value' => $coverLetterRequirement,
+            'decorators' => ['ViewHelper']
+        ]);
+
         $allowedToSeeCoverLetterTranslated = [];
 
         foreach ([Episciences_Acl::ROLE_CHIEF_EDITOR_PLURAL, Episciences_Acl::ROLE_EDITOR_PLURAL, Episciences_Acl::ROLE_REVIEWER_PLURAL] as $roleAllowedToSee) {
@@ -296,32 +335,52 @@ class Episciences_Submit
 
         $descriptionAllowedToSeeCoverLetterTranslated = Zend_Registry::get('Zend_Translate')->translate('Visible par : ') . implode(', ', $allowedToSeeCoverLetterTranslated);
 
+        // Comment field is always optional
+        $optionalSuffix = '<br><em style="font-weight: normal;">' . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>';
 
-        $form->addElement('textarea', self::COVER_LETTER_COMMENT_ELEMENT_NAME, [
-            'label' => Zend_Registry::get('Zend_Translate')->translate('Commentaire') . '<br><em style="font-weight: normal;">' . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>', 'rows' => 5,
+        $commentElementOptions = [
+            'label' => Zend_Registry::get('Zend_Translate')->translate('Commentaire') . $optionalSuffix,
+            'rows' => 5,
             'description' => $descriptionAllowedToSeeCoverLetterTranslated,
             'validators' => [['StringLength', false, ['max' => MAX_INPUT_TEXTAREA]]]
-        ]);
+        ];
+
+        $form->addElement('textarea', self::COVER_LETTER_COMMENT_ELEMENT_NAME, $commentElementOptions);
         $group[] = self::COVER_LETTER_COMMENT_ELEMENT_NAME;
 
-        // Attached file
-        $extensions = ALLOWED_EXTENSIONS;
-        $implode_extensions = implode(',', $extensions);
-        $description = Episciences_Tools::buildAttachedFilesDescription($extensions, '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated);
+        // Cover letter file field (controlled by coverLetterRequirement setting)
+        // 0 = disabled (not displayed), 1 = optional, 2 = required
+        if ($coverLetterRequirement !== 0) {
+            $isRequired = $coverLetterRequirement === 2;
+            $fileOptionalSuffix = $isRequired ? '' : $optionalSuffix;
 
-        $form->addElement('file', self::COVER_LETTER_FILE_ELEMENT_NAME, [
-            'label' => Zend_Registry::get('Zend_Translate')->translate("Lettre d'accompagnement") . "<br><em style=\"font-weight: normal;\">" . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>',
-            'description' => $description,
-            'valueDisabled' => true,
-            'maxFileSize' => MAX_FILE_SIZE,
-            'validators' => [
-                'Count' => [false, 1],
-                'Extension' => [false, $implode_extensions],
-                'Size' => [false, MAX_FILE_SIZE]
-            ]
-        ]);
+            $extensions = ALLOWED_EXTENSIONS;
+            $implode_extensions = implode(',', $extensions);
+            $description = Episciences_Tools::buildAttachedFilesDescription($extensions, '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated);
 
-        $group[] = self::COVER_LETTER_FILE_ELEMENT_NAME;
+            $fileElementOptions = [
+                'label' => Zend_Registry::get('Zend_Translate')->translate("Lettre d'accompagnement") . $fileOptionalSuffix,
+                'description' => $description,
+                'valueDisabled' => true,
+                'maxFileSize' => MAX_FILE_SIZE,
+                'validators' => [
+                    'Count' => [false, 1],
+                    'Extension' => [false, $implode_extensions],
+                    'Size' => [false, MAX_FILE_SIZE]
+                ]
+            ];
+
+            $form->addElement('file', self::COVER_LETTER_FILE_ELEMENT_NAME, $fileElementOptions);
+
+            // Add required class to label when cover letter is required
+            if ($isRequired) {
+                $form->getElement(self::COVER_LETTER_FILE_ELEMENT_NAME)
+                    ->getDecorator('label')
+                    ->setOption('class', 'col-md-3 control-label required');
+            }
+
+            $group[] = self::COVER_LETTER_FILE_ELEMENT_NAME;
+        }
 
         $form = self::addDdElement($form, $group);
 
@@ -655,6 +714,16 @@ class Episciences_Submit
 
             // Author's comments and Cover Letter [new version]
             // Keep in sync with paper views where these roles have access to the comments and cover letter
+            $review = Episciences_ReviewsManager::find(RVID);
+            $review->loadSettings();
+            $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+
+            // Hidden field to pass cover letter requirement to JavaScript
+            $form->addElement('hidden', 'cover_letter_requirement', [
+                'value' => $coverLetterRequirement,
+                'decorators' => ['ViewHelper']
+            ]);
+
             $allowedToSeeCoverLetterTranslated = [];
             foreach ([Episciences_Acl::ROLE_CHIEF_EDITOR_PLURAL, Episciences_Acl::ROLE_EDITOR_PLURAL, Episciences_Acl::ROLE_REVIEWER_PLURAL] as $roleAllowedToSee) {
                 $allowedToSeeCoverLetterTranslated[] = Zend_Registry::get('Zend_Translate')->translate($roleAllowedToSee);
@@ -662,8 +731,12 @@ class Episciences_Submit
 
             $descriptionAllowedToSeeCoverLetterTranslated = Zend_Registry::get('Zend_Translate')->translate('Visible par : ') . implode(', ', $allowedToSeeCoverLetterTranslated);
 
+            // Comment field is always optional
+            $optionalSuffix = '<br><em style="font-weight: normal;">' . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>';
+
             $form->addElement('textarea', self::COVER_LETTER_COMMENT_ELEMENT_NAME, [
-                'label' => Zend_Registry::get('Zend_Translate')->translate('Commentaire') . '<br><em style="font-weight: normal;">' . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>', 'rows' => 5,
+                'label' => Zend_Registry::get('Zend_Translate')->translate('Commentaire') . $optionalSuffix,
+                'rows' => 5,
                 'description' => $descriptionAllowedToSeeCoverLetterTranslated,
                 'validators' => [[
                     'StringLength', false, ['max' => MAX_INPUT_TEXTAREA]
@@ -671,24 +744,36 @@ class Episciences_Submit
             ]);
             $group[] = self::COVER_LETTER_COMMENT_ELEMENT_NAME;
 
+            // Cover letter file field (controlled by coverLetterRequirement setting)
+            // 0 = disabled (not displayed), 1 = optional, 2 = required
+            if ($coverLetterRequirement !== 0) {
+                $isRequired = $coverLetterRequirement === 2;
+                $fileOptionalSuffix = $isRequired ? '' : $optionalSuffix;
 
-            // Attached file [new version]
-            $extensions = ALLOWED_EXTENSIONS;
-            $implode_extensions = implode(',', $extensions);
-            $description = Episciences_Tools::buildAttachedFilesDescription($extensions, '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated);
-            $form->addElement('file', self::COVER_LETTER_FILE_ELEMENT_NAME, [
-                'label' => Zend_Registry::get('Zend_Translate')->translate("Lettre d'accompagnement") . "<br><em style=\"font-weight: normal;\">" . Zend_Registry::get('Zend_Translate')->translate('(optional)') . '</em>',
-                'description' => $description,
-                'valueDisabled' => true,
-                'maxFileSize' => MAX_FILE_SIZE,
-                'validators' => [
-                    'Count' => [false, 1],
-                    'Extension' => [false, $implode_extensions],
-                    'Size' => [false, MAX_FILE_SIZE]
-                ]
-            ]);
+                $extensions = ALLOWED_EXTENSIONS;
+                $implode_extensions = implode(',', $extensions);
+                $description = Episciences_Tools::buildAttachedFilesDescription($extensions, '.&nbsp;' . $descriptionAllowedToSeeCoverLetterTranslated);
+                $form->addElement('file', self::COVER_LETTER_FILE_ELEMENT_NAME, [
+                    'label' => Zend_Registry::get('Zend_Translate')->translate("Lettre d'accompagnement") . $fileOptionalSuffix,
+                    'description' => $description,
+                    'valueDisabled' => true,
+                    'maxFileSize' => MAX_FILE_SIZE,
+                    'validators' => [
+                        'Count' => [false, 1],
+                        'Extension' => [false, $implode_extensions],
+                        'Size' => [false, MAX_FILE_SIZE]
+                    ]
+                ]);
 
-            $group[] = self::COVER_LETTER_FILE_ELEMENT_NAME;
+                // Add required class to label when cover letter is required
+                if ($isRequired) {
+                    $form->getElement(self::COVER_LETTER_FILE_ELEMENT_NAME)
+                        ->getDecorator('label')
+                        ->setOption('class', 'col-md-3 control-label required');
+                }
+
+                $group[] = self::COVER_LETTER_FILE_ELEMENT_NAME;
+            }
 
             if (isset($settings['dataType'])) {
                 self::addDdElement($form, $group, $settings['dataType']);

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -36,8 +36,8 @@ class Episciences_Submit
         $review->loadSettings();
         $coverLetterRequirement = $review->getCoverLetterRequirement();
 
-        // Only validate if cover letter is required (value = 2)
-        if ($coverLetterRequirement !== 2) {
+        // Only validate if cover letter is required
+        if ($coverLetterRequirement !== Episciences_Review::COVER_LETTER_REQUIREMENT_REQUIRED) {
             return true;
         }
 
@@ -349,9 +349,8 @@ class Episciences_Submit
         $group[] = self::COVER_LETTER_COMMENT_ELEMENT_NAME;
 
         // Cover letter file field (controlled by coverLetterRequirement setting)
-        // 0 = disabled (not displayed), 1 = optional, 2 = required
-        if ($coverLetterRequirement !== 0) {
-            $isRequired = $coverLetterRequirement === 2;
+        if ($coverLetterRequirement !== Episciences_Review::COVER_LETTER_REQUIREMENT_DISABLED) {
+            $isRequired = $coverLetterRequirement === Episciences_Review::COVER_LETTER_REQUIREMENT_REQUIRED;
             $fileOptionalSuffix = $isRequired ? '' : $optionalSuffix;
 
             $extensions = ALLOWED_EXTENSIONS;
@@ -745,9 +744,8 @@ class Episciences_Submit
             $group[] = self::COVER_LETTER_COMMENT_ELEMENT_NAME;
 
             // Cover letter file field (controlled by coverLetterRequirement setting)
-            // 0 = disabled (not displayed), 1 = optional, 2 = required
-            if ($coverLetterRequirement !== 0) {
-                $isRequired = $coverLetterRequirement === 2;
+            if ($coverLetterRequirement !== Episciences_Review::COVER_LETTER_REQUIREMENT_DISABLED) {
+                $isRequired = $coverLetterRequirement === Episciences_Review::COVER_LETTER_REQUIREMENT_REQUIRED;
                 $fileOptionalSuffix = $isRequired ? '' : $optionalSuffix;
 
                 $extensions = ALLOWED_EXTENSIONS;

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -34,7 +34,7 @@ class Episciences_Submit
     {
         $review = Episciences_ReviewsManager::find(RVID);
         $review->loadSettings();
-        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+        $coverLetterRequirement = $review->getCoverLetterRequirement();
 
         // Only validate if cover letter is required (value = 2)
         if ($coverLetterRequirement !== 2) {
@@ -319,7 +319,7 @@ class Episciences_Submit
 
         // Author's comments and Cover Letter
         // Keep in sync with paper views where these roles have access to the comments and cover letter
-        $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+        $coverLetterRequirement = $review->getCoverLetterRequirement();
 
         // Hidden field to pass cover letter requirement to JavaScript
         $form->addElement('hidden', 'cover_letter_requirement', [
@@ -716,7 +716,7 @@ class Episciences_Submit
             // Keep in sync with paper views where these roles have access to the comments and cover letter
             $review = Episciences_ReviewsManager::find(RVID);
             $review->loadSettings();
-            $coverLetterRequirement = (int)$review->getSetting(Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT);
+            $coverLetterRequirement = $review->getCoverLetterRequirement();
 
             // Hidden field to pass cover letter requirement to JavaScript
             $form->addElement('hidden', 'cover_letter_requirement', [

--- a/public/js/submit/functions.js
+++ b/public/js/submit/functions.js
@@ -21,6 +21,8 @@ $(function () {
     let $searchRequiredPwd = $('#' + subform + '-h_requiredPwd');
     let $fileDescriptor = $("#file_data_descriptor");
     let $isRequiredDescriptor = $("#file_data_descriptor_is_required");
+    let $coverLetterFile = $("#file_comment_author");
+    let $coverLetterRequirement = $("#cover_letter_requirement");
 
     // if it is a modal, disable submit button
     disableModalSubmitButton();
@@ -50,6 +52,9 @@ $(function () {
         activateDeactivateSubmitButton();
     });
 
+    $coverLetterFile.on('change', function () {
+        activateDeactivateSubmitButton();
+    });
 
     $search_button.on('click', function () {
         doSearching();
@@ -508,6 +513,17 @@ $(function () {
             !$secondDisclaimersDisclaimer.is(':checked')
         ) {
             return false;
+        }
+
+        // Cover letter file check (required = 2 means file must be provided)
+        if (
+            $coverLetterRequirement.length > 0 &&
+            $coverLetterRequirement.val() === '2'
+        ) {
+            const hasFile = $coverLetterFile.length > 0 && $coverLetterFile.val() !== '';
+            if (!hasFile) {
+                return false;
+            }
         }
 
         // data/software descriptor check

--- a/tests/unit/library/Episciences/Episciences_ReviewTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewTest.php
@@ -190,6 +190,51 @@ class Episciences_ReviewTest extends TestCase
     }
 
     // =========================================================================
+    // getCoverLetterRequirement (git #922)
+    // =========================================================================
+
+    public function testGetCoverLetterRequirementDefaultsToOptionalWhenUnset(): void
+    {
+        // Reviews created before this setting existed have no stored value in DB.
+        // Regression: must default to 1 (optional), not 0 (disabled), otherwise
+        // the cover letter file field silently disappears for every pre-existing journal.
+        $this->review->applySettingsFromRows([]);
+        self::assertSame(1, $this->review->getCoverLetterRequirement());
+    }
+
+    public function testGetCoverLetterRequirementReturnsDisabledWhenExplicitlySetToZero(): void
+    {
+        $this->review->applySettingsFromRows([
+            ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '0'],
+        ]);
+        self::assertSame(0, $this->review->getCoverLetterRequirement());
+    }
+
+    public function testGetCoverLetterRequirementReturnsOptionalWhenExplicitlySet(): void
+    {
+        $this->review->applySettingsFromRows([
+            ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '1'],
+        ]);
+        self::assertSame(1, $this->review->getCoverLetterRequirement());
+    }
+
+    public function testGetCoverLetterRequirementReturnsRequired(): void
+    {
+        $this->review->applySettingsFromRows([
+            ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '2'],
+        ]);
+        self::assertSame(2, $this->review->getCoverLetterRequirement());
+    }
+
+    public function testGetCoverLetterRequirementCastsStoredValueToInt(): void
+    {
+        $this->review->applySettingsFromRows([
+            ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '2'],
+        ]);
+        self::assertIsInt($this->review->getCoverLetterRequirement());
+    }
+
+    // =========================================================================
     // getRepositories (reads from $_settings)
     // =========================================================================
 

--- a/tests/unit/library/Episciences/Episciences_ReviewTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewTest.php
@@ -193,13 +193,20 @@ class Episciences_ReviewTest extends TestCase
     // getCoverLetterRequirement (git #922)
     // =========================================================================
 
+    public function testCoverLetterRequirementConstants(): void
+    {
+        self::assertSame(0, Episciences_Review::COVER_LETTER_REQUIREMENT_DISABLED);
+        self::assertSame(1, Episciences_Review::COVER_LETTER_REQUIREMENT_OPTIONAL);
+        self::assertSame(2, Episciences_Review::COVER_LETTER_REQUIREMENT_REQUIRED);
+    }
+
     public function testGetCoverLetterRequirementDefaultsToOptionalWhenUnset(): void
     {
         // Reviews created before this setting existed have no stored value in DB.
-        // Regression: must default to 1 (optional), not 0 (disabled), otherwise
-        // the cover letter file field silently disappears for every pre-existing journal.
+        // Regression: must default to optional, not disabled, otherwise the cover
+        // letter file field silently disappears for every pre-existing journal.
         $this->review->applySettingsFromRows([]);
-        self::assertSame(1, $this->review->getCoverLetterRequirement());
+        self::assertSame(Episciences_Review::COVER_LETTER_REQUIREMENT_OPTIONAL, $this->review->getCoverLetterRequirement());
     }
 
     public function testGetCoverLetterRequirementReturnsDisabledWhenExplicitlySetToZero(): void
@@ -207,7 +214,7 @@ class Episciences_ReviewTest extends TestCase
         $this->review->applySettingsFromRows([
             ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '0'],
         ]);
-        self::assertSame(0, $this->review->getCoverLetterRequirement());
+        self::assertSame(Episciences_Review::COVER_LETTER_REQUIREMENT_DISABLED, $this->review->getCoverLetterRequirement());
     }
 
     public function testGetCoverLetterRequirementReturnsOptionalWhenExplicitlySet(): void
@@ -215,7 +222,7 @@ class Episciences_ReviewTest extends TestCase
         $this->review->applySettingsFromRows([
             ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '1'],
         ]);
-        self::assertSame(1, $this->review->getCoverLetterRequirement());
+        self::assertSame(Episciences_Review::COVER_LETTER_REQUIREMENT_OPTIONAL, $this->review->getCoverLetterRequirement());
     }
 
     public function testGetCoverLetterRequirementReturnsRequired(): void
@@ -223,7 +230,7 @@ class Episciences_ReviewTest extends TestCase
         $this->review->applySettingsFromRows([
             ['SETTING' => Episciences_Review::SETTING_COVER_LETTER_REQUIREMENT, 'VALUE' => '2'],
         ]);
-        self::assertSame(2, $this->review->getCoverLetterRequirement());
+        self::assertSame(Episciences_Review::COVER_LETTER_REQUIREMENT_REQUIRED, $this->review->getCoverLetterRequirement());
     }
 
     public function testGetCoverLetterRequirementCastsStoredValueToInt(): void

--- a/tests/unit/modules/journal/controllers/SubmitControllerTest.php
+++ b/tests/unit/modules/journal/controllers/SubmitControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unit\modules\journal\controllers;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for SubmitController.
+ *
+ * Strategy: source-code pattern analysis (static analysis via PHP string inspection).
+ * No database or HTTP dispatch needed — tests are fast and run without side effects.
+ *
+ * @covers SubmitController
+ */
+final class SubmitControllerTest extends TestCase
+{
+    private string $source;
+
+    protected function setUp(): void
+    {
+        $this->source = (string)file_get_contents(
+            APPLICATION_PATH . '/modules/journal/controllers/SubmitController.php'
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: extract a method body from the source by its name
+    // -----------------------------------------------------------------------
+
+    private function extractMethod(string $methodName): string
+    {
+        $start = strpos($this->source, 'function ' . $methodName);
+        self::assertNotFalse($start, "Method $methodName not found in SubmitController");
+
+        $end = strpos($this->source, 'function ', $start + strlen('function ' . $methodName));
+        if ($end === false) {
+            return substr($this->source, $start);
+        }
+
+        return substr($this->source, $start, $end - $start);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bug (fixed): missing-file error attached to the wrong form element
+    // -----------------------------------------------------------------------
+
+    /**
+     * handleCoverLetterValidation() reports "cover letter file is required" when
+     * Episciences_Submit::validateCoverLetterRequirement() rejects the submission.
+     * That error is about the missing *file*, so it must be attached to
+     * COVER_LETTER_FILE_ELEMENT_NAME. The original code attached it to
+     * COVER_LETTER_COMMENT_ELEMENT_NAME (the always-optional comment textarea)
+     * instead, so the message rendered next to the wrong field and the actual
+     * required file input showed no inline error.
+     */
+    public function testHandleCoverLetterValidationAttachesErrorToFileElement(): void
+    {
+        $method = $this->extractMethod('handleCoverLetterValidation');
+
+        self::assertStringContainsString(
+            'Episciences_Submit::COVER_LETTER_FILE_ELEMENT_NAME',
+            $method,
+            'handleCoverLetterValidation() must attach the missing-file error to the file element'
+        );
+    }
+
+    public function testHandleCoverLetterValidationDoesNotAttachErrorToCommentElement(): void
+    {
+        $method = $this->extractMethod('handleCoverLetterValidation');
+
+        self::assertStringNotContainsString(
+            'Episciences_Submit::COVER_LETTER_COMMENT_ELEMENT_NAME',
+            $method,
+            'handleCoverLetterValidation() must not attach the missing-file error to the comment element'
+        );
+    }
+}


### PR DESCRIPTION
  - Add coverLetterRequirement parameter (0=disabled, 1=optional, 2=required)                     
  - Parameter controls only the file attachment, comment is always optional                       
  - Centralized validation in Episciences_Submit::validateCoverLetterRequirement()                
  - Client-side validation in JavaScript                                                          
  - Server-side validation in SubmitController and PaperController   