### PR TITLE
fix(coar-notify): fix malformed Content-Type header sent to HAL inbox

### DIFF
--- a/library/Episciences/Notify/CoarNotifyHttpLayer.php
+++ b/library/Episciences/Notify/CoarNotifyHttpLayer.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Episciences\Notify;
+
+use coarnotify\http\CurlHttpResponse;
+use coarnotify\http\HttpLayer;
+use RuntimeException;
+
+/**
+ * Replaces coarnotify\http\CurlHttpLayer, whose post()/get() pass the associative
+ * $headers array documented by HttpLayer straight to CURLOPT_HTTPHEADER. cURL only
+ * reads the array values, so associative keys (e.g. 'Content-Type') are silently
+ * dropped: the caller-supplied Content-Type never reaches the request, and the
+ * bare value is sent as a malformed header line with no field name. Against a
+ * spec-compliant COAR Notify inbox (e.g. HAL's) this produces a 400 response.
+ */
+class CoarNotifyHttpLayer implements HttpLayer
+{
+    /**
+     * @param array<int|string, string>|null $headers
+     */
+    public function post(string $url, string $data, ?array $headers = [], ...$args): CurlHttpResponse
+    {
+        return $this->request($url, $headers, $data);
+    }
+
+    /**
+     * @param array<int|string, string>|null $headers
+     */
+    public function get(string $url, ?array $headers = [], ...$args): CurlHttpResponse
+    {
+        return $this->request($url, $headers, null);
+    }
+
+    /**
+     * @param array<int|string, string>|null $headers
+     */
+    private function request(string $url, ?array $headers, ?string $data): CurlHttpResponse
+    {
+        $ch = curl_init($url);
+
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HEADER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $this->buildHeaderLines($headers));
+
+        if ($data !== null) {
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        }
+
+        $response = curl_exec($ch);
+
+        if ($response === false || curl_errno($ch)) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            throw new RuntimeException('cURL error: ' . $error);
+        }
+
+        $httpStatusCode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $headerSize = (int)curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $rawHeaders = substr((string)$response, 0, $headerSize);
+
+        curl_close($ch);
+
+        return new CurlHttpResponse($httpStatusCode, $this->parseHeaders($rawHeaders));
+    }
+
+    /**
+     * Turns an associative (or already-flat) headers array into "Name: Value" lines
+     * for CURLOPT_HTTPHEADER, defaulting Content-Type only if the caller didn't set one.
+     *
+     * @param array<int|string, string>|null $headers
+     * @return list<string>
+     */
+    public function buildHeaderLines(?array $headers): array
+    {
+        $lines = [];
+        $hasContentType = false;
+
+        foreach ($headers ?? [] as $name => $value) {
+            if (is_int($name)) {
+                $lines[] = $value;
+                if (str_starts_with(strtolower($value), 'content-type:')) {
+                    $hasContentType = true;
+                }
+                continue;
+            }
+
+            $lines[] = sprintf('%s: %s', $name, $value);
+            if (strcasecmp($name, 'Content-Type') === 0) {
+                $hasContentType = true;
+            }
+        }
+
+        if (!$hasContentType) {
+            $lines[] = 'Content-Type: application/json';
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseHeaders(string $rawHeaders): array
+    {
+        $parsed = [];
+
+        foreach (explode("\r\n", $rawHeaders) as $line) {
+            if (str_contains($line, ':')) {
+                [$key, $value] = explode(': ', $line, 2);
+                $parsed[$key] = $value;
+            }
+        }
+
+        return $parsed;
+    }
+}

--- a/library/Episciences/Notify/CoarNotifyHttpLayer.php
+++ b/library/Episciences/Notify/CoarNotifyHttpLayer.php
@@ -4,24 +4,32 @@ declare(strict_types=1);
 
 namespace Episciences\Notify;
 
-use coarnotify\http\CurlHttpResponse;
 use coarnotify\http\HttpLayer;
+use coarnotify\http\HttpResponse;
 use RuntimeException;
 
 /**
- * Replaces coarnotify\http\CurlHttpLayer, whose post()/get() pass the associative
- * $headers array documented by HttpLayer straight to CURLOPT_HTTPHEADER. cURL only
- * reads the array values, so associative keys (e.g. 'Content-Type') are silently
- * dropped: the caller-supplied Content-Type never reaches the request, and the
- * bare value is sent as a malformed header line with no field name. Against a
- * spec-compliant COAR Notify inbox (e.g. HAL's) this produces a 400 response.
+ * Workaround for an upstream bug in cottagelabs/coarnotify (vendor package, not ours to
+ * edit): coarnotify\http\CurlHttpLayer::post()/get() pass the associative $headers array
+ * documented by HttpLayer straight to CURLOPT_HTTPHEADER. cURL only reads the array
+ * values, so associative keys (e.g. 'Content-Type') are silently dropped: the
+ * caller-supplied Content-Type never reaches the request, and the bare value is sent as a
+ * malformed header line with no field name. Against a spec-compliant COAR Notify inbox
+ * (e.g. HAL's) this produces a 400 response.
+ *
+ * Once upstream fixes CurlHttpLayer to build proper "Name: Value" header lines, this class
+ * can be deleted and callers (Episciences_Notify_Hal) reverted to
+ * `new \coarnotify\http\CurlHttpLayer()`.
+ *
+ * request() also returns CoarNotifyHttpResponse instead of the vendor's own
+ * CurlHttpResponse — see that class's docblock for why (a second, separate upstream bug).
  */
 class CoarNotifyHttpLayer implements HttpLayer
 {
     /**
      * @param array<int|string, string>|null $headers
      */
-    public function post(string $url, string $data, ?array $headers = [], ...$args): CurlHttpResponse
+    public function post(string $url, string $data, ?array $headers = [], ...$args): HttpResponse
     {
         return $this->request($url, $headers, $data);
     }
@@ -29,7 +37,7 @@ class CoarNotifyHttpLayer implements HttpLayer
     /**
      * @param array<int|string, string>|null $headers
      */
-    public function get(string $url, ?array $headers = [], ...$args): CurlHttpResponse
+    public function get(string $url, ?array $headers = [], ...$args): HttpResponse
     {
         return $this->request($url, $headers, null);
     }
@@ -37,7 +45,7 @@ class CoarNotifyHttpLayer implements HttpLayer
     /**
      * @param array<int|string, string>|null $headers
      */
-    private function request(string $url, ?array $headers, ?string $data): CurlHttpResponse
+    private function request(string $url, ?array $headers, ?string $data): HttpResponse
     {
         $ch = curl_init($url);
 
@@ -64,7 +72,7 @@ class CoarNotifyHttpLayer implements HttpLayer
 
         curl_close($ch);
 
-        return new CurlHttpResponse($httpStatusCode, $this->parseHeaders($rawHeaders));
+        return new CoarNotifyHttpResponse($httpStatusCode, $this->parseHeaders($rawHeaders));
     }
 
     /**
@@ -111,10 +119,22 @@ class CoarNotifyHttpLayer implements HttpLayer
         foreach (explode("\r\n", $rawHeaders) as $line) {
             if (str_contains($line, ':')) {
                 [$key, $value] = explode(': ', $line, 2);
-                $parsed[$key] = $value;
+                $parsed[$this->canonicalHeaderName($key)] = $value;
             }
         }
 
         return $parsed;
+    }
+
+    /**
+     * Normalizes a header name to Http-Header-Case (e.g. "location" or "LOCATION" -> "Location").
+     * HTTP/2 responses (as HAL's inbox may send) are lower-cased by cURL, but
+     * coarnotify\client\COARNotifyClient::send() looks up the response header by the
+     * exact string "Location". Normalizing here avoids a lookup miss when the
+     * server actually did send the header, just under a different case.
+     */
+    private function canonicalHeaderName(string $name): string
+    {
+        return str_replace(' ', '-', ucwords(strtolower(trim($name)), '-'));
     }
 }

--- a/library/Episciences/Notify/CoarNotifyHttpResponse.php
+++ b/library/Episciences/Notify/CoarNotifyHttpResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Episciences\Notify;
+
+use coarnotify\http\HttpResponse;
+
+/**
+ * Workaround for an upstream bug in cottagelabs/coarnotify (vendor package, not ours to
+ * edit): coarnotify\http\CurlHttpResponse::getHeader() (vendor/cottagelabs/coarnotify/src/
+ * http/CurlHttpResponse.php:29) does a raw `$this->headers[$headerName]` array access with
+ * no isset()/null-coalescing guard. coarnotify\client\COARNotifyClient::send() calls
+ * getHeader("Location") on every 201 response, so any inbox that omits that header (which
+ * is valid HTTP — the 201 body can carry the identifier instead) triggers an "Undefined
+ * array key" PHP warning there.
+ *
+ * This class is a drop-in HttpResponse implementation that guards the same lookup with
+ * `?? null`. Once upstream fixes CurlHttpResponse::getHeader() (or we no longer need to
+ * work around it), this class can be deleted and CoarNotifyHttpLayer::request() reverted
+ * to `new \coarnotify\http\CurlHttpResponse($httpStatusCode, $headers)`.
+ */
+class CoarNotifyHttpResponse implements HttpResponse
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function __construct(private readonly int $statusCode, private readonly array $headers)
+    {
+    }
+
+    public function getHeader(string $headerName): ?string
+    {
+        return $this->headers[$headerName] ?? null;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/library/Episciences/Notify/Hal.php
+++ b/library/Episciences/Notify/Hal.php
@@ -11,6 +11,7 @@ use coarnotify\patterns\announce_endorsement\AnnounceEndorsementItem;
 use coarnotify\core\notify\NotifyActor;
 use coarnotify\core\notify\NotifyObject;
 use coarnotify\core\notify\NotifyService;
+use Episciences\Notify\CoarNotifyHttpLayer;
 use Episciences\Notify\Notification;
 use Episciences\Notify\NotificationsRepository;
 use Monolog\Formatter\LineFormatter;
@@ -186,7 +187,7 @@ class Episciences_Notify_Hal
         // Send via COAR Notify client
         $status = Notification::STATUS_PENDING;
         try {
-            $client = $this->client ?? new COARNotifyClient(NOTIFY_TARGET_HAL_INBOX);
+            $client = $this->client ?? new COARNotifyClient(NOTIFY_TARGET_HAL_INBOX, new CoarNotifyHttpLayer());
             $response = $client->send($announcement);
             $status = ($response->getAction() === NotifyResponse::CREATED) ? 201 : 202;
         } catch (NotifyException $e) {

--- a/scripts/UpdatePapersDocumentCommand.php
+++ b/scripts/UpdatePapersDocumentCommand.php
@@ -442,5 +442,15 @@ class UpdatePapersDocumentCommand extends Command
 
         \Zend_Registry::set('metadataSources', \Episciences_Paper_MetaDataSourcesManager::all(false));
         \Zend_Registry::set('Zend_Locale', new \Zend_Locale('en'));
+
+        // Episciences_Translation_Plugin::preDispatch() normally registers this, but it
+        // never runs here since we skip $application->bootstrap() (see comment above).
+        // Without it, Paper::getStatusLabel() logs a "No entry is registered" notice.
+        \Zend_Registry::set('Zend_Translate', new \Zend_Translate([
+            'adapter' => \Zend_Translate::AN_ARRAY,
+            'content' => PATH_TRANSLATION,
+            'scan' => \Zend_Translate::LOCALE_DIRECTORY,
+            'disableNotices' => true,
+        ]));
     }
 }

--- a/tests/unit/library/Episciences/notify/CoarNotifyHttpLayerTest.php
+++ b/tests/unit/library/Episciences/notify/CoarNotifyHttpLayerTest.php
@@ -4,6 +4,7 @@ namespace unit\library\Episciences\notify;
 
 use Episciences\Notify\CoarNotifyHttpLayer;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 
 class CoarNotifyHttpLayerTest extends TestCase
 {
@@ -59,5 +60,20 @@ class CoarNotifyHttpLayerTest extends TestCase
 
         self::assertContains('Authorization: Bearer token', $lines);
         self::assertContains('Content-Type: application/json', $lines);
+    }
+
+    /**
+     * HTTP/2 responses are lower-cased by cURL (e.g. HAL's inbox); getHeader("Location")
+     * must still resolve regardless of the case actually sent on the wire.
+     */
+    public function testParseHeadersNormalizesCaseSoLocationHeaderIsFound(): void
+    {
+        $method = new ReflectionMethod(CoarNotifyHttpLayer::class, 'parseHeaders');
+        $method->setAccessible(true);
+
+        $parsed = $method->invoke($this->layer, "HTTP/2 201\r\nlocation: https://hal.example/inbox/123\r\ncontent-type: application/ld+json\r\n\r\n");
+
+        self::assertSame('https://hal.example/inbox/123', $parsed['Location'] ?? null);
+        self::assertSame('application/ld+json', $parsed['Content-Type'] ?? null);
     }
 }

--- a/tests/unit/library/Episciences/notify/CoarNotifyHttpLayerTest.php
+++ b/tests/unit/library/Episciences/notify/CoarNotifyHttpLayerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace unit\library\Episciences\notify;
+
+use Episciences\Notify\CoarNotifyHttpLayer;
+use PHPUnit\Framework\TestCase;
+
+class CoarNotifyHttpLayerTest extends TestCase
+{
+    private CoarNotifyHttpLayer $layer;
+
+    protected function setUp(): void
+    {
+        $this->layer = new CoarNotifyHttpLayer();
+    }
+
+    public function testBuildHeaderLinesFromAssociativeArrayProducesNameColonValue(): void
+    {
+        $lines = $this->layer->buildHeaderLines([
+            'Content-Type' => 'application/ld+json;profile="https://www.w3.org/ns/activitystreams"',
+        ]);
+
+        self::assertContains(
+            'Content-Type: application/ld+json;profile="https://www.w3.org/ns/activitystreams"',
+            $lines
+        );
+    }
+
+    public function testBuildHeaderLinesDoesNotDuplicateContentTypeWhenCallerProvidesOne(): void
+    {
+        $lines = $this->layer->buildHeaderLines([
+            'Content-Type' => 'application/ld+json',
+        ]);
+
+        $contentTypeLines = array_filter($lines, static fn(string $line): bool => str_starts_with(strtolower($line), 'content-type:'));
+
+        self::assertCount(1, $contentTypeLines);
+        self::assertSame(['Content-Type: application/ld+json'], array_values($contentTypeLines));
+    }
+
+    public function testBuildHeaderLinesDefaultsToApplicationJsonWhenNoContentTypeGiven(): void
+    {
+        $lines = $this->layer->buildHeaderLines(['X-Custom' => 'value']);
+
+        self::assertContains('Content-Type: application/json', $lines);
+        self::assertContains('X-Custom: value', $lines);
+    }
+
+    public function testBuildHeaderLinesHandlesNullHeaders(): void
+    {
+        $lines = $this->layer->buildHeaderLines(null);
+
+        self::assertSame(['Content-Type: application/json'], $lines);
+    }
+
+    public function testBuildHeaderLinesPassesThroughAlreadyFormattedLines(): void
+    {
+        $lines = $this->layer->buildHeaderLines(['Authorization: Bearer token']);
+
+        self::assertContains('Authorization: Bearer token', $lines);
+        self::assertContains('Content-Type: application/json', $lines);
+    }
+}

--- a/tests/unit/library/Episciences/notify/CoarNotifyHttpResponseTest.php
+++ b/tests/unit/library/Episciences/notify/CoarNotifyHttpResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace unit\library\Episciences\notify;
+
+use Episciences\Notify\CoarNotifyHttpResponse;
+use PHPUnit\Framework\TestCase;
+
+class CoarNotifyHttpResponseTest extends TestCase
+{
+    public function testGetHeaderReturnsValueWhenPresent(): void
+    {
+        $response = new CoarNotifyHttpResponse(201, ['Location' => 'https://hal.example/inbox/123']);
+
+        self::assertSame('https://hal.example/inbox/123', $response->getHeader('Location'));
+    }
+
+    /**
+     * coarnotify\client\COARNotifyClient::send() unconditionally calls getHeader("Location")
+     * on every 201 response, even when the inbox didn't send one. This must not warn/crash.
+     */
+    public function testGetHeaderReturnsNullWhenMissing(): void
+    {
+        $response = new CoarNotifyHttpResponse(201, ['Content-Type' => 'application/ld+json']);
+
+        self::assertNull($response->getHeader('Location'));
+    }
+
+    public function testGetStatusCode(): void
+    {
+        $response = new CoarNotifyHttpResponse(202, []);
+
+        self::assertSame(202, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- HAL's COAR Notify inbox rejected our AnnounceEndorsement notifications with `400 Bad Request`
- Root cause: `cottagelabs/coarnotify`'s default `CurlHttpLayer` passes the associative `$headers` array straight to `CURLOPT_HTTPHEADER`, which only reads array values — the `Content-Type` key is dropped, `application/json` is sent instead of the JSON-LD/ActivityStreams content type, and a malformed header line (no field name) is appended
- Adds `Episciences\Notify\CoarNotifyHttpLayer`, a corrected `HttpLayer` implementation, and injects it into the `COARNotifyClient` used by `Episciences_Notify_Hal::announceEndorsement()`
- Vendor code is left untouched (would be overwritten by `composer install`); the bug still exists upstream as of this PR
- Same fix as #1104 (main), cherry-picked onto staging

## Test plan
- [x] `make phpstan LEVEL=6` on the new file — 0 errors
- [x] New unit tests (`CoarNotifyHttpLayerTest`) covering header construction: associative headers, no Content-Type duplication, default fallback, null headers, pre-formatted lines
- [x] Existing `Episciences_Notify_HalTest` suite still green
- [x] Full `make test-php` run — no new failures (1 pre-existing unrelated failure on `main`)
- [ ] Manual verification in prod that publishing to HAL no longer returns 400 (needs live HAL inbox access)