### PR TITLE
feat(volume): add dedicated cover image upload to /volume/edit/

### DIFF
--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -802,6 +802,10 @@ return array(
     "Modifier une métadonnée" => "Edit a metadata",
     //End GIT #85
     "Ajouter un fichier (Édito, Erratum, Addendum, ...)" => "Add a file (Foreword, Erratum, Addendum, ...)",
+    'Couverture' => 'Cover',
+    'Couverture du volume' => 'Volume cover',
+    'Ajouter une couverture' => 'Add a cover image',
+    'Supprimer la couverture' => 'Remove the cover',
     "Aucun volume pour le moment" => "No volume yet",
     "Le nouveau volume a bien été créé." => "New volume has been added.",
     "Le nouveau volume n'a pas pu être créé." => "New volume could not be saved.",

--- a/application/modules/journal/views/scripts/volume/form.phtml
+++ b/application/modules/journal/views/scripts/volume/form.phtml
@@ -29,104 +29,139 @@
         </div>
         <?php endif; ?>
 
-        <?php foreach ($this->element->getElements() as $element) : ?>
-            <div id="<?= $element->getName() ?>-element" class="form-group" <?php if ($element->getAttrib('data-none')):?>style="display: none;" <?php endif;?>>
-                <?= $element ?>
+        <div class="row">
+
+            <div class="col-md-7">
+                <?php foreach ($this->element->getElements() as $element) : ?>
+                    <div id="<?= $element->getName() ?>-element" class="form-group" <?php if ($element->getAttrib('data-none')):?>style="display: none;" <?php endif;?>>
+                        <?= $element ?>
+                    </div>
+                <?php endforeach; ?>
+
+                <?= $this->partial('volume/doi_proceedings_row.phtml', [
+                        'value' => $this->element->getDecorator('ViewScript')->getOption('value')
+                ]) ?>
+
+                <?php if ($this->element->getView()->volume && $this->element->getView()->paperList) : ?>
+                    <?php
+                    if (!empty($this->element->getView()->gapsInOrderingPapers)) {
+                        echo '<div class="alert alert-warning" role="alert">';
+                        echo $this->translate('Des vides ont été détectés dans la numérotation des papiers : ');
+                        echo '<ul>';
+                        foreach ($this->element->getView()->gapsInOrderingPapers as $gapNumber) {
+                            printf('<li><span class="label label-default">%d</span></li>', $gapNumber + 1);
+                        }
+                        echo '</ul>';
+                        echo '</div>';
+                    }
+                    ?>
+                    <div id="papers-element" class="form-group row">
+                        <label class="col-md-3 control-label optional"><?= count($this->element->getView()->paperList) . ' ' . $this->translate('articles') ?></label>
+                        <div class="col-md-9" style="padding-top: 7px">
+                            <div id="papers">
+                                <?php foreach ($this->element->getView()->paperList as $paperOrder => $paper) : ?>
+                                    <?php
+                                    $title = $paper['title'];
+                                    $paperDocid = $paper['docid'];
+                                    $titleStr = $this->escape(Ccsd_Tools::truncate($title, 50));
+                                    ?>
+                                    <div id="paper-<?= $paper['paperid'] ?>" class="paper input-group">
+                                    <span class="label label-status-<?= $paper['status'] ?>" data-toggle="tooltip"
+                                          title="<?= ucfirst($this->translate(Episciences_PapersManager::getStatusLabel($paper['status']))) ?>">
+                                   <?= (int)$paperOrder + 1 ?></span>
+                                        [<a href="/administratepaper/view?id=<?= $paperDocid ?>"># <?= $paperDocid ?></a>]&nbsp;
+                                        <?= $titleStr ?>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                            <input id="paper_positions" name="paper_positions" type="hidden" value=""/>
+                        </div>
+                    </div>
+                <?php endif; ?>
             </div>
-        <?php endforeach; ?>
 
-        <?= $this->partial('volume/doi_proceedings_row.phtml', [
-                'value' => $this->element->getDecorator('ViewScript')->getOption('value')
-        ]) ?>
+            <div class="col-md-5">
 
+                <?php $cover = $this->element->getView()->volume ? $this->element->getView()->volume->getCover() : null; ?>
+                <div id="cover-element" style="margin-bottom: 20px">
+                    <label style="font-weight: bold; display: block; margin-bottom: 8px"><?= $this->translate('Couverture') ?></label>
 
-        <div id="metadata-element" class="form-group row">
-            <label class="col-md-3 control-label optional"><?= $this->translate('Métadonnées') ?></label>
-            <div class="col-md-9" style="padding-top: 7px">
+                    <div id="cover-preview-container" <?= ($cover && $cover->hasFile()) ? '' : 'style="display:none"' ?>>
+                        <img id="cover-preview"
+                             src="<?= ($cover && $cover->hasFile()) ? $this->escape($cover->getFileUrl()) : '' ?>"
+                             style="width:160px;height:226px;object-fit:cover;display:block;margin-bottom:8px"
+                             alt="<?= $this->translate('Couverture du volume') ?>" />
+                        <button type="button" class="btn btn-danger btn-sm" id="remove-cover">
+                            <span class="glyphicon glyphicon-trash"></span>
+                            <?= $this->translate('Supprimer la couverture') ?>
+                        </button>
+                        <label for="cover-file" class="btn btn-default btn-sm" style="cursor:pointer;margin-left:4px">
+                            <span class="glyphicon glyphicon-repeat"></span>
+                            <?= $this->translate('Remplacer') ?>
+                        </label>
+                    </div>
 
-                <div id="metadatas">
-                    <?php if ($this->element->getView()->volume) : ?>
-                        <?php $metadatas = $this->element->getView()->volume->getMetadatas(); ?>
+                    <div id="cover-upload-zone" <?= ($cover && $cover->hasFile()) ? 'style="display:none"' : '' ?>>
+                        <label for="cover-file" class="btn btn-default btn-sm" style="cursor:pointer">
+                            <span class="glyphicon glyphicon-picture"></span>
+                            <?= $this->translate('Ajouter une couverture') ?>
+                        </label>
+                    </div>
 
+                    <input type="file" id="cover-file" accept="image/*" style="display:none" />
+                    <input type="hidden" name="cover_data" id="cover_data" value="" />
+                </div>
 
-                        <?php foreach ($metadatas as $metadata) : ?>
-                            <div class="metadata input-group" style="margin-bottom: 2px">
-					<span style="font-size: inherit; display: block; text-align: justify; white-space: normal; padding: 1px  0px 1px 10px;"
-                          class="label label-primary">
-						<?= $metadata->getTitle(); ?>
-						<a class="modal-opener"
-                           data-width="50%"
+                <div id="metadata-element" style="margin-bottom: 20px">
+                    <label style="font-weight: bold; display: block; margin-bottom: 8px"><?= $this->translate('Métadonnées') ?></label>
+
+                    <div id="metadatas">
+                        <?php if ($this->element->getView()->volume) : ?>
+                            <?php $metadatas = $this->element->getView()->volume->getMetadatas(); ?>
+
+                            <?php foreach ($metadatas as $metadata) : ?>
+                                <?php if ($metadata->isCover()) : continue; endif; ?>
+                                <div class="metadata input-group" style="margin-bottom: 2px">
+                            <span style="font-size: inherit; display: block; text-align: justify; white-space: normal; padding: 1px  0px 1px 10px;"
+                              class="label label-primary">
+                                <?= $metadata->getTitle(); ?>
+                                <a class="modal-opener"
+                                   data-width="50%"
+                                   data-init="init"
+                                   data-callback="submit"
+                                   data-onclose="onclose"
+                                   title="<?= $this->translate('Modifier une métadonnée') ?>"><button
+                                            class="btn btn-xs btn-primary edit-metadata"
+                                            type="button"><span
+                                                class="glyphicon glyphicon-pencil"></span></button></a><button
+                                        onclick="removeMetadata($(this))" data-placement="right"
+                                        style="border-radius:0; height: 20px; padding-top:0; padding-bottom: 0;"
+                                        class="btn btn-xs btn-primary" type="button"><span
+                                            class="glyphicon glyphicon-trash"></span></button>
+                            </span>
+                                    <input type="hidden"
+                                           value="<?= htmlspecialchars(Zend_Json::encode(['id' => $metadata->getId(), 'title' => $metadata->getTitles(), 'content' => $metadata->getContents(), 'file' => $metadata->getFile()]), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                                </div>
+                            <?php endforeach; ?>
+
+                        <?php endif; ?>
+                    </div>
+
+                    <div>
+                        <a class="modal-opener"
+                           title="<?= $this->translate('Ajouter un fichier (Édito, Erratum, Addendum, ...)') ?>"
                            data-init="init"
                            data-callback="submit"
-                           data-onclose="onclose"
-                           title="<?= $this->translate('Modifier une métadonnée') ?>"><button
-                                    class="btn btn-xs btn-primary edit-metadata"
-                                    type="button"><span
-                                        class="glyphicon glyphicon-pencil"></span></button></a><button
-                                onclick="removeMetadata($(this))" data-placement="right"
-                                style="border-radius:0; height: 20px; padding-top:0; padding-bottom: 0;"
-                                class="btn btn-xs btn-primary" type="button"><span
-                                    class="glyphicon glyphicon-trash"></span></button>
-					</span>
-                                <input type="hidden"
-                                       value="<?= htmlspecialchars(Zend_Json::encode(['id' => $metadata->getId(), 'title' => $metadata->getTitles(), 'content' => $metadata->getContents(), 'file' => $metadata->getFile()]), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
-                            </div>
-                        <?php endforeach; ?>
-
-                    <?php endif; ?>
+                           data-width="50%">
+                            <button class="btn btn-default btn-sm" type="button" id="addmetadata" name="addmetadata">
+                                <?= $this->translate('Ajouter un fichier (Édito, Erratum, Addendum, ...)') ?>
+                            </button>
+                        </a>
+                    </div>
                 </div>
 
-                <div>
-                    <a class="modal-opener"
-                       title="<?= $this->translate('Ajouter un fichier (Édito, Erratum, Addendum, ...)') ?>"
-                       data-init="init"
-                       data-callback="submit"
-                       data-width="50%">
-                        <button class="btn btn-default btn-sm" type="button" id="addmetadata" name="addmetadata">
-                            <?= $this->translate('Ajouter un fichier (Édito, Erratum, Addendum, ...)') ?>
-                        </button>
-                    </a>
-                </div>
             </div>
         </div>
-
-
-        <?php if ($this->element->getView()->volume && $this->element->getView()->paperList) : ?>
-            <?php
-            if (!empty($this->element->getView()->gapsInOrderingPapers)) {
-                echo '<div class="alert alert-warning" role="alert">';
-                echo $this->translate('Des vides ont été détectés dans la numérotation des papiers : ');
-                echo '<ul>';
-                foreach ($this->element->getView()->gapsInOrderingPapers as $gapNumber) {
-                    printf('<li><span class="label label-default">%d</span></li>', $gapNumber + 1);
-                }
-                echo '</ul>';
-                echo '</div>';
-            }
-            ?>
-            <div id="papers-element" class="form-group row">
-                <label class="col-md-3 control-label optional"><?= count($this->element->getView()->paperList) . ' ' . $this->translate('articles') ?></label>
-                <div class="col-md-9" style="padding-top: 7px">
-                    <div id="papers">
-                        <?php foreach ($this->element->getView()->paperList as $paperOrder => $paper) : ?>
-                            <?php
-                            $title = $paper['title'];
-                            $paperDocid = $paper['docid'];
-                            $titleStr = $this->escape(Ccsd_Tools::truncate($title, 50));
-                            ?>
-                            <div id="paper-<?= $paper['paperid'] ?>" class="paper input-group">
-                            <span class="label label-status-<?= $paper['status'] ?>" data-toggle="tooltip"
-                                  title="<?= ucfirst($this->translate(Episciences_PapersManager::getStatusLabel($paper['status']))) ?>">
-                           <?= (int)$paperOrder + 1 ?></span>
-                                [<a href="/administratepaper/view?id=<?= $paperDocid ?>"># <?= $paperDocid ?></a>]&nbsp;
-                                <?= $titleStr ?>
-                            </div>
-                        <?php endforeach; ?>
-                    </div>
-                    <input id="paper_positions" name="paper_positions" type="hidden" value=""/>
-                </div>
-            </div>
-        <?php endif; ?>
 
 
         <div class="form-actions text-center">
@@ -140,4 +175,3 @@
     </form>
 
 </div>
-

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -608,6 +608,16 @@ class Episciences_Volume
         return $this->_metadatas;
     }
 
+    public function getCover(): ?Episciences_Volume_Metadata
+    {
+        foreach ($this->_metadatas as $metadata) {
+            if ($metadata->isCover()) {
+                return $metadata;
+            }
+        }
+        return null;
+    }
+
     /**
      * @param $metadatas
      */
@@ -975,6 +985,55 @@ class Episciences_Volume
 
             $this->setMetadata($metadata);
             $newMetadataIds[] = $metadata->getId();
+        }
+
+        // Handle volume cover separately
+        $existingCover = $this->getCover();
+
+        if (!empty($post['cover_data'])) {
+            try {
+                $coverData = json_decode($post['cover_data'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                $errors[] = 'Failed to decode cover_data: ' . $e->getMessage();
+                $coverData = [];
+            }
+            $coverAction = $coverData['action'] ?? '';
+
+            if ($coverAction === 'delete') {
+                // Intentionally excluded from $newMetadataIds → deleteOldMetadata() removes it
+            } elseif ($coverAction === 'save' && !empty($coverData['tmpfile'])) {
+                try {
+                    $tmpfile = json_decode($coverData['tmpfile'], true, 512, JSON_THROW_ON_ERROR);
+                } catch (JsonException $e) {
+                    $errors[] = 'Failed to decode cover tmpfile: ' . $e->getMessage();
+                    $tmpfile = null;
+                }
+
+                if ($tmpfile !== null) {
+                    $langs = array_keys(Episciences_Tools::getLanguages());
+                    $coverTitles = array_fill_keys($langs, Episciences_Volume_Metadata::COVER_TITLE_KEY);
+
+                    $coverMetadata = new Episciences_Volume_Metadata([
+                        'id'       => $existingCover?->getId(),
+                        'vid'      => $this->getVid(),
+                        'title'    => $coverTitles,
+                        'content'  => [],
+                        'file'     => $existingCover?->getFile(),
+                        'tmpfile'  => $tmpfile,
+                        'position' => 0,
+                    ]);
+
+                    if ($coverMetadata->save()) {
+                        $this->setMetadata($coverMetadata);
+                        $newMetadataIds[] = $coverMetadata->getId();
+                    } else {
+                        $errors[] = 'Failed to save cover metadata';
+                    }
+                }
+            }
+        } elseif ($existingCover) {
+            // No cover action posted → preserve existing cover
+            $newMetadataIds[] = $existingCover->getId();
         }
 
         // Clean up old metadata

--- a/library/Episciences/Volume/Metadata.php
+++ b/library/Episciences/Volume/Metadata.php
@@ -3,6 +3,7 @@
 class Episciences_Volume_Metadata
 {
     const TRANSLATION_FILE = 'volumes.php';
+    const COVER_TITLE_KEY = 'tile';
     protected $_db = null;
     private $_id;
     private $_vid;
@@ -204,6 +205,20 @@ class Episciences_Volume_Metadata
     {
         $this->_content = $content;
         return $this;
+    }
+
+    public function isCover(): bool
+    {
+        $titles = $this->getTitles();
+        if (empty($titles)) {
+            return false;
+        }
+        foreach ($titles as $value) {
+            if ($value !== self::COVER_TITLE_KEY) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public function isPDF(): bool

--- a/public/js/volume/form.js
+++ b/public/js/volume/form.js
@@ -9,47 +9,68 @@ $(document).ready(function () {
     $('#metadatas').sortable();
     $('#metadatas').disableSelection();
 
+    // Cache cover selectors — each is referenced in both the change and click handlers
+    var $coverFile = $('#cover-file');
+    var $coverPreview = $('#cover-preview');
+    var $coverPreviewContainer = $('#cover-preview-container');
+    var $coverUploadZone = $('#cover-upload-zone');
+    var $coverData = $('#cover_data');
+
     // Préparation des uploads
     $('#mFile').change(function (event) {
-        // Barre de chargement
         var container = getContainer($(this));
         $(container).html(getLoader());
 
-        // Préparation des données
-        var data = new FormData();
-        $.each(event.target.files, function (key, value) {
-            data.append(key, value);
+        uploadFileToServer(event.target.files[0], function (serverFile) {
+            var $mTmpData = $('#mTmpData');
+            var values = $mTmpData.val() ? JSON.parse($mTmpData.val()) : {};
+            values.tmpfile = JSON.stringify(serverFile);
+            $mTmpData.val(JSON.stringify(values));
+            $('#mFile_content')
+                .empty()
+                .append(
+                    formatFileLabel(
+                        serverFile.name +
+                            ' (' +
+                            readableBytes(serverFile.size, lang) +
+                            ')'
+                    )
+                );
+            $('#value_mFile').val('');
         });
+    });
 
-        // Envoi des données
-        $.ajax({
-            url: '/volume/addfile',
-            type: 'POST',
-            data: data,
-            cache: false,
-            processData: false,
-            contentType: false,
-            success: function (response) {
-                var response = $.parseJSON(response);
-                var file = response.file;
-                var values = $('#mTmpData').val()
-                    ? JSON.parse($('#mTmpData').val())
-                    : new Object();
-                values.tmpfile = JSON.stringify(file);
-                $('#mTmpData').val(JSON.stringify(values));
-                $('#mFile_content')
-                    .empty()
-                    .append(
-                        formatFileLabel(
-                            file.name +
-                                ' (' +
-                                readableBytes(file.size, lang) +
-                                ')'
-                        )
-                    );
-                $('#value_mFile').val('');
-            },
+    // Cover upload and preview
+    $coverFile.on('change', function (event) {
+        var file = event.target.files[0];
+        if (!file) {
+            return;
+        }
+
+        var reader = new FileReader();
+        reader.onload = function (e) {
+            $coverPreview.attr('src', e.target.result);
+        };
+        reader.readAsDataURL(file);
+        $coverPreviewContainer.show();
+        $coverUploadZone.hide();
+
+        uploadFileToServer(file, function (serverFile) {
+            $coverData.val(
+                JSON.stringify({
+                    action: 'save',
+                    tmpfile: JSON.stringify(serverFile),
+                })
+            );
         });
+    });
+
+    $('#remove-cover').on('click', function () {
+        $coverData.val(JSON.stringify({ action: 'delete' }));
+        $coverPreviewContainer.hide();
+        $coverPreview.attr('src', '');
+        $coverUploadZone.show();
+        $coverFile.val('');
     });
 
     // Gestion des positions des articles au sein d'un volume
@@ -63,6 +84,22 @@ $(document).ready(function () {
         $('#papers').disableSelection();
     }
 });
+
+function uploadFileToServer(file, callback) {
+    var data = new FormData();
+    data.append('0', file);
+    $.ajax({
+        url: '/volume/addfile',
+        type: 'POST',
+        data: data,
+        cache: false,
+        processData: false,
+        contentType: false,
+        success: function (response) {
+            callback(JSON.parse(response).file);
+        },
+    });
+}
 
 function getContainer(element) {
     var container_id = 'mFile_content';
@@ -102,25 +139,27 @@ function formatFileLabel(label) {
 }
 
 function removeFile() {
-    var values = JSON.parse($('#mTmpData').val());
-    var deletelist = values.deletelist ? values.deletelist : new Array();
+    var $mTmpData = $('#mTmpData');
+    var $mFileContent = $('#mFile_content');
+    var values = JSON.parse($mTmpData.val());
+    var deletelist = values.deletelist || [];
 
     if (values.tmpfile) {
         var tmp_file = JSON.parse(values.tmpfile);
         deletelist.push({ type: 'tmp_file', path: tmp_file.tmp_name });
         values.deletelist = deletelist;
         values.tmpfile = '';
-        $('#mFile_content').html('');
+        $mFileContent.empty();
         if (values.file) {
-            $('#mFile_content').empty().append(formatFileLabel(values.file));
+            $mFileContent.append(formatFileLabel(values.file));
         }
-        $('#mTmpData').val(JSON.stringify(values));
+        $mTmpData.val(JSON.stringify(values));
     } else {
         deletelist.push({ type: 'current_file', name: values.file });
         values.deletelist = deletelist;
         values.file = '';
-        $('#mTmpData').val(JSON.stringify(values));
-        $('#mFile_content').html('');
+        $mTmpData.val(JSON.stringify(values));
+        $mFileContent.empty();
     }
 }
 
@@ -226,8 +265,8 @@ function submit(source) {
 }
 
 function getInput(id, mce) {
-    var langs = new Array();
-    var value = new Object();
+    var langs = [];
+    var value = {};
 
     if (mce) {
         $('#' + id)
@@ -268,8 +307,9 @@ function getInput(id, mce) {
 }
 
 function getMetadata() {
-    var tmpData = $('#mTmpData').val() ? $.parseJSON($('#mTmpData').val()) : {};
-    var value = new Object();
+    var mTmpDataVal = $('#mTmpData').val();
+    var tmpData = mTmpDataVal ? JSON.parse(mTmpDataVal) : {};
+    var value = {};
     value.id = tmpData.id;
     value.title = getInput('mTitle');
     value.content = getInput('mContent', true);
@@ -365,7 +405,7 @@ function removeMetadata(btn) {
 }
 
 function validate() {
-    var errors = new Array();
+    var errors = [];
 
     if (!validMultilangInput('mTitle')) {
         errors.push(translate('Le champ Nom est obligatoire'));
@@ -417,7 +457,7 @@ function validate() {
 // Contrôle si toutes les langues d'un champ multilangue ont été remplies
 function validMultilangInput(id, mce) {
     var errors = false;
-    var langs = new Array();
+    var langs = [];
 
     if (mce) {
         $('#' + id)


### PR DESCRIPTION
## Summary

- Replaces the undocumented `tile` metadata naming convention with an explicit **Cover** section in the volume edit form
- After upload, a 160×226 px preview is shown immediately (via `FileReader`) alongside **Remove** and **Replace** buttons
- Fully retrocompatible: existing `VOLUME_METADATA` rows with `titles = {"en":"tile","fr":"tile"}` are automatically recognised and displayed in the new section — no DB migration needed
- The `tile` metadata is excluded from the generic file list (Foreword, Erratum, Addendum…) so it no longer appears twice

## Changes

| File | What changed |
|------|-------------|
| `library/Episciences/Volume/Metadata.php` | `COVER_TITLE_KEY = 'tile'` constant + `isCover()` method (all title values must equal `'tile'`) |
| `library/Episciences/Volume.php` | `getCover()` method; `saveVolumeMetadata()` extended to handle `cover_data` POST field (create / replace / delete / preserve) |
| `application/…/volume/form.phtml` | Two-column layout (`col-md-7` form fields + `col-md-5` cover & metadata); cover section with preview, buttons, hidden `cover_data` field; `isCover()` filter on the generic list |
| `public/js/volume/form.js` | `uploadFileToServer()` shared helper extracted (was duplicated); cover DOM selectors cached; `$.parseJSON` → `JSON.parse`; `new Object/Array` → `{}/[]`; variable shadowing and redundant DOM hits fixed |
| `application/languages/en/views.php` | Translations: *Cover*, *Volume cover*, *Add a cover image*, *Remove the cover* |

## Test plan

- [ ] Open `/volume/edit?id={vid}` — **Cover** section appears, empty upload zone shown
- [ ] Upload an image → 160×226 px preview appears immediately; submit → refresh → preview persists
- [ ] Click **Replace** → upload new image → preview updates; submit → refresh → new cover shown
- [ ] Click **Remove the cover** → preview hidden; submit → refresh → section empty, DB row deleted
- [ ] Volume with existing `tile` metadata → appears in **Cover** section, **not** in the generic file list
- [ ] Foreword / Erratum / Addendum metadata → unaffected, still editable via the generic list