### PR TITLE
fix(user): normalize affiliations to {label, rorId} on account creation

### DIFF
--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -572,7 +572,10 @@ class UserDefaultController extends Zend_Controller_Action
         // create an account (CAS + Episciences)
         if ($request->getPost('submit') && $form->isValid($request->getPost())) {
 
-            $user = new Episciences_User($form->getValues());
+            $formValues = $form->getValues();
+            $formValues['AFFILIATIONS'] = $this->processAffiliations($formValues['AFFILIATIONS'] ?? []);
+
+            $user = new Episciences_User($formValues);
             $user->setTime_registered();
             $user->setRegistrationDate(); // Episciences registration
             $user->setScreenName();

--- a/scripts/NormalizeUserAffiliationsCommand.php
+++ b/scripts/NormalizeUserAffiliationsCommand.php
@@ -1,0 +1,263 @@
+<?php
+declare(strict_types=1);
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: normalize legacy `affiliations` entries stored as raw
+ * "Label #rorId" strings (bug in UserDefaultController::createAction(), fixed by
+ * routing new-account affiliations through the same disassemble step used on profile edits)
+ * back into the canonical `{"label": ..., "rorId": ...}` object shape used everywhere else.
+ */
+class NormalizeUserAffiliationsCommand extends Command
+{
+    protected static $defaultName = 'users:normalize-affiliations';
+
+    public const DEFAULT_BUFFER = 500;
+
+    private const SEPARATOR = '#';
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Normalize legacy string-based USER.affiliations entries into {label, rorId} objects.')
+            ->addOption('uid', null, InputOption::VALUE_REQUIRED, 'Process only this UID.')
+            ->addOption('buffer', null, InputOption::VALUE_REQUIRED, 'Number of users to process per page.', self::DEFAULT_BUFFER)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change without writing to the database.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Normalizing USER.affiliations to {label, rorId} objects');
+
+        $isDryRun = (bool) $input->getOption('dry-run');
+        $uid      = $input->getOption('uid');
+        $buffer   = $this->validateBuffer($input->getOption('buffer'));
+
+        $this->bootstrap();
+
+        $db = \Zend_Db_Table_Abstract::getDefaultAdapter();
+
+        if ($db === null) {
+            $io->error('Database adapter not initialized.');
+            return Command::FAILURE;
+        }
+
+        $countQuery = $db->select()->from(T_USERS, [new \Zend_Db_Expr('COUNT(*)')])
+            ->where('ADDITIONAL_PROFILE_INFORMATION LIKE ?', '%affiliations%');
+        $dataQuery = $db->select()->from(T_USERS, ['UID', 'ADDITIONAL_PROFILE_INFORMATION'])
+            ->where('ADDITIONAL_PROFILE_INFORMATION LIKE ?', '%affiliations%')
+            ->order('UID ASC');
+
+        if ($uid !== null) {
+            $countQuery->where('UID = ?', (int) $uid);
+            $dataQuery->where('UID = ?', (int) $uid);
+        }
+
+        $count = (int) $db->fetchOne($countQuery);
+
+        if ($count === 0) {
+            $io->success('No user affiliations to inspect.');
+            return Command::SUCCESS;
+        }
+
+        $paginator = \Zend_Paginator::factory($dataQuery);
+        $paginator->setItemCountPerPage($buffer);
+        $totalPages = $paginator->count();
+
+        $inspected = 0;
+        $fixed     = 0;
+        $failures  = 0;
+
+        $io->progressStart($count);
+
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $paginator->setCurrentPageNumber($page);
+
+            $updates = [];
+
+            foreach ($paginator->getCurrentItems() as $row) {
+                $inspected++;
+                $io->progressAdvance();
+
+                try {
+                    $normalizedJson = $this->normalizeAffiliationsJson((string) $row['ADDITIONAL_PROFILE_INFORMATION']);
+                } catch (\JsonException $e) {
+                    $io->writeln('');
+                    $io->warning(sprintf('[UID %d] Invalid JSON, skipped: %s', (int) $row['UID'], $e->getMessage()));
+                    $failures++;
+                    continue;
+                }
+
+                if ($normalizedJson === null) {
+                    continue;
+                }
+
+                $fixed++;
+                $updates[(int) $row['UID']] = $normalizedJson;
+            }
+
+            if (empty($updates)) {
+                continue;
+            }
+
+            if ($isDryRun) {
+                continue;
+            }
+
+            try {
+                $db->beginTransaction();
+
+                foreach ($updates as $rowUid => $json) {
+                    $db->update(T_USERS, ['ADDITIONAL_PROFILE_INFORMATION' => $json], ['UID = ?' => $rowUid]);
+                }
+
+                $db->commit();
+            } catch (\Exception $e) {
+                $db->rollBack();
+                $io->writeln('');
+                $io->error(sprintf('Page %d: transaction failed: %s', $page, $e->getMessage()));
+                $failures += count($updates);
+                $fixed -= count($updates);
+            }
+        }
+
+        $io->progressFinish();
+
+        $summary = sprintf(
+            'Inspected: %d | Normalized: %d | Failures: %d%s',
+            $inspected,
+            $fixed,
+            $failures,
+            $isDryRun ? ' (dry-run, nothing written)' : ''
+        );
+
+        if ($failures > 0) {
+            $io->warning($summary);
+            return Command::FAILURE;
+        }
+
+        $io->success($summary);
+        return Command::SUCCESS;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public pure helpers — testable without bootstrap or DB
+    // -------------------------------------------------------------------------
+
+    /**
+     * Normalize the `affiliations` entry of a USER.ADDITIONAL_PROFILE_INFORMATION JSON blob.
+     * Returns the re-encoded JSON when a change was needed, or null when the row is
+     * already in the canonical {label, rorId} shape (or has no affiliations at all).
+     *
+     * @throws \JsonException
+     */
+    public function normalizeAffiliationsJson(string $json): ?string
+    {
+        if (trim($json) === '') {
+            return null;
+        }
+
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data) || empty($data['affiliations']) || !is_array($data['affiliations'])) {
+            return null;
+        }
+
+        $needsNormalization = false;
+
+        foreach ($data['affiliations'] as $affiliation) {
+            if (!is_array($affiliation) || !isset($affiliation['label'], $affiliation['rorId'])) {
+                $needsNormalization = true;
+                break;
+            }
+        }
+
+        if (!$needsNormalization) {
+            return null;
+        }
+
+        $data['affiliations'] = array_map([$this, 'disassembleAffiliationEntry'], $data['affiliations']);
+
+        return json_encode($data, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Mirrors UserDefaultController::disassembleAffiliation(): turns a raw "Label #rorId"
+     * string into a {label, rorId} array; leaves an already-correct array untouched.
+     *
+     * @return array{label: string, rorId: string}
+     */
+    public function disassembleAffiliationEntry(mixed $value): array
+    {
+        if (is_array($value) && isset($value['label'], $value['rorId'])) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            [$label, $rorId] = array_pad(explode(self::SEPARATOR, $value), 2, '');
+            $label = trim($label);
+            $rorId = trim($rorId);
+
+            if (!\Episciences_Tools::isRorIdentifier($rorId)) {
+                $rorId = '';
+            }
+
+            return ['label' => $label, 'rorId' => $rorId];
+        }
+
+        return ['label' => '', 'rorId' => ''];
+    }
+
+    /**
+     * Normalise the --buffer option value.
+     * Returns DEFAULT_BUFFER when the value is missing, zero, negative, or non-integer.
+     */
+    public function validateBuffer(mixed $value): int
+    {
+        $int = filter_var($value, FILTER_VALIDATE_INT);
+
+        if ($int === false || $int <= 0) {
+            return self::DEFAULT_BUFFER;
+        }
+
+        return $int;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private function bootstrap(): void
+    {
+        if (!defined('APPLICATION_PATH')) {
+            define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
+        }
+
+        require_once __DIR__ . '/../public/const.php';
+        require_once __DIR__ . '/../public/bdd_const.php';
+
+        defineProtocol();
+        defineSimpleConstants();
+        defineSQLTableConstants();
+        defineApplicationConstants();
+        defineJournalConstants();
+
+        $libraries = [realpath(APPLICATION_PATH . '/../library')];
+        set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
+        require_once 'Zend/Application.php';
+
+        $application = new \Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
+
+        $autoloader = \Zend_Loader_Autoloader::getInstance();
+        $autoloader->setFallbackAutoloader(true);
+
+        $db = \Zend_Db::factory('PDO_MYSQL', $application->getOption('resources')['db']['params']);
+        \Zend_Db_Table::setDefaultAdapter($db);
+    }
+}

--- a/scripts/console.php
+++ b/scripts/console.php
@@ -29,6 +29,7 @@ require_once __DIR__ . '/GenerateDownloadKpiCommand.php';
 require_once __DIR__ . '/UpdatePapersDocumentCommand.php';
 require_once __DIR__ . '/UpdateTranslationsCommand.php';
 require_once __DIR__ . '/GetDoiCommand.php';
+require_once __DIR__ . '/NormalizeUserAffiliationsCommand.php';
 
 use Symfony\Component\Console\Application;
 
@@ -76,6 +77,9 @@ $application->add(new GenerateDownloadKpiCommand());
 
 // DOI commands
 $application->add(new GetDoiCommand());
+
+// User commands
+$application->add(new NormalizeUserAffiliationsCommand());
 
 // GeoIP commands
 $application->add(new UpdateGeoIpCommand());

--- a/tests/unit/modules/common/controllers/UserDefaultControllerAffiliationsTest.php
+++ b/tests/unit/modules/common/controllers/UserDefaultControllerAffiliationsTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unit\modules\common\controllers;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Behavioural tests for UserDefaultController's affiliation (de)serialization helpers:
+ * processAffiliations(), disassembleAffiliation(), assembleAffiliation().
+ *
+ * These are pure methods (no $this state, no DB, no MVC stack), so we instantiate
+ * UserDefaultController without its constructor and invoke the private methods by
+ * reflection — same approach as DefaultControllerResolveSafePathTest.
+ *
+ * Canonical storage shape is `{"label": ..., "rorId": ...}` (produced by 'disassemble',
+ * the default, and used everywhere data is persisted). The flat "Label #rorId" string
+ * shape only exists transiently: as the raw value typed/selected in the affiliations
+ * autocomplete widget (public/js/user/affiliations.js) before submission, and as the
+ * 'assemble' output used solely to prefill the edit-profile form. If these methods ever
+ * regress, either shape could leak into ADDITIONAL_PROFILE_INFORMATION and break any
+ * consumer expecting a single, consistent format (see UserDefaultController::createAction()
+ * bug fixed alongside this test).
+ *
+ * @covers UserDefaultController::processAffiliations
+ * @covers UserDefaultController::disassembleAffiliation
+ * @covers UserDefaultController::assembleAffiliation
+ */
+final class UserDefaultControllerAffiliationsTest extends TestCase
+{
+    private object $controller;
+    private string $source;
+
+    protected function setUp(): void
+    {
+        require_once APPLICATION_PATH . '/modules/common/controllers/UserDefaultController.php';
+
+        $class = new ReflectionClass(\UserDefaultController::class);
+        $this->controller = $class->newInstanceWithoutConstructor();
+
+        $this->source = (string) file_get_contents(
+            APPLICATION_PATH . '/modules/common/controllers/UserDefaultController.php'
+        );
+    }
+
+    /**
+     * Same extraction approach as UserDefaultControllerRequestGuardTest: ZF1 module
+     * controllers can't be dispatched outside the full request stack, so action bodies
+     * are asserted on via source inspection.
+     */
+    private function extractMethod(string $methodName): string
+    {
+        $start = strpos($this->source, 'function ' . $methodName . '(');
+        self::assertNotFalse($start, "Method $methodName not found in UserDefaultController");
+
+        $end = strpos($this->source, "\n    public function ", (int) $start + 1);
+        $end2 = strpos($this->source, "\n    private function ", (int) $start + 1);
+        $end3 = strpos($this->source, "\n    protected function ", (int) $start + 1);
+        $candidates = array_filter([$end, $end2, $end3], static fn($v) => $v !== false);
+        $stop = $candidates ? min($candidates) : strlen($this->source);
+
+        return substr($this->source, (int) $start, $stop - (int) $start);
+    }
+
+    /**
+     * @param array<int, mixed> $args
+     */
+    private function invokePrivate(string $method, array $args): mixed
+    {
+        $reflection = new ReflectionMethod(\UserDefaultController::class, $method);
+        $reflection->setAccessible(true);
+
+        return $reflection->invokeArgs($this->controller, $args);
+    }
+
+    /**
+     * $operationType is left out of the reflection call entirely (rather than passed
+     * as null) when omitted here, so the method's own default value ('disassemble')
+     * is exercised — matching how UserDefaultController's call sites invoke it.
+     */
+    private function processAffiliations(mixed $input, ?string $operationType = null): mixed
+    {
+        $args = $operationType === null ? [$input] : [$input, $operationType];
+
+        return $this->invokePrivate('processAffiliations', $args);
+    }
+
+    private function disassembleAffiliation(mixed $value, string $separator = '#'): mixed
+    {
+        return $this->invokePrivate('disassembleAffiliation', [$value, $separator]);
+    }
+
+    private function assembleAffiliation(mixed $value, string $separator = '#'): mixed
+    {
+        return $this->invokePrivate('assembleAffiliation', [$value, $separator]);
+    }
+
+    // -----------------------------------------------------------------------
+    // disassembleAffiliation() — string ("Label #rorId") -> {label, rorId}
+    // -----------------------------------------------------------------------
+
+    public function testDisassembleStringWithValidRorId(): void
+    {
+        $result = $this->disassembleAffiliation('Donders Centre for Cognitive Neuroimaging [DCCN] #https://ror.org/01jdz5g73');
+
+        self::assertSame([
+            'label' => 'Donders Centre for Cognitive Neuroimaging [DCCN]',
+            'rorId' => 'https://ror.org/01jdz5g73',
+        ], $result);
+    }
+
+    public function testDisassembleStringWithoutRorId(): void
+    {
+        self::assertSame(['label' => 'Just A Label', 'rorId' => ''], $this->disassembleAffiliation('Just A Label'));
+    }
+
+    public function testDisassembleStringWithInvalidRorIdIsDropped(): void
+    {
+        $result = $this->disassembleAffiliation('Some Lab #not-a-ror-id');
+
+        self::assertSame('Some Lab', $result['label']);
+        self::assertSame('', $result['rorId']);
+    }
+
+    public function testDisassembleAlreadyCorrectArrayIsReturnedAsIs(): void
+    {
+        $value = ['label' => 'Already Correct', 'rorId' => 'https://ror.org/01jdz5g73'];
+
+        self::assertSame($value, $this->disassembleAffiliation($value));
+    }
+
+    public function testDisassembleNonStringNonArrayFallsBackToEmpty(): void
+    {
+        self::assertSame(['label' => '', 'rorId' => ''], $this->disassembleAffiliation(42));
+    }
+
+    // -----------------------------------------------------------------------
+    // assembleAffiliation() — {label, rorId} -> "Label #rorId" (form display only)
+    // -----------------------------------------------------------------------
+
+    public function testAssembleWithRorId(): void
+    {
+        $result = $this->assembleAffiliation(['label' => 'Some Lab', 'rorId' => 'https://ror.org/01jdz5g73']);
+
+        self::assertSame('Some Lab#https://ror.org/01jdz5g73', $result);
+    }
+
+    public function testAssembleWithoutRorIdReturnsLabelOnly(): void
+    {
+        self::assertSame('Some Lab', $this->assembleAffiliation(['label' => 'Some Lab', 'rorId' => '']));
+    }
+
+    public function testAssembleStringPassthrough(): void
+    {
+        self::assertSame('Raw String', $this->assembleAffiliation('Raw String'));
+    }
+
+    // -----------------------------------------------------------------------
+    // processAffiliations() — batch behaviour, default operation, count-independence
+    // -----------------------------------------------------------------------
+
+    public function testProcessAffiliationsDefaultsToDisassemble(): void
+    {
+        // Regression guard: the default must stay 'disassemble' so that
+        // createAction()/editAction() persist objects, not raw strings, when the
+        // operation type is omitted at a call site.
+        $result = $this->processAffiliations(['Some Lab #https://ror.org/01jdz5g73'], null);
+
+        self::assertSame([
+            ['label' => 'Some Lab', 'rorId' => 'https://ror.org/01jdz5g73'],
+        ], $result);
+    }
+
+    public function testProcessAffiliationsSingleEntry(): void
+    {
+        $result = $this->processAffiliations(['Donders Centre [DCCN] #https://ror.org/01jdz5g73']);
+
+        self::assertSame([
+            ['label' => 'Donders Centre [DCCN]', 'rorId' => 'https://ror.org/01jdz5g73'],
+        ], $result);
+    }
+
+    public function testProcessAffiliationsMultipleEntriesAllDisassembled(): void
+    {
+        // Regression guard: with several affiliations, every entry must go through
+        // disassembleAffiliation() individually — none may be left as a raw string.
+        $result = $this->processAffiliations([
+            'Donders Centre for Cognitive Neuroimaging [DCCN] #https://ror.org/01jdz5g73',
+            'Radboud University Nijmegen  #https://ror.org/016xsfp80',
+        ]);
+
+        // assertSame already proves every entry was disassembled into a {label, rorId}
+        // array — none left as a raw "Label #rorId" string — for both positions.
+        self::assertSame([
+            ['label' => 'Donders Centre for Cognitive Neuroimaging [DCCN]', 'rorId' => 'https://ror.org/01jdz5g73'],
+            ['label' => 'Radboud University Nijmegen', 'rorId' => 'https://ror.org/016xsfp80'],
+        ], $result);
+    }
+
+    public function testProcessAffiliationsWrapsScalarInputIntoArray(): void
+    {
+        $result = $this->processAffiliations('Single Lab #https://ror.org/01jdz5g73');
+
+        self::assertSame([
+            ['label' => 'Single Lab', 'rorId' => 'https://ror.org/01jdz5g73'],
+        ], $result);
+    }
+
+    public function testProcessAffiliationsEmptyInputReturnsEmptyArray(): void
+    {
+        self::assertSame([], $this->processAffiliations([]));
+        self::assertSame([], $this->processAffiliations(null));
+    }
+
+    public function testProcessAffiliationsSkipsEmptyEntries(): void
+    {
+        $result = $this->processAffiliations(['', 'Some Lab #https://ror.org/01jdz5g73', '']);
+
+        self::assertCount(1, $result);
+    }
+
+    public function testProcessAffiliationsAssembleRoundTrip(): void
+    {
+        $objects = [
+            ['label' => 'Lab A', 'rorId' => 'https://ror.org/01jdz5g73'],
+            ['label' => 'Lab B', 'rorId' => ''],
+        ];
+
+        $assembled = $this->processAffiliations($objects, 'assemble');
+
+        self::assertSame([
+            'Lab A#https://ror.org/01jdz5g73',
+            'Lab B',
+        ], $assembled);
+
+        // Round-tripping back through disassemble must restore the original objects.
+        $roundTripped = $this->processAffiliations($assembled, 'disassemble');
+        self::assertSame($objects, $roundTripped);
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression guards — createAction()/editAction() must normalize AFFILIATIONS
+    // before persisting a user, or raw "Label #rorId" strings leak into
+    // ADDITIONAL_PROFILE_INFORMATION (the account-creation bug this suite guards).
+    // -----------------------------------------------------------------------
+
+    public function testCreateActionNormalizesAffiliationsBeforeConstructingUser(): void
+    {
+        $method = $this->extractMethod('createAction');
+
+        self::assertStringContainsString(
+            "\$this->processAffiliations(\$formValues['AFFILIATIONS']",
+            $method,
+            'createAction must run AFFILIATIONS through processAffiliations() before building the user, '
+            . 'otherwise raw form strings ("Label #rorId") get persisted instead of {label, rorId} objects'
+        );
+
+        $processPos = strpos($method, 'processAffiliations(');
+        // createAction() also builds a plain `new Episciences_User()` earlier, for the
+        // "create from an existing CAS account" branch — target the specific
+        // construction from the submitted form values instead.
+        $constructPos = strpos($method, 'new Episciences_User($formValues)');
+
+        self::assertNotFalse($processPos);
+        self::assertNotFalse($constructPos);
+        self::assertLessThan(
+            $constructPos,
+            $processPos,
+            'AFFILIATIONS must be normalized before the Episciences_User is constructed from the form values'
+        );
+    }
+
+    public function testCreateActionDoesNotDefaultToAssembleOperation(): void
+    {
+        // Passing 'assemble' here would persist flat strings again — the bug this
+        // suite guards against. Only the display pre-fill (editAction, GET path)
+        // may use 'assemble'.
+        $method = $this->extractMethod('createAction');
+
+        self::assertDoesNotMatchRegularExpression(
+            "/processAffiliations\\([^)]*'assemble'/",
+            $method,
+            "createAction must not call processAffiliations() with 'assemble' — that would persist raw strings"
+        );
+    }
+
+    public function testEditActionDisassemblesAffiliationsBeforePersisting(): void
+    {
+        $method = $this->extractMethod('editAction');
+
+        self::assertMatchesRegularExpression(
+            "/STR_AFFILIATIONS\\s*=>\\s*\\\$this->processAffiliations\\(/",
+            $method,
+            'editAction must run submitted AFFILIATIONS through processAffiliations() (disassemble) '
+            . 'before encoding ADDITIONAL_PROFILE_INFORMATION'
+        );
+    }
+}

--- a/tests/unit/scripts/NormalizeUserAffiliationsCommandTest.php
+++ b/tests/unit/scripts/NormalizeUserAffiliationsCommandTest.php
@@ -1,0 +1,280 @@
+<?php
+declare(strict_types=1);
+
+namespace unit\scripts;
+
+use JsonException;
+use NormalizeUserAffiliationsCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+
+require_once __DIR__ . '/../../../scripts/NormalizeUserAffiliationsCommand.php';
+
+/**
+ * Unit tests for NormalizeUserAffiliationsCommand.
+ *
+ * These tests guard the one-off migration that repairs USER.affiliations rows
+ * saved as raw "Label #rorId" strings by the account-creation bug (see
+ * UserDefaultController::createAction()) instead of {label, rorId} objects.
+ * All tests are pure: no bootstrap-time side effects, no database, no I/O.
+ */
+class NormalizeUserAffiliationsCommandTest extends TestCase
+{
+    private NormalizeUserAffiliationsCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new NormalizeUserAffiliationsCommand();
+    }
+
+    // -------------------------------------------------------------------------
+    // Command metadata
+    // -------------------------------------------------------------------------
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('users:normalize-affiliations', $this->command->getName());
+    }
+
+    public function testCommandHasUidOption(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertInstanceOf(InputDefinition::class, $definition);
+        $this->assertTrue($definition->hasOption('uid'));
+        $this->assertTrue($definition->getOption('uid')->isValueRequired(), '--uid must require a value');
+    }
+
+    public function testCommandHasBufferOption(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertTrue($definition->hasOption('buffer'));
+        $this->assertTrue($definition->getOption('buffer')->isValueRequired(), '--buffer must require a value');
+    }
+
+    public function testCommandHasDryRunFlag(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertTrue($definition->hasOption('dry-run'));
+        $this->assertFalse($definition->getOption('dry-run')->acceptValue(), '--dry-run must be a flag');
+    }
+
+    public function testBufferOptionDefaultIs500(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertSame(
+            NormalizeUserAffiliationsCommand::DEFAULT_BUFFER,
+            $definition->getOption('buffer')->getDefault()
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // validateBuffer()
+    // -------------------------------------------------------------------------
+
+    public function testValidateBuffer_positiveValue_returnedAsIs(): void
+    {
+        $this->assertSame(100, $this->command->validateBuffer(100));
+    }
+
+    public function testValidateBuffer_zero_returnsDefault(): void
+    {
+        $this->assertSame(NormalizeUserAffiliationsCommand::DEFAULT_BUFFER, $this->command->validateBuffer(0));
+    }
+
+    public function testValidateBuffer_negative_returnsDefault(): void
+    {
+        $this->assertSame(NormalizeUserAffiliationsCommand::DEFAULT_BUFFER, $this->command->validateBuffer(-1));
+    }
+
+    public function testValidateBuffer_null_returnsDefault(): void
+    {
+        $this->assertSame(NormalizeUserAffiliationsCommand::DEFAULT_BUFFER, $this->command->validateBuffer(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // disassembleAffiliationEntry()
+    // -------------------------------------------------------------------------
+
+    public function testDisassemble_labelAndValidRorId(): void
+    {
+        $result = $this->command->disassembleAffiliationEntry('Donders Centre for Cognitive Neuroimaging [DCCN] #https://ror.org/01jdz5g73');
+
+        $this->assertSame([
+            'label' => 'Donders Centre for Cognitive Neuroimaging [DCCN]',
+            'rorId' => 'https://ror.org/01jdz5g73',
+        ], $result);
+    }
+
+    public function testDisassemble_trimsWhitespaceAroundSeparator(): void
+    {
+        $result = $this->command->disassembleAffiliationEntry('Radboud University Nijmegen  #https://ror.org/016xsfp80');
+
+        $this->assertSame('Radboud University Nijmegen', $result['label']);
+        $this->assertSame('https://ror.org/016xsfp80', $result['rorId']);
+    }
+
+    public function testDisassemble_invalidRorIdIsDropped(): void
+    {
+        $result = $this->command->disassembleAffiliationEntry('Some Lab #not-a-ror-id');
+
+        $this->assertSame('Some Lab', $result['label']);
+        $this->assertSame('', $result['rorId']);
+    }
+
+    public function testDisassemble_labelWithoutSeparator(): void
+    {
+        $result = $this->command->disassembleAffiliationEntry('Just A Label');
+
+        $this->assertSame(['label' => 'Just A Label', 'rorId' => ''], $result);
+    }
+
+    public function testDisassemble_emptyString(): void
+    {
+        $this->assertSame(['label' => '', 'rorId' => ''], $this->command->disassembleAffiliationEntry(''));
+    }
+
+    public function testDisassemble_alreadyCorrectArrayIsUntouched(): void
+    {
+        $value = ['label' => 'Already Correct', 'rorId' => 'https://ror.org/01jdz5g73'];
+
+        $this->assertSame($value, $this->command->disassembleAffiliationEntry($value));
+    }
+
+    public function testDisassemble_arrayMissingKeysFallsBackToEmpty(): void
+    {
+        $this->assertSame(
+            ['label' => '', 'rorId' => ''],
+            $this->command->disassembleAffiliationEntry(['foo' => 'bar'])
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // normalizeAffiliationsJson()
+    // -------------------------------------------------------------------------
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_singleLegacyStringEntry(): void
+    {
+        $json = '{"affiliations":["IT University of Copenhagen  #https:\/\/ror.org\/02309jg23"]}';
+
+        $result = $this->command->normalizeAffiliationsJson($json);
+
+        $this->assertNotNull($result);
+        $decoded = json_decode((string) $result, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame([
+            ['label' => 'IT University of Copenhagen', 'rorId' => 'https://ror.org/02309jg23'],
+        ], $decoded['affiliations']);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_multipleLegacyStringEntries(): void
+    {
+        $json = '{"affiliations":["University of Gothenburg  #https:\/\/ror.org\/01tm6cn81","Chalmers University of Technology  #https:\/\/ror.org\/040wg7k59"]}';
+
+        $result = $this->command->normalizeAffiliationsJson($json);
+        $decoded = json_decode((string) $result, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertCount(2, $decoded['affiliations']);
+        $this->assertSame('University of Gothenburg', $decoded['affiliations'][0]['label']);
+        $this->assertSame('Chalmers University of Technology', $decoded['affiliations'][1]['label']);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_preservesOtherProfileKeys(): void
+    {
+        $json = '{"webSites":["https:\/\/example.org\/"],"affiliations":["Some Lab #https:\/\/ror.org\/01jdz5g73"]}';
+
+        $result = $this->command->normalizeAffiliationsJson($json);
+        $decoded = json_decode((string) $result, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(['https://example.org/'], $decoded['webSites']);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_emptyStringEntryBecomesEmptyObject(): void
+    {
+        $json = '{"affiliations":[""]}';
+
+        $result = $this->command->normalizeAffiliationsJson($json);
+        $decoded = json_decode((string) $result, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame([['label' => '', 'rorId' => '']], $decoded['affiliations']);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_alreadyCorrectFormatReturnsNull(): void
+    {
+        $json = '{"affiliations":[{"label":"Donders Centre","rorId":"https:\/\/ror.org\/01jdz5g73"}]}';
+
+        $this->assertNull($this->command->normalizeAffiliationsJson($json));
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_noAffiliationsKeyReturnsNull(): void
+    {
+        $this->assertNull($this->command->normalizeAffiliationsJson('{"webSites":["https:\/\/example.org\/"]}'));
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_emptyAffiliationsArrayReturnsNull(): void
+    {
+        $this->assertNull($this->command->normalizeAffiliationsJson('{"affiliations":[]}'));
+    }
+
+    public function testNormalize_emptyStringInputReturnsNull(): void
+    {
+        $this->assertNull($this->command->normalizeAffiliationsJson(''));
+    }
+
+    public function testNormalize_invalidJsonThrows(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->command->normalizeAffiliationsJson('{not-json');
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function testNormalize_mixedLegacyAndCorrectEntriesNormalizesAll(): void
+    {
+        $json = '{"affiliations":['
+            . '{"label":"Already Correct","rorId":"https:\/\/ror.org\/01jdz5g73"},'
+            . '"Legacy Lab #https:\/\/ror.org\/016xsfp80"'
+            . ']}';
+
+        $result = $this->command->normalizeAffiliationsJson($json);
+        $decoded = json_decode((string) $result, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('Already Correct', $decoded['affiliations'][0]['label']);
+        $this->assertSame('Legacy Lab', $decoded['affiliations'][1]['label']);
+    }
+
+    /**
+     * @throws JsonException
+     * Idempotency: running the migration twice on already-fixed data must be a no-op.
+     */
+    public function testNormalize_isIdempotent(): void
+    {
+        $json = '{"affiliations":["Some Lab #https:\/\/ror.org\/01jdz5g73"]}';
+
+        $firstPass = $this->command->normalizeAffiliationsJson($json);
+        $this->assertNotNull($firstPass);
+
+        $secondPass = $this->command->normalizeAffiliationsJson((string) $firstPass);
+        $this->assertNull($secondPass, 'A second pass over already-normalized data must report no change');
+    }
+}


### PR DESCRIPTION
## Summary
- `UserDefaultController::createAction()` persisted the raw `"Label #rorId"` autocomplete strings straight into `ADDITIONAL_PROFILE_INFORMATION` instead of routing them through `processAffiliations()` like `editAction()` does. Any account whose affiliations were entered at signup (and never re-saved via profile edit) ends up with a different JSON shape (`["Label #rorId", ...]`) than accounts edited afterwards (`[{"label":...,"rorId":...}]`), which breaks external consumers of that data.
- Confirmed against the local DB dump: 1962 / 5168 accounts with affiliations are affected, all with `MODIFICATION_DATE == REGISTRATION_DATE` (never edited since signup).
- Adds `users:normalize-affiliations` (Symfony console command) to backfill the already-affected accounts, with `--uid`, `--buffer`, and `--dry-run` options. Dry-run against the local DB reports 1962 rows to fix, 0 failures.

## Test plan
- [x] `make phpstan LEVEL=6` on the new/changed files → 0 errors (56 pre-existing errors in `UserDefaultController.php` unchanged)
- [x] New tests: `tests/unit/scripts/NormalizeUserAffiliationsCommandTest.php` (27 tests) and `tests/unit/modules/common/controllers/UserDefaultControllerAffiliationsTest.php` (18 tests, including regression guards on `createAction()`)
- [x] Verified the regression guard actually catches the bug: reverting the controller fix locally makes `testCreateActionNormalizesAffiliationsBeforeConstructingUser` fail
- [x] Full suite: `./vendor/bin/phpunit` → 4532 tests, 3 pre-existing unrelated failures (confirmed present before this change too)
- [ ] Run `users:normalize-affiliations` (without `--dry-run`) against staging/production after merge to backfill existing accounts