### PR TITLE
fix(mysql): drop non-standard FK and ON DUPLICATE KEY VALUES() ahead of MySQL 8.4

### DIFF
--- a/library/Episciences/Paper/ClassificationsManager.php
+++ b/library/Episciences/Paper/ClassificationsManager.php
@@ -32,7 +32,7 @@ class Episciences_Paper_ClassificationsManager
         if (!empty($values)) {
             try {
                 // Prepare the ON DUPLICATE KEY UPDATE clause
-                $onDuplicateKeySql = ' ON DUPLICATE KEY UPDATE `classification_name` = VALUES(`classification_name`), `source_id` = VALUES(`source_id`)';
+                $onDuplicateKeySql = ' AS new_row ON DUPLICATE KEY UPDATE `classification_name` = new_row.`classification_name`, `source_id` = new_row.`source_id`';
 
                 // Execute the query
                 $result = $db->query($sql . implode(', ', $values) . $onDuplicateKeySql);

--- a/library/Episciences/Paper/ConflictsManager.php
+++ b/library/Episciences/Paper/ConflictsManager.php
@@ -297,11 +297,10 @@ class Episciences_Paper_ConflictsManager
             $sql .= $db->quoteIdentifier('date');
             $sql .= ') VALUES ';
             $sql .= implode(',', $values);
-            $sql .= ' ON DUPLICATE KEY UPDATE ';
+            $sql .= ' AS new_row ON DUPLICATE KEY UPDATE ';
             $sql .= $db->quoteIdentifier('by');
-            $sql .= ' = VALUES(';
+            $sql .= ' = new_row.';
             $sql .= $db->quoteIdentifier('by');
-            $sql .= ')';
 
 
             $statement = $db->prepare($sql);

--- a/library/Episciences/Paper/LicenceManager.php
+++ b/library/Episciences/Paper/LicenceManager.php
@@ -325,7 +325,7 @@ class Episciences_Paper_LicenceManager
             try {
                 //Prepares and executes an SQL
                 /** @var Zend_Db_Statement_Interface $result */
-                $result = $db->query($sql . implode(', ', $values) . ' ON DUPLICATE KEY UPDATE licence=VALUES(licence)');
+                $result = $db->query($sql . implode(', ', $values) . ' AS new_row ON DUPLICATE KEY UPDATE licence=new_row.licence');
                 $affectedRows = $result->rowCount();
 
             } catch (Exception $e) {

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -2355,6 +2355,7 @@ class Episciences_PapersManager
             $db->delete(T_VOLUME_PAPER, ['DOCID = ?' => $docid]);
             $db->delete(T_PAPER_LICENCES, ['docid = ?' => $docid]);
             $db->delete(T_VOLUME_PAPER_POSITION, ['PAPERID = ?' => $paper->getPaperid()]);
+            $db->delete(T_PAPER_PROJECTS, ['paperid = ?' => $paper->getPaperid()]);
 
             $db->commit();
         } catch (Exception $e) {

--- a/library/Episciences/Review/DoiSettingsManager.php
+++ b/library/Episciences/Review/DoiSettingsManager.php
@@ -101,7 +101,7 @@ class Episciences_Review_DoiSettingsManager
         $sql .= T_REVIEW_SETTINGS;
         $sql .= ' (RVID, SETTING, VALUE) VALUES ';
         $sql .= implode(',', $values);
-        $sql .= ' ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)';
+        $sql .= ' AS new_row ON DUPLICATE KEY UPDATE VALUE = new_row.VALUE';
 
         if (!$db->getConnection()->query($sql)) {
             return false;

--- a/library/Episciences/Reviewer/AliasManager.php
+++ b/library/Episciences/Reviewer/AliasManager.php
@@ -49,7 +49,7 @@ class Episciences_Reviewer_AliasManager
             $sql .= $db->quoteIdentifier(self::TABLE);
             $sql .= ' (`UID`, `DOCID`, `ALIAS`) VALUES ';
             $sql .= implode(',', $values);
-            $sql .= ' ON DUPLICATE KEY UPDATE ALIAS = VALUES(ALIAS)';
+            $sql .= ' AS new_row ON DUPLICATE KEY UPDATE ALIAS = new_row.ALIAS';
 
             $insert = $db->prepare($sql);
 

--- a/library/Episciences/Section.php
+++ b/library/Episciences/Section.php
@@ -629,7 +629,7 @@ class Episciences_Section
             $result = $this->_db->update(T_SECTIONS, $data, $where);
 
             if (!empty($settings)) {
-                $sql = $this->_db->quoteInto('INSERT INTO ' . T_SECTION_SETTINGS . ' (SID, SETTING, VALUE) VALUES (?) ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)', $settings);
+                $sql = $this->_db->quoteInto('INSERT INTO ' . T_SECTION_SETTINGS . ' (SID, SETTING, VALUE) VALUES (?) AS new_row ON DUPLICATE KEY UPDATE VALUE = new_row.VALUE', $settings);
                 $query = $this->_db->query($sql);
 
                 $result += $query->rowCount();

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -932,8 +932,8 @@ class Episciences_Volume
             if (!$update) {
                 $this->_db->insert(T_VOLUME_SETTINGS, ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
             } else {
-                $sql = $this->_db->quoteInto('INSERT INTO ' . T_VOLUME_SETTINGS . ' (SETTING, VALUE, VID) VALUES (?) 
-                ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)', ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
+                $sql = $this->_db->quoteInto('INSERT INTO ' . T_VOLUME_SETTINGS . ' (SETTING, VALUE, VID) VALUES (?)
+                AS new_row ON DUPLICATE KEY UPDATE VALUE = new_row.VALUE', ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
                 $this->_db->query($sql);
             }
         } catch (Zend_Db_Adapter_Exception $exception) {

--- a/library/Episciences/Volume/DoiQueueManager.php
+++ b/library/Episciences/Volume/DoiQueueManager.php
@@ -43,7 +43,7 @@ class Episciences_Volume_DoiQueueManager
                 $sql = 'INSERT INTO ' . $db->quoteIdentifier(T_DOI_QUEUE_VOLUMES) . ' (`vid`,`doi_status`,`date_init`,`date_updated`) VALUES (';
                 //Prepares and executes an SQL
                 /** @var Zend_Db_Statement_Interface $result */
-                $result = $db->query($sql . implode(', ', $values) . ') ON DUPLICATE KEY UPDATE doi_status=VALUES(doi_status), date_updated=NOW()');
+                $result = $db->query($sql . implode(', ', $values) . ') AS new_row ON DUPLICATE KEY UPDATE doi_status=new_row.doi_status, date_updated=NOW()');
                 $resInsert = $result->rowCount();
             } catch (Exception $e) {
                 error_log($e->getMessage());

--- a/library/Episciences/VolumeProceeding.php
+++ b/library/Episciences/VolumeProceeding.php
@@ -98,8 +98,8 @@ class Episciences_VolumeProceeding
             if (!$update) {
                 $this->_db->insert(T_VOLUME_PROCEEDING, ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
             } else {
-                $sql = $this->_db->quoteInto('INSERT INTO ' . T_VOLUME_PROCEEDING . ' (SETTING, VALUE, VID) VALUES (?) 
-                ON DUPLICATE KEY UPDATE VALUE = VALUES(VALUE)', ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
+                $sql = $this->_db->quoteInto('INSERT INTO ' . T_VOLUME_PROCEEDING . ' (SETTING, VALUE, VID) VALUES (?)
+                AS new_row ON DUPLICATE KEY UPDATE VALUE = new_row.VALUE', ['SETTING' => $setting, 'VALUE' => $value, 'VID' => $vid]);
                 $this->_db->query($sql);
             }
         } catch (Zend_Db_Adapter_Exception $exception) {

--- a/library/Episciences/VolumesManager.php
+++ b/library/Episciences/VolumesManager.php
@@ -839,7 +839,7 @@ class Episciences_VolumesManager
 
         if ($values) {
             try {
-                $db->query($sql . implode(', ', $values) . ' ON DUPLICATE KEY UPDATE POSITION=VALUES(POSITION)');
+                $db->query($sql . implode(', ', $values) . ' AS new_row ON DUPLICATE KEY UPDATE POSITION=new_row.POSITION');
             } catch (Exception $e) {
                 trigger_error($e->getMessage(), E_USER_WARNING);
             }

--- a/scripts/ImportApacheLogsCommand.php
+++ b/scripts/ImportApacheLogsCommand.php
@@ -488,12 +488,12 @@ class ImportApacheLogsCommand extends Command
     {
         $db  = Zend_Db_Table_Abstract::getDefaultAdapter();
         $sql = 'INSERT INTO STAT_PROCESSING_LOG (JOURNAL_CODE, PROCESSED_DATE, FILE_PATH, RECORDS_PROCESSED, STATUS)
-                VALUES (?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?) AS new_row
                 ON DUPLICATE KEY UPDATE
                     PROCESSED_AT      = CURRENT_TIMESTAMP,
-                    FILE_PATH         = VALUES(FILE_PATH),
-                    RECORDS_PROCESSED = VALUES(RECORDS_PROCESSED),
-                    STATUS            = VALUES(STATUS)';
+                    FILE_PATH         = new_row.FILE_PATH,
+                    RECORDS_PROCESSED = new_row.RECORDS_PROCESSED,
+                    STATUS            = new_row.STATUS';
         $stmt = $db->prepare($sql);
         $stmt->execute([$rvcode, $date, $filePath, $records, $status]);
     }

--- a/scripts/legacy/UpgradeUserRoles.php
+++ b/scripts/legacy/UpgradeUserRoles.php
@@ -210,7 +210,7 @@ class UpgradeUserRoles extends JournalScript
         $sql .= $db->quoteIdentifier($this->_table);
         $sql .= ' (`UID`, `RVID`, `ROLEID`) VALUES ';
         $sql .= implode(',', $values);
-        $sql .= ' ON DUPLICATE KEY UPDATE ROLEID = VALUES(ROLEID)';
+        $sql .= ' AS new_row ON DUPLICATE KEY UPDATE ROLEID = new_row.ROLEID';
 
         $insert = $db->prepare($sql);
 

--- a/src/mysql/2026-07-12-drop-paper-projects-fk.sql
+++ b/src/mysql/2026-07-12-drop-paper-projects-fk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `paper_projects` DROP FOREIGN KEY `paper_projects_ibfk_1`;

--- a/src/mysql/docker/episciences/dev-episciences.sql
+++ b/src/mysql/docker/episciences/dev-episciences.sql
@@ -9475,7 +9475,6 @@ ALTER TABLE `paper_datasets`
 -- Constraints for table `paper_projects`
 --
 ALTER TABLE `paper_projects`
-    ADD CONSTRAINT `paper_projects_ibfk_1` FOREIGN KEY (`paperid`) REFERENCES `PAPERS` (`PAPERID`),
     ADD CONSTRAINT `paper_projects_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 COMMIT;
 

--- a/src/mysql/docker/episciences/dev-episciences.sql
+++ b/src/mysql/docker/episciences/dev-episciences.sql
@@ -1,6 +1,5 @@
--- Generation Time: Feb 16, 2026 at 11:23 PM
--- Server version: 8.0.45
-
+-- Generation Time: Jul 12, 2026 at 08:51 PM
+-- Server version: 8.0.*
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 START TRANSACTION;
 SET time_zone = "+00:00";
@@ -22,10 +21,10 @@ SET time_zone = "+00:00";
 --
 
 CREATE TABLE `authors` (
-  `idauthors` int UNSIGNED NOT NULL,
-  `authors` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'json',
-  `paperid` int UNSIGNED NOT NULL,
-  `date_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                           `idauthors` int UNSIGNED NOT NULL,
+                           `authors` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'json',
+                           `paperid` int UNSIGNED NOT NULL,
+                           `date_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -35,8 +34,8 @@ CREATE TABLE `authors` (
 --
 
 CREATE TABLE `classification_jel` (
-  `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
+                                      `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                      `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -912,9 +911,9 @@ INSERT INTO `classification_jel` (`code`, `label`) VALUES
 --
 
 CREATE TABLE `classification_msc2020` (
-  `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
+                                          `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                          `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                          `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
@@ -7549,12 +7548,12 @@ INSERT INTO `classification_msc2020` (`code`, `label`, `description`) VALUES
 --
 
 CREATE TABLE `data_descriptor` (
-  `id` int UNSIGNED NOT NULL,
-  `uid` int UNSIGNED NOT NULL,
-  `docid` int UNSIGNED NOT NULL,
-  `fileid` int UNSIGNED NOT NULL,
-  `version` float UNSIGNED NOT NULL DEFAULT '1',
-  `submission_date` datetime NOT NULL
+                                   `id` int UNSIGNED NOT NULL,
+                                   `uid` int UNSIGNED NOT NULL,
+                                   `docid` int UNSIGNED NOT NULL,
+                                   `fileid` int UNSIGNED NOT NULL,
+                                   `version` float UNSIGNED NOT NULL DEFAULT '1',
+                                   `submission_date` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -7564,11 +7563,11 @@ CREATE TABLE `data_descriptor` (
 --
 
 CREATE TABLE `doi_queue` (
-  `id_doi_queue` int UNSIGNED NOT NULL,
-  `paperid` int UNSIGNED NOT NULL,
-  `doi_status` enum('assigned','requested','public','') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'assigned',
-  `date_init` datetime NOT NULL,
-  `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                             `id_doi_queue` int UNSIGNED NOT NULL,
+                             `paperid` int UNSIGNED NOT NULL,
+                             `doi_status` enum('assigned','requested','public','') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'assigned',
+                             `date_init` datetime NOT NULL,
+                             `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -7578,12 +7577,12 @@ CREATE TABLE `doi_queue` (
 --
 
 CREATE TABLE `doi_queue_volumes` (
-  `id` int UNSIGNED NOT NULL,
-  `vid` int UNSIGNED NOT NULL,
-  `doi_status` enum('assigned','requested','public','') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'assigned',
-  `date_init` datetime NOT NULL,
-  `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+                                     `id` int UNSIGNED NOT NULL,
+                                     `vid` int UNSIGNED NOT NULL,
+                                     `doi_status` enum('assigned','requested','public','') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'assigned',
+                                     `date_init` datetime NOT NULL,
+                                     `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -7592,16 +7591,52 @@ CREATE TABLE `doi_queue_volumes` (
 --
 
 CREATE TABLE `files` (
-  `id` int UNSIGNED NOT NULL,
-  `docid` int UNSIGNED NOT NULL,
-  `name` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `extension` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `type_mime` varchar(200) NOT NULL,
-  `size` bigint UNSIGNED NOT NULL,
-  `md5` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `source` varchar(20) NOT NULL DEFAULT 'dd',
-  `uploaded_date` datetime NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+                         `id` int UNSIGNED NOT NULL,
+                         `docid` int UNSIGNED NOT NULL,
+                         `name` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `extension` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `type_mime` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `size` bigint UNSIGNED NOT NULL,
+                         `md5` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `source` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'dd',
+                         `uploaded_date` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_lists`
+--
+
+CREATE TABLE `mailing_lists` (
+                                 `id` int UNSIGNED NOT NULL,
+                                 `rvid` int UNSIGNED NOT NULL,
+                                 `name` varchar(255) NOT NULL,
+                                 `type` varchar(50) DEFAULT NULL,
+                                 `status` tinyint NOT NULL DEFAULT '1'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_list_roles`
+--
+
+CREATE TABLE `mailing_list_roles` (
+                                      `list_id` int UNSIGNED NOT NULL,
+                                      `role` varchar(50) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_list_users`
+--
+
+CREATE TABLE `mailing_list_users` (
+                                      `list_id` int UNSIGNED NOT NULL,
+                                      `uid` int UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
 
@@ -7610,33 +7645,35 @@ CREATE TABLE `files` (
 --
 
 CREATE TABLE `MAIL_LOG` (
-  `ID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED DEFAULT NULL COMMENT 'Sender identifier (via the mailing module or the article page)',
-  `RVID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED DEFAULT NULL,
-  `FROM` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `REPLYTO` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `TO` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `CC` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `BCC` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `SUBJECT` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
-  `CONTENT` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `FILES` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `WHEN` datetime NOT NULL
+                            `ID` int UNSIGNED NOT NULL,
+                            `UID` int UNSIGNED DEFAULT NULL COMMENT 'Sender identifier (via the mailing module or the article page)',
+                            `RVID` int UNSIGNED NOT NULL,
+                            `DOCID` int UNSIGNED DEFAULT NULL,
+                            `FROM` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `REPLYTO` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `TO` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+                            `CC` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                            `BCC` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                            `SUBJECT` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `CONTENT` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+                            `FILES` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+                            `WHEN` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `MAIL_TEMPLATE`
 --
 
 CREATE TABLE `MAIL_TEMPLATE` (
-  `ID` int UNSIGNED NOT NULL,
-  `PARENTID` int UNSIGNED DEFAULT NULL,
-  `RVID` int UNSIGNED DEFAULT NULL,
-  `RVCODE` varchar(25) DEFAULT NULL,
-  `KEY` varchar(255) NOT NULL,
-  `TYPE` varchar(255) NOT NULL,
-  `POSITION` int UNSIGNED DEFAULT NULL
+                                 `ID` int UNSIGNED NOT NULL,
+                                 `PARENTID` int UNSIGNED DEFAULT NULL,
+                                 `RVID` int UNSIGNED DEFAULT NULL,
+                                 `RVCODE` varchar(25) DEFAULT NULL,
+                                 `KEY` varchar(255) NOT NULL,
+                                 `TYPE` varchar(255) NOT NULL,
+                                 `POSITION` int UNSIGNED DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 --
@@ -7753,17 +7790,17 @@ INSERT INTO `MAIL_TEMPLATE` (`ID`, `PARENTID`, `RVID`, `RVCODE`, `KEY`, `TYPE`, 
 --
 
 CREATE TABLE `metadata_sources` (
-  `id` int UNSIGNED NOT NULL,
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `type` enum('repository','metadataRepository','dataverse','user') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
-  `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'enabled by default',
-  `identifier` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'OAI identifier',
-  `base_url` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'OAI base url',
-  `doi_prefix` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `api_url` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `doc_url` varchar(150) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `paper_url` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+                                    `id` int UNSIGNED NOT NULL,
+                                    `name` varchar(255) NOT NULL,
+                                    `type` enum('repository','metadataRepository','dataverse','dspace','user') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+                                    `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'enabled by default',
+                                    `identifier` varchar(50) DEFAULT NULL COMMENT 'OAI identifier',
+                                    `base_url` varchar(100) DEFAULT NULL COMMENT 'OAI base url',
+                                    `doi_prefix` varchar(10) NOT NULL,
+                                    `api_url` varchar(100) NOT NULL,
+                                    `doc_url` varchar(150) NOT NULL COMMENT 'See the document''s page on',
+                                    `paper_url` varchar(100) NOT NULL COMMENT 'PDF'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 --
 -- Dumping data for table `metadata_sources`
@@ -7793,36 +7830,36 @@ INSERT INTO `metadata_sources` (`id`, `name`, `type`, `status`, `identifier`, `b
 -- --------------------------------------------------------
 
 --
--- Table structure for table `NEWS`
---
-
-CREATE TABLE `NEWS` (
-  `NEWSID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED NOT NULL,
-  `LINK` varchar(2000) NOT NULL,
-  `ONLINE` tinyint UNSIGNED NOT NULL,
-  `DATE_POST` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
-
--- --------------------------------------------------------
-
---
 -- Table structure for table `news`
 --
 
 CREATE TABLE `news` (
-  `id` int UNSIGNED NOT NULL,
-  `legacy_id` int UNSIGNED DEFAULT NULL COMMENT 'Legacy News id',
-  `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
-  `uid` int UNSIGNED NOT NULL,
-  `date_creation` datetime DEFAULT NULL,
-  `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `title` json NOT NULL COMMENT 'Page title',
-  `content` json DEFAULT NULL,
-  `link` json DEFAULT NULL,
-  `visibility` json NOT NULL
+                        `id` int UNSIGNED NOT NULL,
+                        `legacy_id` int UNSIGNED DEFAULT NULL COMMENT 'Legacy News id',
+                        `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
+                        `uid` int UNSIGNED NOT NULL,
+                        `date_creation` datetime DEFAULT NULL,
+                        `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        `title` json NOT NULL COMMENT 'Page title',
+                        `content` json DEFAULT NULL,
+                        `link` json DEFAULT NULL,
+                        `visibility` json NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `NEWS`
+--
+
+CREATE TABLE `NEWS` (
+                        `NEWSID` int UNSIGNED NOT NULL,
+                        `RVID` int UNSIGNED NOT NULL,
+                        `UID` int UNSIGNED NOT NULL,
+                        `LINK` varchar(2000) NOT NULL,
+                        `ONLINE` tinyint UNSIGNED NOT NULL,
+                        `DATE_POST` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
 
@@ -7831,15 +7868,15 @@ CREATE TABLE `news` (
 --
 
 CREATE TABLE `pages` (
-  `id` int NOT NULL,
-  `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
-  `uid` int UNSIGNED NOT NULL,
-  `date_creation` datetime DEFAULT NULL,
-  `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `title` json NOT NULL COMMENT 'Page title',
-  `content` json NOT NULL,
-  `visibility` json NOT NULL,
-  `page_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Page code'
+                         `id` int NOT NULL,
+                         `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
+                         `uid` int UNSIGNED NOT NULL,
+                         `date_creation` datetime DEFAULT NULL,
+                         `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                         `title` json NOT NULL COMMENT 'Page title',
+                         `content` json NOT NULL,
+                         `visibility` json NOT NULL,
+                         `page_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Page code'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -7849,28 +7886,28 @@ CREATE TABLE `pages` (
 --
 
 CREATE TABLE `PAPERS` (
-  `DOCID` int UNSIGNED NOT NULL,
-  `PAPERID` int UNSIGNED DEFAULT NULL,
-  `DOI` varchar(250) DEFAULT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `VID` int UNSIGNED NOT NULL DEFAULT '0',
-  `SID` int UNSIGNED NOT NULL DEFAULT '0',
-  `UID` int UNSIGNED NOT NULL,
-  `STATUS` int UNSIGNED NOT NULL DEFAULT '0',
-  `IDENTIFIER` varchar(500) NOT NULL,
-  `VERSION` float UNSIGNED NOT NULL DEFAULT '1',
-  `REPOID` int UNSIGNED NOT NULL,
-  `TYPE` json DEFAULT NULL,
-  `RECORD` text NOT NULL,
-  `DOCUMENT` json DEFAULT NULL,
-  `CONCEPT_IDENTIFIER` varchar(500) DEFAULT NULL COMMENT 'This identifier represents all versions',
-  `FLAG` enum('submitted','imported') NOT NULL DEFAULT 'submitted',
-  `PASSWORD` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
-  `WHEN` datetime NOT NULL,
-  `SUBMISSION_DATE` datetime NOT NULL,
-  `MODIFICATION_DATE` datetime DEFAULT NULL,
-  `PUBLICATION_DATE` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Conference papers';
+                          `DOCID` int UNSIGNED NOT NULL COMMENT 'Unique Identifier for each submission',
+                          `PAPERID` int UNSIGNED DEFAULT NULL COMMENT 'Common Identifier for several versions of a paper',
+                          `DOI` varchar(250) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL COMMENT 'PID of accepted and published papers',
+                          `RVID` int UNSIGNED NOT NULL COMMENT 'Link to Journal ID',
+                          `VID` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Link to Volume ID',
+                          `SID` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Link to Section ID',
+                          `UID` int UNSIGNED NOT NULL COMMENT 'Link to User ID',
+                          `STATUS` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Status of the submission',
+                          `IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL COMMENT 'Open Repository Identifier',
+                          `VERSION` float UNSIGNED NOT NULL DEFAULT '1' COMMENT 'Version identifier of a submission',
+                          `REPOID` int UNSIGNED NOT NULL COMMENT 'Link to Repository ID',
+                          `TYPE` json DEFAULT NULL,
+                          `RECORD` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL COMMENT 'Text of Metadata Record from Open repository ',
+                          `DOCUMENT` json DEFAULT NULL,
+                          `CONCEPT_IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL COMMENT 'Zenodo ID This identifier represents all versions',
+                          `FLAG` enum('submitted','imported') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'submitted' COMMENT 'Submission source',
+                          `PASSWORD` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci COMMENT 'Encrypted temporary password for sharing arXiv submissions',
+                          `WHEN` datetime NOT NULL COMMENT 'Timestamp of insertion in database',
+                          `SUBMISSION_DATE` datetime NOT NULL COMMENT 'Timestamp of the 1st submission - common to all versions of a Paper',
+                          `MODIFICATION_DATE` datetime DEFAULT NULL COMMENT 'Timestamp of the update of the line in database',
+                          `PUBLICATION_DATE` datetime DEFAULT NULL COMMENT 'Timestamp of the publication date of a paper'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Submissions';
 
 -- --------------------------------------------------------
 
@@ -7879,12 +7916,12 @@ CREATE TABLE `PAPERS` (
 --
 
 CREATE TABLE `paper_citations` (
-  `id` int UNSIGNED NOT NULL,
-  `citation` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Json (cited by)',
-  `docid` int UNSIGNED NOT NULL,
-  `source_id` int UNSIGNED NOT NULL,
-  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Cited by ';
+                                   `id` int UNSIGNED NOT NULL,
+                                   `citation` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Json Citations.php',
+                                   `docid` int UNSIGNED NOT NULL,
+                                   `source_id` int UNSIGNED NOT NULL,
+                                   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
 
@@ -7893,12 +7930,12 @@ CREATE TABLE `paper_citations` (
 --
 
 CREATE TABLE `paper_classifications` (
-  `id` int UNSIGNED NOT NULL,
-  `docid` int UNSIGNED NOT NULL,
-  `classification_code` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `classification_name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `source_id` int UNSIGNED NOT NULL,
-  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                                         `id` int UNSIGNED NOT NULL,
+                                         `docid` int UNSIGNED NOT NULL,
+                                         `classification_code` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                         `classification_name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                         `source_id` int UNSIGNED NOT NULL,
+                                         `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
@@ -7908,16 +7945,16 @@ CREATE TABLE `paper_classifications` (
 --
 
 CREATE TABLE `PAPER_COMMENTS` (
-  `PCID` int UNSIGNED NOT NULL,
-  `PARENTID` int UNSIGNED DEFAULT NULL,
-  `TYPE` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED NOT NULL,
-  `MESSAGE` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `FILE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `WHEN` datetime NOT NULL,
-  `DEADLINE` date DEFAULT NULL,
-  `OPTIONS` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+                                  `PCID` int UNSIGNED NOT NULL,
+                                  `PARENTID` int UNSIGNED DEFAULT NULL,
+                                  `TYPE` int UNSIGNED NOT NULL,
+                                  `DOCID` int UNSIGNED NOT NULL,
+                                  `UID` int UNSIGNED NOT NULL,
+                                  `MESSAGE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                                  `FILE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                                  `WHEN` datetime NOT NULL,
+                                  `DEADLINE` date DEFAULT NULL,
+                                  `OPTIONS` text
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Suivi des demandes de modification sur un papier';
 
 -- --------------------------------------------------------
@@ -7927,13 +7964,12 @@ CREATE TABLE `PAPER_COMMENTS` (
 --
 
 CREATE TABLE `paper_conflicts` (
-  `cid` int UNSIGNED NOT NULL,
-  `paper_id` int UNSIGNED NOT NULL,
-  `by` int UNSIGNED NOT NULL COMMENT 'uid',
-  `answer` enum('yes','no','later') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
-  `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `valid` enum('0','1') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '1'
+                                   `cid` int UNSIGNED NOT NULL,
+                                   `paper_id` int UNSIGNED NOT NULL,
+                                   `by` int UNSIGNED NOT NULL COMMENT 'uid',
+                                   `answer` enum('yes','no') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+                                   `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                                   `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='conflicts handling';
 
 -- --------------------------------------------------------
@@ -7943,16 +7979,16 @@ CREATE TABLE `paper_conflicts` (
 --
 
 CREATE TABLE `paper_datasets` (
-  `id` int UNSIGNED NOT NULL,
-  `doc_id` int UNSIGNED NOT NULL,
-  `code` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `value` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `link` varchar(750) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `source_id` int UNSIGNED NOT NULL,
-  `relationship` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `id_paper_datasets_meta` int UNSIGNED DEFAULT NULL COMMENT 'Link to JSON text',
-  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                  `id` int NOT NULL,
+                                  `doc_id` int NOT NULL,
+                                  `code` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Identifier type',
+                                  `value` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `link` varchar(750) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `source_id` int NOT NULL,
+                                  `relationship` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+                                  `id_paper_datasets_meta` int UNSIGNED DEFAULT NULL,
+                                  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -7962,9 +7998,9 @@ CREATE TABLE `paper_datasets` (
 --
 
 CREATE TABLE `paper_datasets_meta` (
-  `id` int UNSIGNED NOT NULL,
-  `metatext` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'JSON text',
-  `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                       `id` int UNSIGNED NOT NULL,
+                                       `metatext` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'JSON text',
+                                       `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -7974,16 +8010,16 @@ CREATE TABLE `paper_datasets_meta` (
 --
 
 CREATE TABLE `paper_files` (
-  `id` int UNSIGNED NOT NULL,
-  `doc_id` int UNSIGNED NOT NULL,
-  `source` int NOT NULL DEFAULT '4',
-  `file_name` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `checksum` char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `checksum_type` char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'md5',
-  `self_link` varchar(750) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `file_size` bigint UNSIGNED NOT NULL,
-  `file_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `time_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP
+                               `id` int UNSIGNED NOT NULL,
+                               `doc_id` int UNSIGNED NOT NULL,
+                               `source` int NOT NULL DEFAULT '4',
+                               `file_name` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                               `checksum` char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                               `checksum_type` char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'md5',
+                               `self_link` varchar(750) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+                               `file_size` bigint UNSIGNED NOT NULL,
+                               `file_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                               `time_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -7993,11 +8029,11 @@ CREATE TABLE `paper_files` (
 --
 
 CREATE TABLE `paper_licences` (
-  `id` int UNSIGNED NOT NULL,
-  `licence` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `docid` int UNSIGNED NOT NULL,
-  `source_id` int UNSIGNED NOT NULL,
-  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+                                  `id` int UNSIGNED NOT NULL,
+                                  `licence` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `docid` int UNSIGNED NOT NULL,
+                                  `source_id` int UNSIGNED NOT NULL,
+                                  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8007,16 +8043,16 @@ CREATE TABLE `paper_licences` (
 --
 
 CREATE TABLE `PAPER_LOG` (
-  `LOGID` int UNSIGNED NOT NULL,
-  `PAPERID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `ACTION` varchar(50) NOT NULL,
-  `FILE` varchar(150) DEFAULT NULL,
-  `DATE` datetime NOT NULL,
-  `DETAIL` json DEFAULT NULL,
-  `status` int UNSIGNED GENERATED ALWAYS AS (json_unquote(json_extract(`DETAIL`,_utf8mb4'$.status'))) STORED
+                             `LOGID` int UNSIGNED NOT NULL,
+                             `PAPERID` int UNSIGNED NOT NULL,
+                             `DOCID` int UNSIGNED NOT NULL,
+                             `UID` int UNSIGNED NOT NULL,
+                             `RVID` int UNSIGNED NOT NULL,
+                             `ACTION` varchar(50) NOT NULL,
+                             `FILE` varchar(150) DEFAULT NULL,
+                             `DATE` datetime NOT NULL,
+                             `DETAIL` json DEFAULT NULL,
+                             `status` int UNSIGNED GENERATED ALWAYS AS (json_unquote(json_extract(`DETAIL`,_utf8mb4'$.status'))) STORED
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Life of papers';
 
 -- --------------------------------------------------------
@@ -8026,12 +8062,12 @@ CREATE TABLE `PAPER_LOG` (
 --
 
 CREATE TABLE `paper_projects` (
-  `idproject` int UNSIGNED NOT NULL,
-  `funding` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Json of funding',
-  `paperid` int UNSIGNED NOT NULL,
-  `source_id` int UNSIGNED NOT NULL,
-  `date_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                                  `idproject` int UNSIGNED NOT NULL,
+                                  `funding` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Json of funding',
+                                  `paperid` int UNSIGNED NOT NULL,
+                                  `source_id` int UNSIGNED NOT NULL,
+                                  `date_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -8040,10 +8076,10 @@ CREATE TABLE `paper_projects` (
 --
 
 CREATE TABLE `PAPER_SETTINGS` (
-  `PSID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(100) NOT NULL,
-  `VALUE` varchar(250) DEFAULT NULL
+                                  `PSID` int UNSIGNED NOT NULL,
+                                  `DOCID` int UNSIGNED NOT NULL,
+                                  `SETTING` varchar(100) NOT NULL,
+                                  `VALUE` varchar(250) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8053,15 +8089,19 @@ CREATE TABLE `PAPER_SETTINGS` (
 --
 
 CREATE TABLE `PAPER_STAT` (
-  `DOCID` int UNSIGNED NOT NULL,
-  `CONSULT` enum('notice','file','oai','api') NOT NULL DEFAULT 'notice',
-  `IP` int UNSIGNED NOT NULL,
-  `ROBOT` tinyint UNSIGNED NOT NULL DEFAULT '0',
-  `DOMAIN` varchar(100) DEFAULT NULL,
-  `CONTINENT` varchar(100) DEFAULT NULL,
-  `COUNTRY` varchar(100) DEFAULT NULL,
-  `HIT` date NOT NULL,
-  `COUNTER` int UNSIGNED NOT NULL
+                              `DOCID` int UNSIGNED NOT NULL,
+                              `CONSULT` enum('notice','file','oai','api') NOT NULL DEFAULT 'notice',
+                              `IP` int UNSIGNED NOT NULL,
+                              `ROBOT` tinyint UNSIGNED NOT NULL DEFAULT '0',
+                              `AGENT` varchar(2000) DEFAULT NULL,
+                              `DOMAIN` varchar(100) DEFAULT NULL,
+                              `CONTINENT` varchar(100) DEFAULT NULL,
+                              `COUNTRY` varchar(100) DEFAULT NULL,
+                              `CITY` varchar(100) DEFAULT NULL,
+                              `LAT` float DEFAULT NULL,
+                              `LON` float DEFAULT NULL,
+                              `HIT` date NOT NULL,
+                              `COUNTER` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8071,14 +8111,14 @@ CREATE TABLE `PAPER_STAT` (
 --
 
 CREATE TABLE `queue_messages` (
-  `id` int UNSIGNED NOT NULL,
-  `rvcode` varchar(50) NOT NULL,
-  `type` varchar(50) NOT NULL DEFAULT '',
-  `message` json NOT NULL,
-  `created_at` int UNSIGNED NOT NULL,
-  `timeout` int UNSIGNED NOT NULL DEFAULT '120',
-  `processed` tinyint(1) NOT NULL DEFAULT '0',
-  `updated_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                                  `id` int UNSIGNED NOT NULL,
+                                  `rvcode` varchar(50) NOT NULL,
+                                  `type` varchar(50) NOT NULL DEFAULT '',
+                                  `message` json NOT NULL,
+                                  `created_at` int UNSIGNED NOT NULL,
+                                  `timeout` int UNSIGNED NOT NULL DEFAULT '120',
+                                  `processed` tinyint(1) NOT NULL DEFAULT '0',
+                                  `updated_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC;
 
 -- --------------------------------------------------------
@@ -8088,12 +8128,12 @@ CREATE TABLE `queue_messages` (
 --
 
 CREATE TABLE `refresh_tokens` (
-  `id` int NOT NULL,
-  `refreshToken` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `username` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `rvid` int UNSIGNED DEFAULT NULL,
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `valid` datetime NOT NULL
+                                  `id` int NOT NULL,
+                                  `refreshToken` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `username` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+                                  `rvid` int UNSIGNED DEFAULT NULL,
+                                  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                  `valid` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8103,13 +8143,13 @@ CREATE TABLE `refresh_tokens` (
 --
 
 CREATE TABLE `REMINDERS` (
-  `ID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED DEFAULT NULL,
-  `TYPE` tinyint UNSIGNED DEFAULT NULL,
-  `DELAY` smallint UNSIGNED DEFAULT NULL,
-  `RECIPIENT` varchar(25) NOT NULL DEFAULT 'reviewer',
-  `REPETITION` varchar(20) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                             `ID` int UNSIGNED NOT NULL,
+                             `RVID` int UNSIGNED DEFAULT NULL,
+                             `TYPE` tinyint UNSIGNED DEFAULT NULL,
+                             `DELAY` smallint UNSIGNED NOT NULL,
+                             `REPETITION` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                             `RECIPIENT` varchar(25) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL DEFAULT 'reviewer'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -8118,14 +8158,14 @@ CREATE TABLE `REMINDERS` (
 --
 
 CREATE TABLE `REVIEW` (
-  `RVID` int UNSIGNED NOT NULL,
-  `CODE` varchar(50) NOT NULL,
-  `NAME` varchar(2000) NOT NULL,
-  `subtitle` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
-  `STATUS` smallint UNSIGNED NOT NULL DEFAULT '0',
-  `CREATION` datetime NOT NULL,
-  `PIWIKID` int UNSIGNED NOT NULL,
-  `is_new_front_switched` enum('yes','no') NOT NULL DEFAULT 'no'
+                          `RVID` int UNSIGNED NOT NULL,
+                          `CODE` varchar(50) NOT NULL,
+                          `NAME` varchar(2000) NOT NULL,
+                          `subtitle` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `STATUS` smallint UNSIGNED NOT NULL DEFAULT '0',
+                          `CREATION` datetime NOT NULL,
+                          `PIWIKID` int UNSIGNED NOT NULL,
+                          `is_new_front_switched` enum('yes','no') NOT NULL DEFAULT 'no'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Basic journal informations';
 
 --
@@ -8143,10 +8183,10 @@ INSERT INTO `REVIEW` (`RVID`, `CODE`, `NAME`, `subtitle`, `STATUS`, `CREATION`, 
 --
 
 CREATE TABLE `REVIEWER_ALIAS` (
-  `ID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL,
-  `ALIAS` int UNSIGNED NOT NULL
+                                  `ID` int UNSIGNED NOT NULL,
+                                  `UID` int UNSIGNED NOT NULL,
+                                  `DOCID` int UNSIGNED NOT NULL,
+                                  `ALIAS` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8156,10 +8196,10 @@ CREATE TABLE `REVIEWER_ALIAS` (
 --
 
 CREATE TABLE `REVIEWER_POOL` (
-  `RVID` int UNSIGNED NOT NULL,
-  `VID` int UNSIGNED NOT NULL DEFAULT '0',
-  `UID` int UNSIGNED NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                                 `RVID` int UNSIGNED NOT NULL,
+                                 `VID` int UNSIGNED NOT NULL DEFAULT '0',
+                                 `UID` int UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -8168,13 +8208,13 @@ CREATE TABLE `REVIEWER_POOL` (
 --
 
 CREATE TABLE `REVIEWER_REPORT` (
-  `ID` int UNSIGNED NOT NULL,
-  `UID` int UNSIGNED NOT NULL,
-  `ONBEHALF_UID` int UNSIGNED DEFAULT NULL COMMENT 'Mis à jour [!= de NULL] uniquement si l’évaluation est faite à la place de relecteur UID',
-  `DOCID` int UNSIGNED NOT NULL,
-  `STATUS` int UNSIGNED NOT NULL,
-  `CREATION_DATE` datetime NOT NULL,
-  `UPDATE_DATE` datetime DEFAULT NULL
+                                   `ID` int UNSIGNED NOT NULL,
+                                   `UID` int UNSIGNED NOT NULL,
+                                   `ONBEHALF_UID` int UNSIGNED DEFAULT NULL COMMENT 'Mis à jour [!= de NULL] uniquement si l’évaluation est faite à la place de relecteur UID',
+                                   `DOCID` int UNSIGNED NOT NULL,
+                                   `STATUS` int UNSIGNED NOT NULL,
+                                   `CREATION_DATE` datetime NOT NULL,
+                                   `UPDATE_DATE` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8184,9 +8224,10 @@ CREATE TABLE `REVIEWER_REPORT` (
 --
 
 CREATE TABLE `REVIEW_SETTING` (
-  `RVID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+                                  `RVID` int UNSIGNED NOT NULL,
+                                  `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci,
+                                  `TIME` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Journal configurations';
 
 --
@@ -8257,11 +8298,11 @@ INSERT INTO `REVIEW_SETTING` (`RVID`, `SETTING`, `VALUE`) VALUES
 --
 
 CREATE TABLE `SECTION` (
-  `SID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `POSITION` int UNSIGNED NOT NULL,
-  `titles` json DEFAULT NULL,
-  `descriptions` json DEFAULT NULL
+                           `SID` int UNSIGNED NOT NULL,
+                           `RVID` int UNSIGNED NOT NULL,
+                           `POSITION` int UNSIGNED NOT NULL,
+                           `titles` json DEFAULT NULL,
+                           `descriptions` json DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8271,9 +8312,9 @@ CREATE TABLE `SECTION` (
 --
 
 CREATE TABLE `SECTION_SETTING` (
-  `SID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+                                   `SID` int UNSIGNED NOT NULL,
+                                   `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+                                   `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8283,13 +8324,13 @@ CREATE TABLE `SECTION_SETTING` (
 --
 
 CREATE TABLE `STAT_PROCESSING_LOG` (
-  `ID` int UNSIGNED NOT NULL,
-  `JOURNAL_CODE` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `PROCESSED_DATE` date NOT NULL,
-  `PROCESSED_AT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `FILE_PATH` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `RECORDS_PROCESSED` int UNSIGNED NOT NULL DEFAULT '0',
-  `STATUS` enum('success','error','partial') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'success'
+                                       `ID` int UNSIGNED NOT NULL,
+                                       `JOURNAL_CODE` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                       `PROCESSED_DATE` date NOT NULL,
+                                       `PROCESSED_AT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       `FILE_PATH` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                       `RECORDS_PROCESSED` int UNSIGNED NOT NULL DEFAULT '0',
+                                       `STATUS` enum('success','error','partial') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'success'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Tracks processed statistics log files to prevent duplicates';
 
 -- --------------------------------------------------------
@@ -8299,12 +8340,12 @@ CREATE TABLE `STAT_PROCESSING_LOG` (
 --
 
 CREATE TABLE `STAT_TEMP` (
-  `VISITID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL,
-  `IP` int UNSIGNED NOT NULL,
-  `HTTP_USER_AGENT` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
-  `DHIT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `CONSULT` enum('notice','file','oai') CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'notice'
+                             `VISITID` int UNSIGNED NOT NULL,
+                             `DOCID` int UNSIGNED NOT NULL,
+                             `IP` int UNSIGNED NOT NULL,
+                             `HTTP_USER_AGENT` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+                             `DHIT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                             `CONSULT` enum('notice','file','oai') CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'notice'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci COMMENT='Statistique de consultation journalière temporaire';
 
 -- --------------------------------------------------------
@@ -8314,41 +8355,43 @@ CREATE TABLE `STAT_TEMP` (
 --
 
 CREATE TABLE `USER` (
-  `UID` int UNSIGNED NOT NULL,
-  `uuid` char(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT '',
-  `LANGUEID` varchar(2) NOT NULL DEFAULT 'fr',
-  `SCREEN_NAME` varchar(250) NOT NULL,
-  `USERNAME` varchar(100) NOT NULL,
-  `API_PASSWORD` varchar(255) NOT NULL,
-  `EMAIL` varchar(320) NOT NULL,
-  `CIV` varchar(255) DEFAULT NULL,
-  `LASTNAME` varchar(100) NOT NULL,
-  `FIRSTNAME` varchar(100) DEFAULT NULL,
-  `MIDDLENAME` varchar(100) DEFAULT NULL,
-  `ORCID` varchar(19) DEFAULT NULL,
-  `ADDITIONAL_PROFILE_INFORMATION` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
-  `REGISTRATION_DATE` timestamp NULL DEFAULT NULL COMMENT 'Date the profile was created',
-  `MODIFICATION_DATE` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Date the profile was updated',
-  `IS_VALID` tinyint(1) NOT NULL DEFAULT '1'
+                        `UID` int UNSIGNED NOT NULL,
+                        `uuid` char(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'Storing As a String',
+                        `LANGUEID` varchar(2) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'fr' COMMENT 'Account language code',
+                        `SCREEN_NAME` varchar(250) NOT NULL,
+                        `USERNAME` varchar(100) NOT NULL,
+                        `API_PASSWORD` varchar(255) NOT NULL,
+                        `EMAIL` varchar(320) NOT NULL,
+                        `CIV` varchar(255) DEFAULT NULL,
+                        `LASTNAME` varchar(100) NOT NULL,
+                        `FIRSTNAME` varchar(100) DEFAULT NULL,
+                        `MIDDLENAME` varchar(100) DEFAULT NULL,
+                        `ORCID` varchar(19) DEFAULT NULL,
+                        `ADDITIONAL_PROFILE_INFORMATION` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+                        `REGISTRATION_DATE` timestamp NULL DEFAULT NULL COMMENT 'Date the profile was created',
+                        `MODIFICATION_DATE` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Date the profile was updated',
+                        `IS_VALID` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'Is account enabled'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `USER_ASSIGNMENT`
 --
 
 CREATE TABLE `USER_ASSIGNMENT` (
-  `ID` int UNSIGNED NOT NULL,
-  `INVITATION_ID` int UNSIGNED DEFAULT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `ITEMID` int UNSIGNED NOT NULL,
-  `ITEM` varchar(50) NOT NULL DEFAULT 'paper',
-  `UID` int UNSIGNED NOT NULL,
-  `FROM_UID` int UNSIGNED DEFAULT NULL COMMENT 'Linked from',
-  `TMP_USER` tinyint UNSIGNED NOT NULL DEFAULT '0',
-  `ROLEID` varchar(50) NOT NULL,
-  `STATUS` varchar(20) NOT NULL,
-  `WHEN` datetime NOT NULL,
-  `DEADLINE` datetime DEFAULT NULL
+                                   `ID` int UNSIGNED NOT NULL,
+                                   `INVITATION_ID` int UNSIGNED DEFAULT NULL,
+                                   `RVID` int UNSIGNED NOT NULL,
+                                   `ITEMID` int UNSIGNED NOT NULL,
+                                   `ITEM` varchar(50) NOT NULL DEFAULT 'paper',
+                                   `UID` int UNSIGNED NOT NULL,
+                                   `FROM_UID` int UNSIGNED DEFAULT NULL COMMENT 'Linked from',
+                                   `TMP_USER` tinyint UNSIGNED NOT NULL DEFAULT '0',
+                                   `ROLEID` varchar(50) NOT NULL,
+                                   `STATUS` varchar(20) NOT NULL,
+                                   `WHEN` datetime NOT NULL,
+                                   `DEADLINE` datetime DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8358,13 +8401,13 @@ CREATE TABLE `USER_ASSIGNMENT` (
 --
 
 CREATE TABLE `USER_INVITATION` (
-  `ID` int UNSIGNED NOT NULL,
-  `AID` int UNSIGNED NOT NULL COMMENT 'Assignment ID',
-  `STATUS` varchar(50) NOT NULL DEFAULT 'pending',
-  `TOKEN` varchar(40) DEFAULT NULL,
-  `SENDER_UID` int UNSIGNED DEFAULT NULL,
-  `SENDING_DATE` datetime NOT NULL,
-  `EXPIRATION_DATE` datetime NOT NULL
+                                   `ID` int UNSIGNED NOT NULL,
+                                   `AID` int UNSIGNED NOT NULL COMMENT 'Assignment ID',
+                                   `STATUS` varchar(50) NOT NULL DEFAULT 'pending',
+                                   `TOKEN` varchar(40) DEFAULT NULL,
+                                   `SENDER_UID` int UNSIGNED DEFAULT NULL,
+                                   `SENDING_DATE` datetime NOT NULL,
+                                   `EXPIRATION_DATE` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8374,10 +8417,10 @@ CREATE TABLE `USER_INVITATION` (
 --
 
 CREATE TABLE `USER_INVITATION_ANSWER` (
-  `ID_UIA` int UNSIGNED NOT NULL,
-  `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
-  `ANSWER` varchar(10) NOT NULL,
-  `ANSWER_DATE` datetime NOT NULL
+                                          `ID_UIA` int UNSIGNED NOT NULL,
+                                          `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
+                                          `ANSWER` varchar(10) NOT NULL,
+                                          `ANSWER_DATE` datetime NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8387,10 +8430,10 @@ CREATE TABLE `USER_INVITATION_ANSWER` (
 --
 
 CREATE TABLE `USER_INVITATION_ANSWER_DETAIL` (
-  `ID_UIAD` int UNSIGNED NOT NULL,
-  `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
-  `NAME` varchar(30) NOT NULL,
-  `VALUE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
+                                                 `ID_UIAD` int UNSIGNED NOT NULL,
+                                                 `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
+                                                 `NAME` varchar(30) NOT NULL,
+                                                 `VALUE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8400,12 +8443,12 @@ CREATE TABLE `USER_INVITATION_ANSWER_DETAIL` (
 --
 
 CREATE TABLE `USER_MERGE` (
-  `MID` int UNSIGNED NOT NULL,
-  `TOKEN` varchar(40) DEFAULT NULL,
-  `MERGER_UID` int UNSIGNED NOT NULL COMMENT 'CASID du compte à fusionner',
-  `KEEPER_UID` int UNSIGNED NOT NULL COMMENT 'CASID du compte à conserver',
-  `DETAIL` text,
-  `DATE` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+                              `MID` int UNSIGNED NOT NULL,
+                              `TOKEN` varchar(40) DEFAULT NULL,
+                              `MERGER_UID` int UNSIGNED NOT NULL COMMENT 'CASID du compte à fusionner',
+                              `KEEPER_UID` int UNSIGNED NOT NULL COMMENT 'CASID du compte à conserver',
+                              `DETAIL` text,
+                              `DATE` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8415,23 +8458,25 @@ CREATE TABLE `USER_MERGE` (
 --
 
 CREATE TABLE `USER_ROLES` (
-  `UID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL DEFAULT '0',
-  `ROLEID` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
-  `IS_AVAILABLE` tinyint UNSIGNED DEFAULT NULL
+                              `UID` int UNSIGNED NOT NULL,
+                              `RVID` int UNSIGNED NOT NULL DEFAULT '0',
+                              `ROLEID` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+                              `IS_AVAILABLE` tinyint UNSIGNED DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
 
 --
 -- Table structure for table `USER_TMP`
 --
 
 CREATE TABLE `USER_TMP` (
-  `ID` int UNSIGNED NOT NULL,
-  `EMAIL` varchar(250) DEFAULT NULL,
-  `FIRSTNAME` varchar(100) DEFAULT NULL,
-  `LASTNAME` varchar(100) DEFAULT NULL,
-  `LANG` varchar(3) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                            `ID` int UNSIGNED NOT NULL,
+                            `EMAIL` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `FIRSTNAME` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `LASTNAME` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
+                            `LANG` varchar(3) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -8440,15 +8485,15 @@ CREATE TABLE `USER_TMP` (
 --
 
 CREATE TABLE `VOLUME` (
-  `VID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `POSITION` int UNSIGNED NOT NULL,
-  `BIB_REFERENCE` varchar(255) DEFAULT NULL COMMENT 'Volume''s bibliographical reference',
-  `titles` json DEFAULT NULL,
-  `descriptions` json DEFAULT NULL,
-  `vol_year` varchar(9) DEFAULT NULL,
-  `vol_type` set('special_issue','proceedings') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
-  `vol_num` varchar(6) DEFAULT NULL
+                          `VID` int UNSIGNED NOT NULL,
+                          `RVID` int UNSIGNED NOT NULL,
+                          `POSITION` int UNSIGNED NOT NULL,
+                          `BIB_REFERENCE` varchar(255) DEFAULT NULL COMMENT 'Volume bibliographical reference',
+                          `titles` json DEFAULT NULL,
+                          `descriptions` json DEFAULT NULL,
+                          `vol_year` varchar(9) DEFAULT NULL,
+                          `vol_type` set('special_issue','proceedings') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+                          `vol_num` varchar(6) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Journal volumes';
 
 -- --------------------------------------------------------
@@ -8458,14 +8503,14 @@ CREATE TABLE `VOLUME` (
 --
 
 CREATE TABLE `VOLUME_METADATA` (
-  `ID` int UNSIGNED NOT NULL,
-  `VID` int UNSIGNED NOT NULL,
-  `POSITION` int UNSIGNED NOT NULL,
-  `CONTENT` json DEFAULT NULL COMMENT 'Metadata decsriptions',
-  `FILE` varchar(250) DEFAULT NULL,
-  `titles` json DEFAULT NULL,
-  `date_creation` datetime DEFAULT NULL,
-  `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                                   `ID` int UNSIGNED NOT NULL,
+                                   `VID` int UNSIGNED NOT NULL,
+                                   `POSITION` int UNSIGNED NOT NULL,
+                                   `CONTENT` json DEFAULT NULL COMMENT 'Metadata decsriptions',
+                                   `FILE` varchar(250) DEFAULT NULL,
+                                   `titles` json DEFAULT NULL,
+                                   `date_creation` datetime DEFAULT NULL,
+                                   `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -8475,9 +8520,9 @@ CREATE TABLE `VOLUME_METADATA` (
 --
 
 CREATE TABLE `VOLUME_PAPER` (
-  `ID` int UNSIGNED NOT NULL,
-  `VID` int UNSIGNED NOT NULL,
-  `DOCID` int UNSIGNED NOT NULL
+                                `ID` int UNSIGNED NOT NULL,
+                                `VID` int UNSIGNED NOT NULL,
+                                `DOCID` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
@@ -8487,10 +8532,10 @@ CREATE TABLE `VOLUME_PAPER` (
 --
 
 CREATE TABLE `VOLUME_PAPER_POSITION` (
-  `ID` int UNSIGNED NOT NULL,
-  `VID` int UNSIGNED NOT NULL,
-  `PAPERID` int UNSIGNED NOT NULL,
-  `POSITION` int UNSIGNED NOT NULL
+                                         `ID` int UNSIGNED NOT NULL,
+                                         `VID` int UNSIGNED NOT NULL,
+                                         `PAPERID` int UNSIGNED NOT NULL,
+                                         `POSITION` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -8500,9 +8545,9 @@ CREATE TABLE `VOLUME_PAPER_POSITION` (
 --
 
 CREATE TABLE `volume_proceeding` (
-  `VID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(200) NOT NULL,
-  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+                                     `VID` int UNSIGNED NOT NULL,
+                                     `SETTING` varchar(200) NOT NULL,
+                                     `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8512,10 +8557,25 @@ CREATE TABLE `volume_proceeding` (
 --
 
 CREATE TABLE `VOLUME_SETTING` (
-  `VID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(200) NOT NULL,
-  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Journal configurations';
+                                  `VID` int UNSIGNED NOT NULL,
+                                  `SETTING` varchar(200) NOT NULL,
+                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
+
+--
+-- Stand-in structure for view `v_mailing_lists_resolved`
+-- (See below for the actual view)
+--
+CREATE TABLE `v_mailing_lists_resolved` (
+                                            `list_id` int unsigned
+    ,`journal_id` int unsigned
+    ,`list_name` varchar(255)
+    ,`list_type` varchar(50)
+    ,`list_status` varchar(6)
+    ,`members` json
+);
 
 -- --------------------------------------------------------
 
@@ -8524,18 +8584,18 @@ CREATE TABLE `VOLUME_SETTING` (
 --
 
 CREATE TABLE `WEBSITE_HEADER` (
-  `LOGOID` int UNSIGNED NOT NULL,
-  `RVID` int UNSIGNED NOT NULL,
-  `TYPE` enum('img','text') NOT NULL,
-  `IMG` varchar(255) NOT NULL,
-  `IMG_WIDTH` varchar(255) NOT NULL,
-  `IMG_HEIGHT` varchar(255) NOT NULL,
-  `IMG_HREF` varchar(255) NOT NULL,
-  `IMG_ALT` varchar(255) NOT NULL,
-  `TEXT` varchar(1000) NOT NULL,
-  `TEXT_CLASS` varchar(255) NOT NULL,
-  `TEXT_STYLE` varchar(255) NOT NULL,
-  `ALIGN` varchar(10) NOT NULL
+                                  `LOGOID` int UNSIGNED NOT NULL,
+                                  `RVID` int UNSIGNED NOT NULL,
+                                  `TYPE` enum('img','text') NOT NULL,
+                                  `IMG` varchar(255) NOT NULL,
+                                  `IMG_WIDTH` varchar(255) NOT NULL,
+                                  `IMG_HEIGHT` varchar(255) NOT NULL,
+                                  `IMG_HREF` varchar(255) NOT NULL,
+                                  `IMG_ALT` varchar(255) NOT NULL,
+                                  `TEXT` varchar(1000) NOT NULL,
+                                  `TEXT_CLASS` varchar(255) NOT NULL,
+                                  `TEXT_STYLE` varchar(255) NOT NULL,
+                                  `ALIGN` varchar(10) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8545,15 +8605,15 @@ CREATE TABLE `WEBSITE_HEADER` (
 --
 
 CREATE TABLE `WEBSITE_NAVIGATION` (
-  `NAVIGATIONID` int UNSIGNED NOT NULL,
-  `SID` int UNSIGNED NOT NULL,
-  `PAGEID` int UNSIGNED NOT NULL,
-  `TYPE_PAGE` varchar(255) NOT NULL,
-  `CONTROLLER` varchar(255) NOT NULL,
-  `ACTION` varchar(255) NOT NULL,
-  `LABEL` varchar(500) NOT NULL,
-  `PARENT_PAGEID` int UNSIGNED NOT NULL,
-  `PARAMS` text NOT NULL
+                                      `NAVIGATIONID` int UNSIGNED NOT NULL,
+                                      `SID` int UNSIGNED NOT NULL COMMENT 'RVID',
+                                      `PAGEID` int UNSIGNED NOT NULL,
+                                      `TYPE_PAGE` varchar(255) NOT NULL,
+                                      `CONTROLLER` varchar(255) NOT NULL,
+                                      `ACTION` varchar(255) NOT NULL,
+                                      `LABEL` varchar(500) NOT NULL,
+                                      `PARENT_PAGEID` int UNSIGNED NOT NULL,
+                                      `PARAMS` text NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -8563,9 +8623,9 @@ CREATE TABLE `WEBSITE_NAVIGATION` (
 --
 
 CREATE TABLE `WEBSITE_SETTINGS` (
-  `SID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(50) NOT NULL,
-  `VALUE` varchar(1000) NOT NULL
+                                    `SID` int UNSIGNED NOT NULL,
+                                    `SETTING` varchar(50) NOT NULL,
+                                    `VALUE` varchar(1000) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 --
@@ -8582,9 +8642,9 @@ INSERT INTO `WEBSITE_SETTINGS` (`SID`, `SETTING`, `VALUE`) VALUES
 --
 
 CREATE TABLE `WEBSITE_STYLES` (
-  `RVID` int UNSIGNED NOT NULL,
-  `SETTING` varchar(50) NOT NULL,
-  `VALUE` varchar(1000) NOT NULL
+                                  `RVID` int UNSIGNED NOT NULL,
+                                  `SETTING` varchar(50) NOT NULL,
+                                  `VALUE` varchar(1000) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 --
@@ -8595,478 +8655,491 @@ CREATE TABLE `WEBSITE_STYLES` (
 -- Indexes for table `authors`
 --
 ALTER TABLE `authors`
-  ADD PRIMARY KEY (`idauthors`),
-  ADD KEY `paperid` (`paperid`);
+    ADD PRIMARY KEY (`idauthors`),
+    ADD KEY `paperid` (`paperid`);
 
 --
 -- Indexes for table `classification_jel`
 --
 ALTER TABLE `classification_jel`
-  ADD PRIMARY KEY (`code`);
+    ADD PRIMARY KEY (`code`);
 
 --
 -- Indexes for table `classification_msc2020`
 --
 ALTER TABLE `classification_msc2020`
-  ADD PRIMARY KEY (`code`);
+    ADD PRIMARY KEY (`code`);
 
 --
 -- Indexes for table `data_descriptor`
 --
 ALTER TABLE `data_descriptor`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `docid` (`docid`),
-  ADD KEY `fileid` (`fileid`),
-  ADD KEY `version` (`version`),
-  ADD KEY `submission_date` (`submission_date`),
-  ADD KEY `INDEX_UID` (`uid`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `docid` (`docid`),
+    ADD KEY `fileid` (`fileid`),
+    ADD KEY `version` (`version`),
+    ADD KEY `submission_date` (`submission_date`),
+    ADD KEY `INDEX_UID` (`uid`);
 
 --
 -- Indexes for table `doi_queue`
 --
 ALTER TABLE `doi_queue`
-  ADD PRIMARY KEY (`id_doi_queue`),
-  ADD UNIQUE KEY `paperid` (`paperid`),
-  ADD KEY `doi_status` (`doi_status`);
+    ADD PRIMARY KEY (`id_doi_queue`),
+    ADD UNIQUE KEY `paperid` (`paperid`),
+    ADD KEY `doi_status` (`doi_status`);
 
 --
 -- Indexes for table `doi_queue_volumes`
 --
 ALTER TABLE `doi_queue_volumes`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `uniq_vid` (`vid`) USING BTREE,
-  ADD KEY `vid` (`vid`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `uniq_vid` (`vid`) USING BTREE,
+    ADD KEY `vid` (`vid`);
 
 --
 -- Indexes for table `files`
 --
 ALTER TABLE `files`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `INDEX_DOCID` (`docid`),
-  ADD KEY `INDEX_SOURCE` (`source`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `INDEX_DOCID` (`docid`),
+    ADD KEY `INDEX_SOURCE` (`source`);
+
+--
+-- Indexes for table `mailing_lists`
+--
+ALTER TABLE `mailing_lists`
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `name_unique` (`name`),
+    ADD KEY `rvid` (`rvid`);
+
+--
+-- Indexes for table `mailing_list_roles`
+--
+ALTER TABLE `mailing_list_roles`
+    ADD PRIMARY KEY (`list_id`,`role`);
+
+--
+-- Indexes for table `mailing_list_users`
+--
+ALTER TABLE `mailing_list_users`
+    ADD PRIMARY KEY (`list_id`,`uid`);
 
 --
 -- Indexes for table `MAIL_LOG`
 --
 ALTER TABLE `MAIL_LOG`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `WHEN` (`WHEN`),
-  ADD KEY `UID` (`UID`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `DOCID` (`DOCID`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `idx_rvid_when` (`RVID`,`WHEN`);
 
 --
 -- Indexes for table `MAIL_TEMPLATE`
 --
 ALTER TABLE `MAIL_TEMPLATE`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `KEY` (`KEY`),
-  ADD KEY `RVCODE` (`RVCODE`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `PARENTID` (`PARENTID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `KEY` (`KEY`),
+    ADD KEY `RVCODE` (`RVCODE`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `PARENTID` (`PARENTID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `metadata_sources`
 --
 ALTER TABLE `metadata_sources`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `type` (`type`),
-  ADD KEY `type_2` (`type`);
-
---
--- Indexes for table `NEWS`
---
-ALTER TABLE `NEWS`
-  ADD PRIMARY KEY (`NEWSID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `ONLINE` (`ONLINE`),
-  ADD KEY `DATE_POST` (`DATE_POST`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `type` (`type`);
 
 --
 -- Indexes for table `news`
 --
 ALTER TABLE `news`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `uid` (`uid`),
-  ADD KEY `code` (`code`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `uid` (`uid`),
+    ADD KEY `code` (`code`);
+
+--
+-- Indexes for table `NEWS`
+--
+ALTER TABLE `NEWS`
+    ADD PRIMARY KEY (`NEWSID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `ONLINE` (`ONLINE`),
+    ADD KEY `DATE_POST` (`DATE_POST`);
 
 --
 -- Indexes for table `pages`
 --
 ALTER TABLE `pages`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `uid` (`uid`),
-  ADD KEY `rvcode` (`code`) USING BTREE,
-  ADD KEY `page_code` (`page_code`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `uid` (`uid`),
+    ADD KEY `rvcode` (`code`) USING BTREE,
+    ADD KEY `page_code` (`page_code`);
 
 --
 -- Indexes for table `PAPERS`
 --
 ALTER TABLE `PAPERS`
-  ADD PRIMARY KEY (`DOCID`),
-  ADD KEY `FK_CONFID_idx` (`RVID`),
-  ADD KEY `FK_REPOID_idx` (`REPOID`),
-  ADD KEY `FK_VID_idx` (`VID`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `PAPERID` (`PAPERID`),
-  ADD KEY `SID` (`SID`),
-  ADD KEY `UID` (`UID`),
-  ADD KEY `FLAG` (`FLAG`),
-  ADD KEY `FLAG_2` (`FLAG`),
-  ADD KEY `DOI` (`DOI`);
-ALTER TABLE `PAPERS` ADD FULLTEXT KEY `RECORD` (`RECORD`);
+    ADD PRIMARY KEY (`DOCID`),
+    ADD KEY `FK_REPOID_idx` (`REPOID`),
+    ADD KEY `FK_VID_idx` (`VID`),
+    ADD KEY `FK_RVID_idx` (`RVID`),
+    ADD KEY `STATUS` (`STATUS`),
+    ADD KEY `PAPERID` (`PAPERID`),
+    ADD KEY `SID` (`SID`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `SUBMISSION_DATE` (`SUBMISSION_DATE`),
+    ADD KEY `PUBLICATION_DATE` (`PUBLICATION_DATE`),
+    ADD KEY `FLAG` (`FLAG`),
+    ADD KEY `DOI` (`DOI`),
+    ADD KEY `idx_identifier` (`IDENTIFIER`),
+    ADD KEY `idx_concept_identifier` (`CONCEPT_IDENTIFIER`);
 
 --
 -- Indexes for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `source_id_2` (`source_id`,`docid`),
-  ADD KEY `docid` (`docid`),
-  ADD KEY `source_id` (`source_id`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `source_id_2` (`source_id`,`docid`),
+    ADD KEY `docid` (`docid`),
+    ADD KEY `source_id` (`source_id`);
 
 --
 -- Indexes for table `paper_classifications`
 --
 ALTER TABLE `paper_classifications`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `uniqClassification` (`docid`,`classification_code`,`classification_name`),
-  ADD KEY `source_id` (`source_id`),
-  ADD KEY `docid` (`docid`),
-  ADD KEY `classification_code` (`classification_code`),
-  ADD KEY `classification_name` (`classification_name`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `uniqClassification` (`docid`,`classification_code`,`classification_name`),
+    ADD KEY `source_id` (`source_id`),
+    ADD KEY `classification_code` (`classification_code`),
+    ADD KEY `classification_name` (`classification_name`);
 
 --
 -- Indexes for table `PAPER_COMMENTS`
 --
 ALTER TABLE `PAPER_COMMENTS`
-  ADD PRIMARY KEY (`PCID`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `TYPE` (`TYPE`),
-  ADD KEY `UID` (`UID`),
-  ADD KEY `DEADLINE` (`DEADLINE`),
-  ADD KEY `WHEN` (`WHEN`),
-  ADD KEY `PARENTID` (`PARENTID`);
+    ADD PRIMARY KEY (`PCID`),
+    ADD KEY `DOCID` (`DOCID`),
+    ADD KEY `TYPE` (`TYPE`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `DEADLINE` (`DEADLINE`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `PARENTID` (`PARENTID`);
 
 --
 -- Indexes for table `paper_conflicts`
 --
 ALTER TABLE `paper_conflicts`
-  ADD PRIMARY KEY (`cid`),
-  ADD UNIQUE KEY `U_PAPERID_BY` (`paper_id`,`by`) USING BTREE,
-  ADD KEY `BY_UID` (`by`),
-  ADD KEY `PAPERID` (`paper_id`),
-  ADD KEY `answer` (`answer`);
+    ADD PRIMARY KEY (`cid`),
+    ADD UNIQUE KEY `U_PAPERID_BY` (`paper_id`,`by`) USING BTREE,
+    ADD KEY `BY_UID` (`by`),
+    ADD KEY `answer` (`answer`);
 
 --
 -- Indexes for table `paper_datasets`
 --
 ALTER TABLE `paper_datasets`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `unique` (`doc_id`,`code`(15),`name`(35),`value`(47),`source_id`),
-  ADD KEY `doc_id` (`doc_id`),
-  ADD KEY `source_id` (`source_id`),
-  ADD KEY `code` (`code`(15)),
-  ADD KEY `name` (`name`(35)),
-  ADD KEY `id_paper_datasets_meta` (`id_paper_datasets_meta`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `unique` (`doc_id`,`code`(15),`name`(35),`value`(47),`source_id`),
+    ADD KEY `source_id` (`source_id`),
+    ADD KEY `code` (`code`(15)),
+    ADD KEY `name` (`name`(35)),
+    ADD KEY `id_paper_datasets_meta` (`id_paper_datasets_meta`);
 
 --
 -- Indexes for table `paper_datasets_meta`
 --
 ALTER TABLE `paper_datasets_meta`
-  ADD PRIMARY KEY (`id`);
+    ADD PRIMARY KEY (`id`);
 
 --
 -- Indexes for table `paper_files`
 --
 ALTER TABLE `paper_files`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `doc_id` (`doc_id`),
-  ADD KEY `source` (`source`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `doc_id` (`doc_id`),
+    ADD KEY `source` (`source`);
 
 --
 -- Indexes for table `paper_licences`
 --
 ALTER TABLE `paper_licences`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `unique_docid` (`id`),
-  ADD UNIQUE KEY `docid` (`docid`),
-  ADD KEY `source_id` (`source_id`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `docid` (`docid`),
+    ADD KEY `source_id` (`source_id`);
 
 --
 -- Indexes for table `PAPER_LOG`
 --
 ALTER TABLE `PAPER_LOG`
-  ADD PRIMARY KEY (`LOGID`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `UID` (`UID`),
-  ADD KEY `PAPERID` (`PAPERID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `DATE` (`DATE`),
-  ADD KEY `idx_status` (`status`),
-  ADD KEY `idx_paperid_docid_date_logid` (`PAPERID`,`DOCID`,`DATE`,`LOGID`);
+    ADD PRIMARY KEY (`LOGID`),
+    ADD KEY `fk_T_PAPER_MODIF_T_PAPERS_idx` (`DOCID`),
+    ADD KEY `fk_T_PAPER_MODIF_T_USER_idx` (`UID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `DATE` (`DATE`),
+    ADD KEY `idx_status` (`status`),
+    ADD KEY `ACTION` (`ACTION`),
+    ADD KEY `idx_paperid_docid_date_logid` (`PAPERID`,`DOCID`,`DATE`,`LOGID`);
 
 --
 -- Indexes for table `paper_projects`
 --
 ALTER TABLE `paper_projects`
-  ADD PRIMARY KEY (`idproject`),
-  ADD UNIQUE KEY `paperid` (`paperid`),
-  ADD UNIQUE KEY `paperid_src_uniq` (`paperid`,`source_id`) USING BTREE,
-  ADD KEY `idx_source_id` (`source_id`);
+    ADD PRIMARY KEY (`idproject`),
+    ADD UNIQUE KEY `paperid` (`paperid`),
+    ADD KEY `idx_source_id` (`source_id`);
 
 --
 -- Indexes for table `PAPER_SETTINGS`
 --
 ALTER TABLE `PAPER_SETTINGS`
-  ADD PRIMARY KEY (`PSID`),
-  ADD KEY `SETTING` (`SETTING`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `SETTING_2` (`SETTING`),
-  ADD KEY `DOCID_2` (`DOCID`);
+    ADD PRIMARY KEY (`PSID`),
+    ADD KEY `SETTING` (`SETTING`),
+    ADD KEY `DOCID` (`DOCID`);
 
 --
 -- Indexes for table `PAPER_STAT`
 --
 ALTER TABLE `PAPER_STAT`
-  ADD PRIMARY KEY (`DOCID`,`CONSULT`,`IP`,`HIT`);
+    ADD PRIMARY KEY (`DOCID`,`CONSULT`,`IP`,`HIT`),
+    ADD KEY `CONSULT` (`CONSULT`);
 
 --
 -- Indexes for table `queue_messages`
 --
 ALTER TABLE `queue_messages`
-  ADD PRIMARY KEY (`id`),
-  ADD KEY `idx_status` (`processed`),
-  ADD KEY `idx_timeout` (`timeout`),
-  ADD KEY `idx_created` (`created_at`),
-  ADD KEY `idx_time_status` (`processed`,`created_at`),
-  ADD KEY `idx_ready_messages` (`processed`,`timeout`,`created_at`),
-  ADD KEY `idx_type` (`type`),
-  ADD KEY `idx_rvcode` (`rvcode`);
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `idx_status` (`processed`),
+    ADD KEY `idx_timeout` (`timeout`),
+    ADD KEY `idx_created` (`created_at`),
+    ADD KEY `idx_time_status` (`processed`,`created_at`),
+    ADD KEY `idx_ready_messages` (`processed`,`timeout`,`created_at`),
+    ADD KEY `idx_type` (`type`),
+    ADD KEY `idx_rvcode` (`rvcode`);
 
 --
 -- Indexes for table `refresh_tokens`
 --
 ALTER TABLE `refresh_tokens`
-  ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `UNIQ_9BACE7E16973EC66` (`refreshToken`);
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `UNIQ_9BACE7E16973EC66` (`refreshToken`);
 
 --
 -- Indexes for table `REMINDERS`
 --
 ALTER TABLE `REMINDERS`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `TYPE` (`TYPE`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `TYPE` (`TYPE`);
 
 --
 -- Indexes for table `REVIEW`
 --
 ALTER TABLE `REVIEW`
-  ADD PRIMARY KEY (`RVID`),
-  ADD UNIQUE KEY `U_CODE` (`CODE`);
+    ADD PRIMARY KEY (`RVID`),
+    ADD UNIQUE KEY `U_CODE` (`CODE`),
+    ADD KEY `STATUS` (`STATUS`);
 
 --
 -- Indexes for table `REVIEWER_ALIAS`
 --
 ALTER TABLE `REVIEWER_ALIAS`
-  ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `UID` (`UID`,`DOCID`,`ALIAS`);
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `UNIQUE` (`UID`,`DOCID`,`ALIAS`) USING BTREE;
 
 --
 -- Indexes for table `REVIEWER_POOL`
 --
 ALTER TABLE `REVIEWER_POOL`
-  ADD PRIMARY KEY (`RVID`,`VID`,`UID`);
+    ADD PRIMARY KEY (`RVID`,`VID`,`UID`);
 
 --
 -- Indexes for table `REVIEWER_REPORT`
 --
 ALTER TABLE `REVIEWER_REPORT`
-  ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `UID` (`UID`,`DOCID`),
-  ADD KEY `ONBEHALF_UID` (`ONBEHALF_UID`) USING BTREE;
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `UID` (`UID`,`DOCID`),
+    ADD KEY `ONBEHALF_UID` (`ONBEHALF_UID`) USING BTREE,
+    ADD KEY `idx_docid` (`DOCID`);
 
 --
 -- Indexes for table `REVIEW_SETTING`
 --
 ALTER TABLE `REVIEW_SETTING`
-  ADD PRIMARY KEY (`RVID`,`SETTING`),
-  ADD KEY `FK_CONFIG_idx` (`RVID`);
+    ADD PRIMARY KEY (`RVID`,`SETTING`);
 
 --
 -- Indexes for table `SECTION`
 --
 ALTER TABLE `SECTION`
-  ADD PRIMARY KEY (`SID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD PRIMARY KEY (`SID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `SECTION_SETTING`
 --
 ALTER TABLE `SECTION_SETTING`
-  ADD PRIMARY KEY (`SID`,`SETTING`);
+    ADD PRIMARY KEY (`SID`,`SETTING`);
 
 --
 -- Indexes for table `STAT_PROCESSING_LOG`
 --
 ALTER TABLE `STAT_PROCESSING_LOG`
-  ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `unique_journal_date` (`JOURNAL_CODE`,`PROCESSED_DATE`),
-  ADD KEY `idx_journal_code` (`JOURNAL_CODE`),
-  ADD KEY `idx_processed_date` (`PROCESSED_DATE`),
-  ADD KEY `idx_processed_at` (`PROCESSED_AT`);
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `unique_journal_date` (`JOURNAL_CODE`,`PROCESSED_DATE`),
+    ADD KEY `idx_processed_date` (`PROCESSED_DATE`),
+    ADD KEY `idx_processed_at` (`PROCESSED_AT`);
 
 --
 -- Indexes for table `STAT_TEMP`
 --
 ALTER TABLE `STAT_TEMP`
-  ADD PRIMARY KEY (`VISITID`),
-  ADD KEY `DOCID` (`DOCID`);
+    ADD PRIMARY KEY (`VISITID`),
+    ADD KEY `DOCID` (`DOCID`);
 
 --
 -- Indexes for table `USER`
 --
 ALTER TABLE `USER`
-  ADD PRIMARY KEY (`UID`),
-  ADD UNIQUE KEY `U_USERNAME` (`USERNAME`),
-  ADD UNIQUE KEY `uuid` (`uuid`),
-  ADD KEY `IS_VALID` (`IS_VALID`),
-  ADD KEY `LASTNAME` (`LASTNAME`),
-  ADD KEY `FIRSTNAME` (`FIRSTNAME`),
-  ADD KEY `API_PASSWORD` (`API_PASSWORD`),
-  ADD KEY `SCREEN_NAME` (`SCREEN_NAME`);
+    ADD PRIMARY KEY (`UID`),
+    ADD UNIQUE KEY `U_USERNAME` (`USERNAME`),
+    ADD UNIQUE KEY `uuid` (`uuid`),
+    ADD KEY `IS_VALID` (`IS_VALID`),
+    ADD KEY `SCREEN_NAME` (`SCREEN_NAME`),
+    ADD KEY `EMAIL` (`EMAIL`(255)),
+    ADD KEY `REGISTRATION_DATE` (`REGISTRATION_DATE`);
 
 --
 -- Indexes for table `USER_ASSIGNMENT`
 --
 ALTER TABLE `USER_ASSIGNMENT`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `FK_DOCID_idx` (`ITEMID`),
-  ADD KEY `FK_UID_idx` (`UID`),
-  ADD KEY `ITEM` (`ITEM`),
-  ADD KEY `ROLEID` (`ROLEID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `WHEN` (`WHEN`),
-  ADD KEY `TMP_USER` (`TMP_USER`),
-  ADD KEY `INVITATION_ID` (`INVITATION_ID`),
-  ADD KEY `TMP_USER_2` (`TMP_USER`),
-  ADD KEY `LINKED_FROM` (`FROM_UID`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `FK_ITEMID_idx` (`ITEMID`),
+    ADD KEY `FK_UID_idx` (`UID`),
+    ADD KEY `ITEM` (`ITEM`),
+    ADD KEY `ROLEID` (`ROLEID`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `TMP_USER` (`TMP_USER`),
+    ADD KEY `INVITATION_ID` (`INVITATION_ID`),
+    ADD KEY `LINKED_FROM` (`FROM_UID`),
+    ADD KEY `idx_rvid_roleid` (`RVID`,`ROLEID`);
 
 --
 -- Indexes for table `USER_INVITATION`
 --
 ALTER TABLE `USER_INVITATION`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `TOKEN` (`TOKEN`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `SENDER_UID` (`SENDER_UID`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `SENDER_UID` (`SENDER_UID`),
+    ADD KEY `AID_SENDING_DATE` (`AID`,`SENDING_DATE`);
 
 --
 -- Indexes for table `USER_INVITATION_ANSWER`
 --
 ALTER TABLE `USER_INVITATION_ANSWER`
-  ADD PRIMARY KEY (`ID_UIA`),
-  ADD UNIQUE KEY `U_ID` (`ID`) USING BTREE;
+    ADD PRIMARY KEY (`ID_UIA`),
+    ADD UNIQUE KEY `U_ID` (`ID`);
 
 --
 -- Indexes for table `USER_INVITATION_ANSWER_DETAIL`
 --
 ALTER TABLE `USER_INVITATION_ANSWER_DETAIL`
-  ADD PRIMARY KEY (`ID_UIAD`),
-  ADD UNIQUE KEY `U_ID_NAME` (`ID`,`NAME`);
+    ADD PRIMARY KEY (`ID_UIAD`),
+    ADD UNIQUE KEY `U_ID_NAME` (`ID`,`NAME`);
 
 --
 -- Indexes for table `USER_MERGE`
 --
 ALTER TABLE `USER_MERGE`
-  ADD PRIMARY KEY (`MID`);
+    ADD PRIMARY KEY (`MID`);
 
 --
 -- Indexes for table `USER_ROLES`
 --
 ALTER TABLE `USER_ROLES`
-  ADD PRIMARY KEY (`UID`,`RVID`,`ROLEID`);
+    ADD PRIMARY KEY (`UID`,`RVID`,`ROLEID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `ROLEID` (`ROLEID`);
 
 --
 -- Indexes for table `USER_TMP`
 --
 ALTER TABLE `USER_TMP`
-  ADD PRIMARY KEY (`ID`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `EMAIL` (`EMAIL`(150));
 
 --
 -- Indexes for table `VOLUME`
 --
 ALTER TABLE `VOLUME`
-  ADD PRIMARY KEY (`VID`),
-  ADD KEY `FK_CONFID_idx` (`RVID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD PRIMARY KEY (`VID`),
+    ADD KEY `FK_CONFID_idx` (`RVID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `VOLUME_METADATA`
 --
 ALTER TABLE `VOLUME_METADATA`
-  ADD PRIMARY KEY (`ID`),
-  ADD KEY `VID` (`VID`);
+    ADD PRIMARY KEY (`ID`),
+    ADD KEY `VID` (`VID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `VOLUME_PAPER`
 --
 ALTER TABLE `VOLUME_PAPER`
-  ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `UNIQUE` (`VID`,`DOCID`) USING BTREE;
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `UNIQUE` (`VID`,`DOCID`) USING BTREE;
 
 --
 -- Indexes for table `VOLUME_PAPER_POSITION`
 --
 ALTER TABLE `VOLUME_PAPER_POSITION`
-  ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `VID` (`VID`,`PAPERID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `VID` (`VID`,`PAPERID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `volume_proceeding`
 --
 ALTER TABLE `volume_proceeding`
-  ADD PRIMARY KEY (`VID`,`SETTING`),
-  ADD KEY `FK_RVID0_idx` (`VID`);
+    ADD PRIMARY KEY (`VID`,`SETTING`);
 
 --
 -- Indexes for table `VOLUME_SETTING`
 --
 ALTER TABLE `VOLUME_SETTING`
-  ADD PRIMARY KEY (`VID`,`SETTING`),
-  ADD KEY `FK_RVID0_idx` (`VID`);
+    ADD PRIMARY KEY (`VID`,`SETTING`);
 
 --
 -- Indexes for table `WEBSITE_HEADER`
 --
 ALTER TABLE `WEBSITE_HEADER`
-  ADD PRIMARY KEY (`LOGOID`,`RVID`);
+    ADD PRIMARY KEY (`LOGOID`,`RVID`);
 
 --
 -- Indexes for table `WEBSITE_NAVIGATION`
 --
 ALTER TABLE `WEBSITE_NAVIGATION`
-  ADD PRIMARY KEY (`NAVIGATIONID`),
-  ADD KEY `SID` (`SID`),
-  ADD KEY `TYPE_PAGE` (`TYPE_PAGE`),
-  ADD KEY `PARENT_PAGEID` (`PARENT_PAGEID`);
+    ADD PRIMARY KEY (`NAVIGATIONID`),
+    ADD KEY `SID` (`SID`),
+    ADD KEY `TYPE_PAGE` (`TYPE_PAGE`),
+    ADD KEY `PARENT_PAGEID` (`PARENT_PAGEID`);
 
 --
 -- Indexes for table `WEBSITE_SETTINGS`
 --
 ALTER TABLE `WEBSITE_SETTINGS`
-  ADD PRIMARY KEY (`SID`,`SETTING`);
+    ADD PRIMARY KEY (`SID`,`SETTING`);
 
 --
 -- Indexes for table `WEBSITE_STYLES`
 --
 ALTER TABLE `WEBSITE_STYLES`
-  ADD PRIMARY KEY (`RVID`,`SETTING`);
+    ADD PRIMARY KEY (`RVID`,`SETTING`);
 
 --
 -- AUTO_INCREMENT for dumped tables
@@ -9076,294 +9149,334 @@ ALTER TABLE `WEBSITE_STYLES`
 -- AUTO_INCREMENT for table `authors`
 --
 ALTER TABLE `authors`
-  MODIFY `idauthors` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `idauthors` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `data_descriptor`
 --
 ALTER TABLE `data_descriptor`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `doi_queue`
 --
 ALTER TABLE `doi_queue`
-  MODIFY `id_doi_queue` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id_doi_queue` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `doi_queue_volumes`
 --
 ALTER TABLE `doi_queue_volumes`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `files`
 --
 ALTER TABLE `files`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `mailing_lists`
+--
+ALTER TABLE `mailing_lists`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `MAIL_LOG`
 --
 ALTER TABLE `MAIL_LOG`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `MAIL_TEMPLATE`
 --
 ALTER TABLE `MAIL_TEMPLATE`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=565;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `metadata_sources`
 --
 ALTER TABLE `metadata_sources`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=39;
-
---
--- AUTO_INCREMENT for table `NEWS`
---
-ALTER TABLE `NEWS`
-  MODIFY `NEWSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `news`
 --
 ALTER TABLE `news`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `NEWS`
+--
+ALTER TABLE `NEWS`
+    MODIFY `NEWSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `pages`
 --
 ALTER TABLE `pages`
-  MODIFY `id` int NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `PAPERS`
 --
 ALTER TABLE `PAPERS`
-  MODIFY `DOCID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `DOCID` int UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Unique Identifier for each submission';
 
 --
 -- AUTO_INCREMENT for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_classifications`
 --
 ALTER TABLE `paper_classifications`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `PAPER_COMMENTS`
 --
 ALTER TABLE `PAPER_COMMENTS`
-  MODIFY `PCID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `PCID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_conflicts`
 --
 ALTER TABLE `paper_conflicts`
-  MODIFY `cid` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `cid` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_datasets`
 --
 ALTER TABLE `paper_datasets`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_datasets_meta`
 --
 ALTER TABLE `paper_datasets_meta`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_files`
 --
 ALTER TABLE `paper_files`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_licences`
 --
 ALTER TABLE `paper_licences`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `PAPER_LOG`
 --
 ALTER TABLE `PAPER_LOG`
-  MODIFY `LOGID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `LOGID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `paper_projects`
 --
 ALTER TABLE `paper_projects`
-  MODIFY `idproject` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `idproject` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `PAPER_SETTINGS`
 --
 ALTER TABLE `PAPER_SETTINGS`
-  MODIFY `PSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `PSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `queue_messages`
 --
 ALTER TABLE `queue_messages`
-  MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `refresh_tokens`
 --
 ALTER TABLE `refresh_tokens`
-  MODIFY `id` int NOT NULL AUTO_INCREMENT;
+    MODIFY `id` int NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `REMINDERS`
 --
 ALTER TABLE `REMINDERS`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `REVIEW`
 --
 ALTER TABLE `REVIEW`
-  MODIFY `RVID` int UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+    MODIFY `RVID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `REVIEWER_ALIAS`
 --
 ALTER TABLE `REVIEWER_ALIAS`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `REVIEWER_REPORT`
 --
 ALTER TABLE `REVIEWER_REPORT`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `SECTION`
 --
 ALTER TABLE `SECTION`
-  MODIFY `SID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `SID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `STAT_PROCESSING_LOG`
 --
 ALTER TABLE `STAT_PROCESSING_LOG`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `STAT_TEMP`
 --
 ALTER TABLE `STAT_TEMP`
-  MODIFY `VISITID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `VISITID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER`
 --
 ALTER TABLE `USER`
-  MODIFY `UID` int UNSIGNED NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=5;
+    MODIFY `UID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_ASSIGNMENT`
 --
 ALTER TABLE `USER_ASSIGNMENT`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_INVITATION`
 --
 ALTER TABLE `USER_INVITATION`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_INVITATION_ANSWER`
 --
 ALTER TABLE `USER_INVITATION_ANSWER`
-  MODIFY `ID_UIA` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID_UIA` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_INVITATION_ANSWER_DETAIL`
 --
 ALTER TABLE `USER_INVITATION_ANSWER_DETAIL`
-  MODIFY `ID_UIAD` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID_UIAD` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_MERGE`
 --
 ALTER TABLE `USER_MERGE`
-  MODIFY `MID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `MID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_TMP`
 --
 ALTER TABLE `USER_TMP`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `VOLUME`
 --
 ALTER TABLE `VOLUME`
-  MODIFY `VID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `VID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `VOLUME_METADATA`
 --
 ALTER TABLE `VOLUME_METADATA`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `VOLUME_PAPER`
 --
 ALTER TABLE `VOLUME_PAPER`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `VOLUME_PAPER_POSITION`
 --
 ALTER TABLE `VOLUME_PAPER_POSITION`
-  MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `WEBSITE_HEADER`
 --
 ALTER TABLE `WEBSITE_HEADER`
-  MODIFY `LOGOID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `LOGOID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `WEBSITE_NAVIGATION`
 --
 ALTER TABLE `WEBSITE_NAVIGATION`
-  MODIFY `NAVIGATIONID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+    MODIFY `NAVIGATIONID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+-- --------------------------------------------------------
+
+--
+-- Structure for view `v_mailing_lists_resolved`
+--
+DROP TABLE IF EXISTS `v_mailing_lists_resolved`;
+
+CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_mailing_lists_resolved`  AS WITH   `list_members_data` as (select `ml`.`id` AS `list_id`,`u`.`UID` AS `UID`,`u`.`FIRSTNAME` AS `FIRSTNAME`,`u`.`LASTNAME` AS `LASTNAME`,`u`.`EMAIL` AS `EMAIL` from ((`mailing_lists` `ml` join (select `mailing_list_users`.`list_id` AS `list_id`,`mailing_list_users`.`uid` AS `uid` from `mailing_list_users` union select `mlr`.`list_id` AS `list_id`,`ur`.`UID` AS `uid` from ((`mailing_list_roles` `mlr` join `mailing_lists` `ml_inner` on((`ml_inner`.`id` = `mlr`.`list_id`))) join `USER_ROLES` `ur` on(((`ur`.`ROLEID` = `mlr`.`role`) and (`ur`.`RVID` = `ml_inner`.`rvid`))))) `lm` on((`ml`.`id` = `lm`.`list_id`))) join `USER` `u` on((`lm`.`uid` = `u`.`UID`))) where (`u`.`IS_VALID` = 1)) select `ml`.`id` AS `list_id`,`ml`.`rvid` AS `journal_id`,`ml`.`name` AS `list_name`,`ml`.`type` AS `list_type`,if((`ml`.`status` = 1),'open','closed') AS `list_status`,if((count(`lmd`.`UID`) = 0),json_array(),json_arrayagg(json_object('firstname',`lmd`.`FIRSTNAME`,'lastname',`lmd`.`LASTNAME`,'email',`lmd`.`EMAIL`))) AS `members` from (`mailing_lists` `ml` left join `list_members_data` `lmd` on((`ml`.`id` = `lmd`.`list_id`))) group by `ml`.`id`,`ml`.`rvid`,`ml`.`name`,`ml`.`type`,`ml`.`status`  ;
 
 --
 -- Constraints for dumped tables
 --
 
 --
+-- Constraints for table `data_descriptor`
+--
+ALTER TABLE `data_descriptor`
+    ADD CONSTRAINT `FK_DD_FILES` FOREIGN KEY (`fileid`) REFERENCES `files` (`id`) ON DELETE CASCADE;
+
+--
 -- Constraints for table `doi_queue_volumes`
 --
 ALTER TABLE `doi_queue_volumes`
-  ADD CONSTRAINT `doi_queue_volumes_ibfk_1` FOREIGN KEY (`vid`) REFERENCES `VOLUME` (`VID`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+    ADD CONSTRAINT `doi_queue_volumes_ibfk_1` FOREIGN KEY (`vid`) REFERENCES `VOLUME` (`VID`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Constraints for table `mailing_list_roles`
+--
+ALTER TABLE `mailing_list_roles`
+    ADD CONSTRAINT `fk_mlr_list_id` FOREIGN KEY (`list_id`) REFERENCES `mailing_lists` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `mailing_list_users`
+--
+ALTER TABLE `mailing_list_users`
+    ADD CONSTRAINT `fk_mlu_list_id` FOREIGN KEY (`list_id`) REFERENCES `mailing_lists` (`id`) ON DELETE CASCADE;
 
 --
 -- Constraints for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
-  ADD CONSTRAINT `paper_citations_ibfk_1` FOREIGN KEY (`docid`) REFERENCES `PAPERS` (`DOCID`) ON DELETE RESTRICT ON UPDATE RESTRICT,
-  ADD CONSTRAINT `paper_citations_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT;
+    ADD CONSTRAINT `paper_citations_ibfk_1` FOREIGN KEY (`docid`) REFERENCES `PAPERS` (`DOCID`),
+    ADD CONSTRAINT `paper_citations_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 
 --
 -- Constraints for table `paper_datasets`
 --
 ALTER TABLE `paper_datasets`
-  ADD CONSTRAINT `deleteAssocMeta` FOREIGN KEY (`id_paper_datasets_meta`) REFERENCES `paper_datasets_meta` (`id`) ON DELETE CASCADE;
+    ADD CONSTRAINT `deleteAssocMeta` FOREIGN KEY (`id_paper_datasets_meta`) REFERENCES `paper_datasets_meta` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `paper_projects`
+--
+ALTER TABLE `paper_projects`
+    ADD CONSTRAINT `paper_projects_ibfk_1` FOREIGN KEY (`paperid`) REFERENCES `PAPERS` (`PAPERID`),
+    ADD CONSTRAINT `paper_projects_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/src/mysql/docker/episciences/episciences.sql
+++ b/src/mysql/docker/episciences/episciences.sql
@@ -1776,7 +1776,6 @@ ALTER TABLE `paper_datasets`
 -- Constraints for table `paper_projects`
 --
 ALTER TABLE `paper_projects`
-    ADD CONSTRAINT `paper_projects_ibfk_1` FOREIGN KEY (`paperid`) REFERENCES `PAPERS` (`PAPERID`),
     ADD CONSTRAINT `paper_projects_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 COMMIT;
 

--- a/src/mysql/docker/episciences/episciences.sql
+++ b/src/mysql/docker/episciences/episciences.sql
@@ -1,6 +1,5 @@
--- Generation Time: Jun 13, 2024 at 04:01 PM
--- Server version: 8.0.29
-
+-- Generation Time: Jul 12, 2026 at 08:51 PM
+-- Server version: 8.0.*
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 START TRANSACTION;
 SET time_zone = "+00:00";
@@ -27,6 +26,44 @@ CREATE TABLE `authors` (
                            `paperid` int UNSIGNED NOT NULL,
                            `date_updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `classification_jel`
+--
+
+CREATE TABLE `classification_jel` (
+                                      `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                      `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `classification_msc2020`
+--
+
+CREATE TABLE `classification_msc2020` (
+                                          `code` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                          `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                          `description` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `data_descriptor`
+--
+
+CREATE TABLE `data_descriptor` (
+                                   `id` int UNSIGNED NOT NULL,
+                                   `uid` int UNSIGNED NOT NULL,
+                                   `docid` int UNSIGNED NOT NULL,
+                                   `fileid` int UNSIGNED NOT NULL,
+                                   `version` float UNSIGNED NOT NULL DEFAULT '1',
+                                   `submission_date` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
 
@@ -59,11 +96,66 @@ CREATE TABLE `doi_queue_volumes` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `files`
+--
+
+CREATE TABLE `files` (
+                         `id` int UNSIGNED NOT NULL,
+                         `docid` int UNSIGNED NOT NULL,
+                         `name` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `extension` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `type_mime` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `size` bigint UNSIGNED NOT NULL,
+                         `md5` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                         `source` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'dd',
+                         `uploaded_date` datetime NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_lists`
+--
+
+CREATE TABLE `mailing_lists` (
+                                 `id` int UNSIGNED NOT NULL,
+                                 `rvid` int UNSIGNED NOT NULL,
+                                 `name` varchar(255) NOT NULL,
+                                 `type` varchar(50) DEFAULT NULL,
+                                 `status` tinyint NOT NULL DEFAULT '1'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_list_roles`
+--
+
+CREATE TABLE `mailing_list_roles` (
+                                      `list_id` int UNSIGNED NOT NULL,
+                                      `role` varchar(50) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `mailing_list_users`
+--
+
+CREATE TABLE `mailing_list_users` (
+                                      `list_id` int UNSIGNED NOT NULL,
+                                      `uid` int UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `MAIL_LOG`
 --
 
 CREATE TABLE `MAIL_LOG` (
                             `ID` int UNSIGNED NOT NULL,
+                            `UID` int UNSIGNED DEFAULT NULL COMMENT 'Sender identifier (via the mailing module or the article page)',
                             `RVID` int UNSIGNED NOT NULL,
                             `DOCID` int UNSIGNED DEFAULT NULL,
                             `FROM` varchar(250) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL,
@@ -102,7 +194,7 @@ CREATE TABLE `MAIL_TEMPLATE` (
 CREATE TABLE `metadata_sources` (
                                     `id` int UNSIGNED NOT NULL,
                                     `name` varchar(255) NOT NULL,
-                                    `type` enum('repository','metadataRepository','dataverse','user') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
+                                    `type` enum('repository','metadataRepository','dataverse','dspace','user') CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
                                     `status` tinyint(1) NOT NULL DEFAULT '1' COMMENT 'enabled by default',
                                     `identifier` varchar(50) DEFAULT NULL COMMENT 'OAI identifier',
                                     `base_url` varchar(100) DEFAULT NULL COMMENT 'OAI base url',
@@ -111,6 +203,25 @@ CREATE TABLE `metadata_sources` (
                                     `doc_url` varchar(150) NOT NULL COMMENT 'See the document''s page on',
                                     `paper_url` varchar(100) NOT NULL COMMENT 'PDF'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `news`
+--
+
+CREATE TABLE `news` (
+                        `id` int UNSIGNED NOT NULL,
+                        `legacy_id` int UNSIGNED DEFAULT NULL COMMENT 'Legacy News id',
+                        `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
+                        `uid` int UNSIGNED NOT NULL,
+                        `date_creation` datetime DEFAULT NULL,
+                        `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                        `title` json NOT NULL COMMENT 'Page title',
+                        `content` json DEFAULT NULL,
+                        `link` json DEFAULT NULL,
+                        `visibility` json NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -130,25 +241,44 @@ CREATE TABLE `NEWS` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `pages`
+--
+
+CREATE TABLE `pages` (
+                         `id` int NOT NULL,
+                         `code` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Journal code rvcode',
+                         `uid` int UNSIGNED NOT NULL,
+                         `date_creation` datetime DEFAULT NULL,
+                         `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                         `title` json NOT NULL COMMENT 'Page title',
+                         `content` json NOT NULL,
+                         `visibility` json NOT NULL,
+                         `page_code` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Page code'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `PAPERS`
 --
 
 CREATE TABLE `PAPERS` (
                           `DOCID` int UNSIGNED NOT NULL COMMENT 'Unique Identifier for each submission',
                           `PAPERID` int UNSIGNED DEFAULT NULL COMMENT 'Common Identifier for several versions of a paper',
-                          `DOI` varchar(250) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL COMMENT 'PID of accepted and published papers',
-                          `TYPE` json DEFAULT NULL,
+                          `DOI` varchar(250) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL COMMENT 'PID of accepted and published papers',
                           `RVID` int UNSIGNED NOT NULL COMMENT 'Link to Journal ID',
                           `VID` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Link to Volume ID',
                           `SID` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Link to Section ID',
                           `UID` int UNSIGNED NOT NULL COMMENT 'Link to User ID',
                           `STATUS` int UNSIGNED NOT NULL DEFAULT '0' COMMENT 'Status of the submission',
-                          `IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL COMMENT 'Open Repository Identifier',
+                          `IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL COMMENT 'Open Repository Identifier',
                           `VERSION` float UNSIGNED NOT NULL DEFAULT '1' COMMENT 'Version identifier of a submission',
                           `REPOID` int UNSIGNED NOT NULL COMMENT 'Link to Repository ID',
-                          `RECORD` text CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL COMMENT 'Text of Metadata Record from Open repository ',
-                          `CONCEPT_IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8_general_ci DEFAULT NULL COMMENT 'Zenodo ID This identifier represents all versions',
-                          `FLAG` enum('submitted','imported') CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL DEFAULT 'submitted' COMMENT 'Submission source',
+                          `TYPE` json DEFAULT NULL,
+                          `RECORD` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL COMMENT 'Text of Metadata Record from Open repository ',
+                          `DOCUMENT` json DEFAULT NULL,
+                          `CONCEPT_IDENTIFIER` varchar(500) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL COMMENT 'Zenodo ID This identifier represents all versions',
+                          `FLAG` enum('submitted','imported') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'submitted' COMMENT 'Submission source',
                           `PASSWORD` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci COMMENT 'Encrypted temporary password for sharing arXiv submissions',
                           `WHEN` datetime NOT NULL COMMENT 'Timestamp of insertion in database',
                           `SUBMISSION_DATE` datetime NOT NULL COMMENT 'Timestamp of the 1st submission - common to all versions of a Paper',
@@ -178,11 +308,12 @@ CREATE TABLE `paper_citations` (
 
 CREATE TABLE `paper_classifications` (
                                          `id` int UNSIGNED NOT NULL,
-                                         `paperid` int UNSIGNED NOT NULL,
-                                         `classification` varchar(200) NOT NULL,
-                                         `type` varchar(50) NOT NULL,
-                                         `source_id` int UNSIGNED NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+                                         `docid` int UNSIGNED NOT NULL,
+                                         `classification_code` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                         `classification_name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                                         `source_id` int UNSIGNED NOT NULL,
+                                         `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- --------------------------------------------------------
 
@@ -213,7 +344,7 @@ CREATE TABLE `paper_conflicts` (
                                    `cid` int UNSIGNED NOT NULL,
                                    `paper_id` int UNSIGNED NOT NULL,
                                    `by` int UNSIGNED NOT NULL COMMENT 'uid',
-                                   `answer` enum('yes','no') CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL,
+                                   `answer` enum('yes','no') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
                                    `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
                                    `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='conflicts handling';
@@ -295,9 +426,10 @@ CREATE TABLE `PAPER_LOG` (
                              `UID` int UNSIGNED NOT NULL,
                              `RVID` int UNSIGNED NOT NULL,
                              `ACTION` varchar(50) NOT NULL,
-                             `DETAIL` mediumtext,
                              `FILE` varchar(150) DEFAULT NULL,
-                             `DATE` datetime NOT NULL
+                             `DATE` datetime NOT NULL,
+                             `DETAIL` json DEFAULT NULL,
+                             `status` int UNSIGNED GENERATED ALWAYS AS (json_unquote(json_extract(`DETAIL`,_utf8mb4'$.status'))) STORED
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Life of papers';
 
 -- --------------------------------------------------------
@@ -338,12 +470,33 @@ CREATE TABLE `PAPER_STAT` (
                               `CONSULT` enum('notice','file','oai','api') NOT NULL DEFAULT 'notice',
                               `IP` int UNSIGNED NOT NULL,
                               `ROBOT` tinyint UNSIGNED NOT NULL DEFAULT '0',
+                              `AGENT` varchar(2000) DEFAULT NULL,
                               `DOMAIN` varchar(100) DEFAULT NULL,
                               `CONTINENT` varchar(100) DEFAULT NULL,
                               `COUNTRY` varchar(100) DEFAULT NULL,
+                              `CITY` varchar(100) DEFAULT NULL,
+                              `LAT` float DEFAULT NULL,
+                              `LON` float DEFAULT NULL,
                               `HIT` date NOT NULL,
                               `COUNTER` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `queue_messages`
+--
+
+CREATE TABLE `queue_messages` (
+                                  `id` int UNSIGNED NOT NULL,
+                                  `rvcode` varchar(50) NOT NULL,
+                                  `type` varchar(50) NOT NULL DEFAULT '',
+                                  `message` json NOT NULL,
+                                  `created_at` int UNSIGNED NOT NULL,
+                                  `timeout` int UNSIGNED NOT NULL DEFAULT '120',
+                                  `processed` tinyint(1) NOT NULL DEFAULT '0',
+                                  `updated_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC;
 
 -- --------------------------------------------------------
 
@@ -385,9 +538,11 @@ CREATE TABLE `REVIEW` (
                           `RVID` int UNSIGNED NOT NULL,
                           `CODE` varchar(50) NOT NULL,
                           `NAME` varchar(2000) NOT NULL,
+                          `subtitle` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
                           `STATUS` smallint UNSIGNED NOT NULL DEFAULT '0',
                           `CREATION` datetime NOT NULL,
-                          `PIWIKID` int UNSIGNED NOT NULL
+                          `PIWIKID` int UNSIGNED NOT NULL,
+                          `is_new_front_switched` enum('yes','no') NOT NULL DEFAULT 'no'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Basic journal informations';
 
 -- --------------------------------------------------------
@@ -397,6 +552,7 @@ CREATE TABLE `REVIEW` (
 --
 
 CREATE TABLE `REVIEWER_ALIAS` (
+                                  `ID` int UNSIGNED NOT NULL,
                                   `UID` int UNSIGNED NOT NULL,
                                   `DOCID` int UNSIGNED NOT NULL,
                                   `ALIAS` int UNSIGNED NOT NULL
@@ -428,7 +584,7 @@ CREATE TABLE `REVIEWER_REPORT` (
                                    `STATUS` int UNSIGNED NOT NULL,
                                    `CREATION_DATE` datetime NOT NULL,
                                    `UPDATE_DATE` datetime DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -438,8 +594,8 @@ CREATE TABLE `REVIEWER_REPORT` (
 
 CREATE TABLE `REVIEW_SETTING` (
                                   `RVID` int UNSIGNED NOT NULL,
-                                  `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci NOT NULL,
-                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci,
+                                  `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci,
                                   `TIME` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Journal configurations';
 
@@ -455,7 +611,7 @@ CREATE TABLE `SECTION` (
                            `POSITION` int UNSIGNED NOT NULL,
                            `titles` json DEFAULT NULL,
                            `descriptions` json DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -465,9 +621,25 @@ CREATE TABLE `SECTION` (
 
 CREATE TABLE `SECTION_SETTING` (
                                    `SID` int UNSIGNED NOT NULL,
-                                   `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci NOT NULL,
-                                   `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
+                                   `SETTING` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
+                                   `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `STAT_PROCESSING_LOG`
+--
+
+CREATE TABLE `STAT_PROCESSING_LOG` (
+                                       `ID` int UNSIGNED NOT NULL,
+                                       `JOURNAL_CODE` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                       `PROCESSED_DATE` date NOT NULL,
+                                       `PROCESSED_AT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                       `FILE_PATH` varchar(500) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                                       `RECORDS_PROCESSED` int UNSIGNED NOT NULL DEFAULT '0',
+                                       `STATUS` enum('success','error','partial') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'success'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Tracks processed statistics log files to prevent duplicates';
 
 -- --------------------------------------------------------
 
@@ -479,10 +651,10 @@ CREATE TABLE `STAT_TEMP` (
                              `VISITID` int UNSIGNED NOT NULL,
                              `DOCID` int UNSIGNED NOT NULL,
                              `IP` int UNSIGNED NOT NULL,
-                             `HTTP_USER_AGENT` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci NOT NULL,
+                             `HTTP_USER_AGENT` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,
                              `DHIT` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                             `CONSULT` enum('notice','file','oai') CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci NOT NULL DEFAULT 'notice'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci COMMENT='Statistique de consultation journalière temporaire';
+                             `CONSULT` enum('notice','file','oai') CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'notice'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci COMMENT='Statistique de consultation journalière temporaire';
 
 -- --------------------------------------------------------
 
@@ -492,7 +664,8 @@ CREATE TABLE `STAT_TEMP` (
 
 CREATE TABLE `USER` (
                         `UID` int UNSIGNED NOT NULL,
-                        `LANGUEID` varchar(2) CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL DEFAULT 'fr' COMMENT 'Account language code',
+                        `uuid` char(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'Storing As a String',
+                        `LANGUEID` varchar(2) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT 'fr' COMMENT 'Account language code',
                         `SCREEN_NAME` varchar(250) NOT NULL,
                         `USERNAME` varchar(100) NOT NULL,
                         `API_PASSWORD` varchar(255) NOT NULL,
@@ -521,6 +694,7 @@ CREATE TABLE `USER_ASSIGNMENT` (
                                    `ITEMID` int UNSIGNED NOT NULL,
                                    `ITEM` varchar(50) NOT NULL DEFAULT 'paper',
                                    `UID` int UNSIGNED NOT NULL,
+                                   `FROM_UID` int UNSIGNED DEFAULT NULL COMMENT 'Linked from',
                                    `TMP_USER` tinyint UNSIGNED NOT NULL DEFAULT '0',
                                    `ROLEID` varchar(50) NOT NULL,
                                    `STATUS` varchar(20) NOT NULL,
@@ -551,6 +725,7 @@ CREATE TABLE `USER_INVITATION` (
 --
 
 CREATE TABLE `USER_INVITATION_ANSWER` (
+                                          `ID_UIA` int UNSIGNED NOT NULL,
                                           `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
                                           `ANSWER` varchar(10) NOT NULL,
                                           `ANSWER_DATE` datetime NOT NULL
@@ -563,6 +738,7 @@ CREATE TABLE `USER_INVITATION_ANSWER` (
 --
 
 CREATE TABLE `USER_INVITATION_ANSWER_DETAIL` (
+                                                 `ID_UIAD` int UNSIGNED NOT NULL,
                                                  `ID` int UNSIGNED NOT NULL COMMENT 'Invitation ID',
                                                  `NAME` varchar(30) NOT NULL,
                                                  `VALUE` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci
@@ -592,7 +768,8 @@ CREATE TABLE `USER_MERGE` (
 CREATE TABLE `USER_ROLES` (
                               `UID` int UNSIGNED NOT NULL,
                               `RVID` int UNSIGNED NOT NULL DEFAULT '0',
-                              `ROLEID` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8_general_ci NOT NULL
+                              `ROLEID` varchar(50) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,
+                              `IS_AVAILABLE` tinyint UNSIGNED DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
@@ -621,7 +798,10 @@ CREATE TABLE `VOLUME` (
                           `POSITION` int UNSIGNED NOT NULL,
                           `BIB_REFERENCE` varchar(255) DEFAULT NULL COMMENT 'Volume bibliographical reference',
                           `titles` json DEFAULT NULL,
-                          `descriptions` json DEFAULT NULL
+                          `descriptions` json DEFAULT NULL,
+                          `vol_year` varchar(9) DEFAULT NULL,
+                          `vol_type` set('special_issue','proceedings') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+                          `vol_num` varchar(6) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COMMENT='Journal volumes';
 
 -- --------------------------------------------------------
@@ -636,7 +816,9 @@ CREATE TABLE `VOLUME_METADATA` (
                                    `POSITION` int UNSIGNED NOT NULL,
                                    `CONTENT` json DEFAULT NULL COMMENT 'Metadata decsriptions',
                                    `FILE` varchar(250) DEFAULT NULL,
-                                   `titles` json DEFAULT NULL
+                                   `titles` json DEFAULT NULL,
+                                   `date_creation` datetime DEFAULT NULL,
+                                   `date_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 -- --------------------------------------------------------
@@ -649,7 +831,7 @@ CREATE TABLE `VOLUME_PAPER` (
                                 `ID` int UNSIGNED NOT NULL,
                                 `VID` int UNSIGNED NOT NULL,
                                 `DOCID` int UNSIGNED NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 -- --------------------------------------------------------
 
@@ -658,10 +840,23 @@ CREATE TABLE `VOLUME_PAPER` (
 --
 
 CREATE TABLE `VOLUME_PAPER_POSITION` (
+                                         `ID` int UNSIGNED NOT NULL,
                                          `VID` int UNSIGNED NOT NULL,
                                          `PAPERID` int UNSIGNED NOT NULL,
                                          `POSITION` int UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `volume_proceeding`
+--
+
+CREATE TABLE `volume_proceeding` (
+                                     `VID` int UNSIGNED NOT NULL,
+                                     `SETTING` varchar(200) NOT NULL,
+                                     `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
 
 -- --------------------------------------------------------
 
@@ -672,8 +867,23 @@ CREATE TABLE `VOLUME_PAPER_POSITION` (
 CREATE TABLE `VOLUME_SETTING` (
                                   `VID` int UNSIGNED NOT NULL,
                                   `SETTING` varchar(200) NOT NULL,
-                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8_unicode_ci
+                                  `VALUE` text CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+-- --------------------------------------------------------
+
+--
+-- Stand-in structure for view `v_mailing_lists_resolved`
+-- (See below for the actual view)
+--
+CREATE TABLE `v_mailing_lists_resolved` (
+                                            `list_id` int unsigned
+    ,`journal_id` int unsigned
+    ,`list_name` varchar(255)
+    ,`list_type` varchar(50)
+    ,`list_status` varchar(6)
+    ,`members` json
+);
 
 -- --------------------------------------------------------
 
@@ -747,129 +957,198 @@ CREATE TABLE `WEBSITE_STYLES` (
 --
 ALTER TABLE `authors`
     ADD PRIMARY KEY (`idauthors`),
-  ADD KEY `paperid` (`paperid`);
+    ADD KEY `paperid` (`paperid`);
+
+--
+-- Indexes for table `classification_jel`
+--
+ALTER TABLE `classification_jel`
+    ADD PRIMARY KEY (`code`);
+
+--
+-- Indexes for table `classification_msc2020`
+--
+ALTER TABLE `classification_msc2020`
+    ADD PRIMARY KEY (`code`);
+
+--
+-- Indexes for table `data_descriptor`
+--
+ALTER TABLE `data_descriptor`
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `docid` (`docid`),
+    ADD KEY `fileid` (`fileid`),
+    ADD KEY `version` (`version`),
+    ADD KEY `submission_date` (`submission_date`),
+    ADD KEY `INDEX_UID` (`uid`);
 
 --
 -- Indexes for table `doi_queue`
 --
 ALTER TABLE `doi_queue`
     ADD PRIMARY KEY (`id_doi_queue`),
-  ADD UNIQUE KEY `paperid` (`paperid`),
-  ADD KEY `doi_status` (`doi_status`);
+    ADD UNIQUE KEY `paperid` (`paperid`),
+    ADD KEY `doi_status` (`doi_status`);
 
 --
 -- Indexes for table `doi_queue_volumes`
 --
 ALTER TABLE `doi_queue_volumes`
     ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `uniq_vid` (`vid`) USING BTREE,
-  ADD KEY `vid` (`vid`);
+    ADD UNIQUE KEY `uniq_vid` (`vid`) USING BTREE,
+    ADD KEY `vid` (`vid`);
+
+--
+-- Indexes for table `files`
+--
+ALTER TABLE `files`
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `INDEX_DOCID` (`docid`),
+    ADD KEY `INDEX_SOURCE` (`source`);
+
+--
+-- Indexes for table `mailing_lists`
+--
+ALTER TABLE `mailing_lists`
+    ADD PRIMARY KEY (`id`),
+    ADD UNIQUE KEY `name_unique` (`name`),
+    ADD KEY `rvid` (`rvid`);
+
+--
+-- Indexes for table `mailing_list_roles`
+--
+ALTER TABLE `mailing_list_roles`
+    ADD PRIMARY KEY (`list_id`,`role`);
+
+--
+-- Indexes for table `mailing_list_users`
+--
+ALTER TABLE `mailing_list_users`
+    ADD PRIMARY KEY (`list_id`,`uid`);
 
 --
 -- Indexes for table `MAIL_LOG`
 --
 ALTER TABLE `MAIL_LOG`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `WHEN` (`WHEN`);
+    ADD KEY `DOCID` (`DOCID`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `idx_rvid_when` (`RVID`,`WHEN`);
 
 --
 -- Indexes for table `MAIL_TEMPLATE`
 --
 ALTER TABLE `MAIL_TEMPLATE`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `KEY` (`KEY`),
-  ADD KEY `RVCODE` (`RVCODE`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `PARENTID` (`PARENTID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD KEY `KEY` (`KEY`),
+    ADD KEY `RVCODE` (`RVCODE`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `PARENTID` (`PARENTID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `metadata_sources`
 --
 ALTER TABLE `metadata_sources`
     ADD PRIMARY KEY (`id`),
-  ADD KEY `type` (`type`);
+    ADD KEY `type` (`type`);
+
+--
+-- Indexes for table `news`
+--
+ALTER TABLE `news`
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `uid` (`uid`),
+    ADD KEY `code` (`code`);
 
 --
 -- Indexes for table `NEWS`
 --
 ALTER TABLE `NEWS`
     ADD PRIMARY KEY (`NEWSID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `ONLINE` (`ONLINE`),
-  ADD KEY `DATE_POST` (`DATE_POST`);
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `ONLINE` (`ONLINE`),
+    ADD KEY `DATE_POST` (`DATE_POST`);
+
+--
+-- Indexes for table `pages`
+--
+ALTER TABLE `pages`
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `uid` (`uid`),
+    ADD KEY `rvcode` (`code`) USING BTREE,
+    ADD KEY `page_code` (`page_code`);
 
 --
 -- Indexes for table `PAPERS`
 --
 ALTER TABLE `PAPERS`
     ADD PRIMARY KEY (`DOCID`),
-  ADD KEY `FK_REPOID_idx` (`REPOID`),
-  ADD KEY `FK_VID_idx` (`VID`),
-  ADD KEY `FK_RVID_idx` (`RVID`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `PAPERID` (`PAPERID`),
-  ADD KEY `SID` (`SID`),
-  ADD KEY `UID` (`UID`),
-  ADD KEY `SUBMISSION_DATE` (`SUBMISSION_DATE`),
-  ADD KEY `PUBLICATION_DATE` (`PUBLICATION_DATE`),
-  ADD KEY `FLAG` (`FLAG`),
-  ADD KEY `DOI` (`DOI`);
-ALTER TABLE `PAPERS` ADD FULLTEXT KEY `RECORD` (`RECORD`);
+    ADD KEY `FK_REPOID_idx` (`REPOID`),
+    ADD KEY `FK_VID_idx` (`VID`),
+    ADD KEY `FK_RVID_idx` (`RVID`),
+    ADD KEY `STATUS` (`STATUS`),
+    ADD KEY `PAPERID` (`PAPERID`),
+    ADD KEY `SID` (`SID`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `SUBMISSION_DATE` (`SUBMISSION_DATE`),
+    ADD KEY `PUBLICATION_DATE` (`PUBLICATION_DATE`),
+    ADD KEY `FLAG` (`FLAG`),
+    ADD KEY `DOI` (`DOI`),
+    ADD KEY `idx_identifier` (`IDENTIFIER`),
+    ADD KEY `idx_concept_identifier` (`CONCEPT_IDENTIFIER`);
 
 --
 -- Indexes for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
     ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `source_id_2` (`source_id`,`docid`),
-  ADD KEY `docid` (`docid`),
-  ADD KEY `source_id` (`source_id`);
+    ADD UNIQUE KEY `source_id_2` (`source_id`,`docid`),
+    ADD KEY `docid` (`docid`),
+    ADD KEY `source_id` (`source_id`);
 
 --
 -- Indexes for table `paper_classifications`
 --
 ALTER TABLE `paper_classifications`
     ADD PRIMARY KEY (`id`),
-  ADD KEY `paperid` (`paperid`),
-  ADD KEY `type` (`type`),
-  ADD KEY `source_id` (`source_id`);
+    ADD UNIQUE KEY `uniqClassification` (`docid`,`classification_code`,`classification_name`),
+    ADD KEY `source_id` (`source_id`),
+    ADD KEY `classification_code` (`classification_code`),
+    ADD KEY `classification_name` (`classification_name`);
 
 --
 -- Indexes for table `PAPER_COMMENTS`
 --
 ALTER TABLE `PAPER_COMMENTS`
     ADD PRIMARY KEY (`PCID`),
-  ADD KEY `DOCID` (`DOCID`),
-  ADD KEY `TYPE` (`TYPE`),
-  ADD KEY `UID` (`UID`),
-  ADD KEY `DEADLINE` (`DEADLINE`),
-  ADD KEY `WHEN` (`WHEN`),
-  ADD KEY `PARENTID` (`PARENTID`);
+    ADD KEY `DOCID` (`DOCID`),
+    ADD KEY `TYPE` (`TYPE`),
+    ADD KEY `UID` (`UID`),
+    ADD KEY `DEADLINE` (`DEADLINE`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `PARENTID` (`PARENTID`);
 
 --
 -- Indexes for table `paper_conflicts`
 --
 ALTER TABLE `paper_conflicts`
     ADD PRIMARY KEY (`cid`),
-  ADD UNIQUE KEY `U_PAPERID_BY` (`paper_id`,`by`) USING BTREE,
-  ADD KEY `BY_UID` (`by`),
-  ADD KEY `PAPERID` (`paper_id`),
-  ADD KEY `answer` (`answer`);
+    ADD UNIQUE KEY `U_PAPERID_BY` (`paper_id`,`by`) USING BTREE,
+    ADD KEY `BY_UID` (`by`),
+    ADD KEY `answer` (`answer`);
 
 --
 -- Indexes for table `paper_datasets`
 --
 ALTER TABLE `paper_datasets`
     ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `unique` (`doc_id`,`code`(15),`name`(35),`value`(47),`source_id`),
-  ADD KEY `doc_id` (`doc_id`),
-  ADD KEY `source_id` (`source_id`),
-  ADD KEY `code` (`code`(15)),
-  ADD KEY `name` (`name`(35)),
-  ADD KEY `id_paper_datasets_meta` (`id_paper_datasets_meta`);
+    ADD UNIQUE KEY `unique` (`doc_id`,`code`(15),`name`(35),`value`(47),`source_id`),
+    ADD KEY `source_id` (`source_id`),
+    ADD KEY `code` (`code`(15)),
+    ADD KEY `name` (`name`(35)),
+    ADD KEY `id_paper_datasets_meta` (`id_paper_datasets_meta`);
 
 --
 -- Indexes for table `paper_datasets_meta`
@@ -882,80 +1161,94 @@ ALTER TABLE `paper_datasets_meta`
 --
 ALTER TABLE `paper_files`
     ADD PRIMARY KEY (`id`),
-  ADD KEY `doc_id` (`doc_id`),
-  ADD KEY `source` (`source`);
+    ADD KEY `doc_id` (`doc_id`),
+    ADD KEY `source` (`source`);
 
 --
 -- Indexes for table `paper_licences`
 --
 ALTER TABLE `paper_licences`
     ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `docid` (`docid`),
-  ADD KEY `source_id` (`source_id`);
+    ADD UNIQUE KEY `docid` (`docid`),
+    ADD KEY `source_id` (`source_id`);
 
 --
 -- Indexes for table `PAPER_LOG`
 --
 ALTER TABLE `PAPER_LOG`
     ADD PRIMARY KEY (`LOGID`),
-  ADD KEY `fk_T_PAPER_MODIF_T_PAPERS_idx` (`DOCID`),
-  ADD KEY `fk_T_PAPER_MODIF_T_USER_idx` (`UID`),
-  ADD KEY `PAPERID` (`PAPERID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `DATE` (`DATE`);
+    ADD KEY `fk_T_PAPER_MODIF_T_PAPERS_idx` (`DOCID`),
+    ADD KEY `fk_T_PAPER_MODIF_T_USER_idx` (`UID`),
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `DATE` (`DATE`),
+    ADD KEY `idx_status` (`status`),
+    ADD KEY `ACTION` (`ACTION`),
+    ADD KEY `idx_paperid_docid_date_logid` (`PAPERID`,`DOCID`,`DATE`,`LOGID`);
 
 --
 -- Indexes for table `paper_projects`
 --
 ALTER TABLE `paper_projects`
     ADD PRIMARY KEY (`idproject`),
-  ADD UNIQUE KEY `paperid` (`paperid`),
-  ADD UNIQUE KEY `paperid_src_uniq` (`paperid`,`source_id`) USING BTREE,
-  ADD KEY `idx_source_id` (`source_id`);
+    ADD UNIQUE KEY `paperid` (`paperid`),
+    ADD KEY `idx_source_id` (`source_id`);
 
 --
 -- Indexes for table `PAPER_SETTINGS`
 --
 ALTER TABLE `PAPER_SETTINGS`
     ADD PRIMARY KEY (`PSID`),
-  ADD KEY `SETTING` (`SETTING`),
-  ADD KEY `DOCID` (`DOCID`);
+    ADD KEY `SETTING` (`SETTING`),
+    ADD KEY `DOCID` (`DOCID`);
 
 --
 -- Indexes for table `PAPER_STAT`
 --
 ALTER TABLE `PAPER_STAT`
     ADD PRIMARY KEY (`DOCID`,`CONSULT`,`IP`,`HIT`),
-  ADD KEY `COUNTER` (`COUNTER`),
-  ADD KEY `CONSULT` (`CONSULT`);
+    ADD KEY `CONSULT` (`CONSULT`);
+
+--
+-- Indexes for table `queue_messages`
+--
+ALTER TABLE `queue_messages`
+    ADD PRIMARY KEY (`id`),
+    ADD KEY `idx_status` (`processed`),
+    ADD KEY `idx_timeout` (`timeout`),
+    ADD KEY `idx_created` (`created_at`),
+    ADD KEY `idx_time_status` (`processed`,`created_at`),
+    ADD KEY `idx_ready_messages` (`processed`,`timeout`,`created_at`),
+    ADD KEY `idx_type` (`type`),
+    ADD KEY `idx_rvcode` (`rvcode`);
 
 --
 -- Indexes for table `refresh_tokens`
 --
 ALTER TABLE `refresh_tokens`
     ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `UNIQ_9BACE7E16973EC66` (`refreshToken`);
+    ADD UNIQUE KEY `UNIQ_9BACE7E16973EC66` (`refreshToken`);
 
 --
 -- Indexes for table `REMINDERS`
 --
 ALTER TABLE `REMINDERS`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `TYPE` (`TYPE`);
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `TYPE` (`TYPE`);
 
 --
 -- Indexes for table `REVIEW`
 --
 ALTER TABLE `REVIEW`
     ADD PRIMARY KEY (`RVID`),
-  ADD UNIQUE KEY `U_CODE` (`CODE`),
-  ADD KEY `STATUS` (`STATUS`);
+    ADD UNIQUE KEY `U_CODE` (`CODE`),
+    ADD KEY `STATUS` (`STATUS`);
 
 --
 -- Indexes for table `REVIEWER_ALIAS`
 --
 ALTER TABLE `REVIEWER_ALIAS`
+    ADD PRIMARY KEY (`ID`),
     ADD UNIQUE KEY `UNIQUE` (`UID`,`DOCID`,`ALIAS`) USING BTREE;
 
 --
@@ -969,23 +1262,23 @@ ALTER TABLE `REVIEWER_POOL`
 --
 ALTER TABLE `REVIEWER_REPORT`
     ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `UID` (`UID`,`DOCID`),
-  ADD KEY `ONBEHALF_UID` (`ONBEHALF_UID`) USING BTREE;
+    ADD UNIQUE KEY `UID` (`UID`,`DOCID`),
+    ADD KEY `ONBEHALF_UID` (`ONBEHALF_UID`) USING BTREE,
+    ADD KEY `idx_docid` (`DOCID`);
 
 --
 -- Indexes for table `REVIEW_SETTING`
 --
 ALTER TABLE `REVIEW_SETTING`
-    ADD PRIMARY KEY (`RVID`,`SETTING`),
-  ADD KEY `FK_CONFIG_idx` (`RVID`);
+    ADD PRIMARY KEY (`RVID`,`SETTING`);
 
 --
 -- Indexes for table `SECTION`
 --
 ALTER TABLE `SECTION`
     ADD PRIMARY KEY (`SID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `SECTION_SETTING`
@@ -994,60 +1287,68 @@ ALTER TABLE `SECTION_SETTING`
     ADD PRIMARY KEY (`SID`,`SETTING`);
 
 --
+-- Indexes for table `STAT_PROCESSING_LOG`
+--
+ALTER TABLE `STAT_PROCESSING_LOG`
+    ADD PRIMARY KEY (`ID`),
+    ADD UNIQUE KEY `unique_journal_date` (`JOURNAL_CODE`,`PROCESSED_DATE`),
+    ADD KEY `idx_processed_date` (`PROCESSED_DATE`),
+    ADD KEY `idx_processed_at` (`PROCESSED_AT`);
+
+--
 -- Indexes for table `STAT_TEMP`
 --
 ALTER TABLE `STAT_TEMP`
     ADD PRIMARY KEY (`VISITID`),
-  ADD KEY `DOCID` (`DOCID`);
+    ADD KEY `DOCID` (`DOCID`);
 
 --
 -- Indexes for table `USER`
 --
 ALTER TABLE `USER`
     ADD PRIMARY KEY (`UID`),
-  ADD UNIQUE KEY `U_USERNAME` (`USERNAME`),
-  ADD KEY `API_PASSWORD` (`API_PASSWORD`),
-  ADD KEY `IS_VALID` (`IS_VALID`),
-  ADD KEY `FIRSTNAME` (`FIRSTNAME`),
-  ADD KEY `LASTNAME` (`LASTNAME`),
-  ADD KEY `SCREEN_NAME` (`SCREEN_NAME`),
-  ADD KEY `EMAIL` (`EMAIL`(255)),
-  ADD KEY `REGISTRATION_DATE` (`REGISTRATION_DATE`);
+    ADD UNIQUE KEY `U_USERNAME` (`USERNAME`),
+    ADD UNIQUE KEY `uuid` (`uuid`),
+    ADD KEY `IS_VALID` (`IS_VALID`),
+    ADD KEY `SCREEN_NAME` (`SCREEN_NAME`),
+    ADD KEY `EMAIL` (`EMAIL`(255)),
+    ADD KEY `REGISTRATION_DATE` (`REGISTRATION_DATE`);
 
 --
 -- Indexes for table `USER_ASSIGNMENT`
 --
 ALTER TABLE `USER_ASSIGNMENT`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `FK_ITEMID_idx` (`ITEMID`),
-  ADD KEY `FK_UID_idx` (`UID`),
-  ADD KEY `ITEM` (`ITEM`),
-  ADD KEY `ROLEID` (`ROLEID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `WHEN` (`WHEN`),
-  ADD KEY `TMP_USER` (`TMP_USER`),
-  ADD KEY `INVITATION_ID` (`INVITATION_ID`);
+    ADD KEY `FK_ITEMID_idx` (`ITEMID`),
+    ADD KEY `FK_UID_idx` (`UID`),
+    ADD KEY `ITEM` (`ITEM`),
+    ADD KEY `ROLEID` (`ROLEID`),
+    ADD KEY `WHEN` (`WHEN`),
+    ADD KEY `TMP_USER` (`TMP_USER`),
+    ADD KEY `INVITATION_ID` (`INVITATION_ID`),
+    ADD KEY `LINKED_FROM` (`FROM_UID`),
+    ADD KEY `idx_rvid_roleid` (`RVID`,`ROLEID`);
 
 --
 -- Indexes for table `USER_INVITATION`
 --
 ALTER TABLE `USER_INVITATION`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `TOKEN` (`TOKEN`),
-  ADD KEY `STATUS` (`STATUS`),
-  ADD KEY `SENDER_UID` (`SENDER_UID`);
+    ADD KEY `SENDER_UID` (`SENDER_UID`),
+    ADD KEY `AID_SENDING_DATE` (`AID`,`SENDING_DATE`);
 
 --
 -- Indexes for table `USER_INVITATION_ANSWER`
 --
 ALTER TABLE `USER_INVITATION_ANSWER`
+    ADD PRIMARY KEY (`ID_UIA`),
     ADD UNIQUE KEY `U_ID` (`ID`);
 
 --
 -- Indexes for table `USER_INVITATION_ANSWER_DETAIL`
 --
 ALTER TABLE `USER_INVITATION_ANSWER_DETAIL`
+    ADD PRIMARY KEY (`ID_UIAD`),
     ADD UNIQUE KEY `U_ID_NAME` (`ID`,`NAME`);
 
 --
@@ -1061,53 +1362,58 @@ ALTER TABLE `USER_MERGE`
 --
 ALTER TABLE `USER_ROLES`
     ADD PRIMARY KEY (`UID`,`RVID`,`ROLEID`),
-  ADD KEY `RVID` (`RVID`),
-  ADD KEY `ROLEID` (`ROLEID`),
-  ADD KEY `UID` (`UID`);
+    ADD KEY `RVID` (`RVID`),
+    ADD KEY `ROLEID` (`ROLEID`);
 
 --
 -- Indexes for table `USER_TMP`
 --
 ALTER TABLE `USER_TMP`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `EMAIL` (`EMAIL`(150));
+    ADD KEY `EMAIL` (`EMAIL`(150));
 
 --
 -- Indexes for table `VOLUME`
 --
 ALTER TABLE `VOLUME`
     ADD PRIMARY KEY (`VID`),
-  ADD KEY `FK_CONFID_idx` (`RVID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD KEY `FK_CONFID_idx` (`RVID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `VOLUME_METADATA`
 --
 ALTER TABLE `VOLUME_METADATA`
     ADD PRIMARY KEY (`ID`),
-  ADD KEY `VID` (`VID`),
-  ADD KEY `POSITION` (`POSITION`);
+    ADD KEY `VID` (`VID`),
+    ADD KEY `POSITION` (`POSITION`);
 
 --
 -- Indexes for table `VOLUME_PAPER`
 --
 ALTER TABLE `VOLUME_PAPER`
     ADD PRIMARY KEY (`ID`),
-  ADD UNIQUE KEY `UNIQUE` (`VID`,`DOCID`) USING BTREE;
+    ADD UNIQUE KEY `UNIQUE` (`VID`,`DOCID`) USING BTREE;
 
 --
 -- Indexes for table `VOLUME_PAPER_POSITION`
 --
 ALTER TABLE `VOLUME_PAPER_POSITION`
+    ADD PRIMARY KEY (`ID`),
     ADD UNIQUE KEY `VID` (`VID`,`PAPERID`),
     ADD KEY `POSITION` (`POSITION`);
+
+--
+-- Indexes for table `volume_proceeding`
+--
+ALTER TABLE `volume_proceeding`
+    ADD PRIMARY KEY (`VID`,`SETTING`);
 
 --
 -- Indexes for table `VOLUME_SETTING`
 --
 ALTER TABLE `VOLUME_SETTING`
-    ADD PRIMARY KEY (`VID`,`SETTING`),
-  ADD KEY `FK_RVID0_idx` (`VID`);
+    ADD PRIMARY KEY (`VID`,`SETTING`);
 
 --
 -- Indexes for table `WEBSITE_HEADER`
@@ -1120,9 +1426,9 @@ ALTER TABLE `WEBSITE_HEADER`
 --
 ALTER TABLE `WEBSITE_NAVIGATION`
     ADD PRIMARY KEY (`NAVIGATIONID`),
-  ADD KEY `SID` (`SID`),
-  ADD KEY `TYPE_PAGE` (`TYPE_PAGE`),
-  ADD KEY `PARENT_PAGEID` (`PARENT_PAGEID`);
+    ADD KEY `SID` (`SID`),
+    ADD KEY `TYPE_PAGE` (`TYPE_PAGE`),
+    ADD KEY `PARENT_PAGEID` (`PARENT_PAGEID`);
 
 --
 -- Indexes for table `WEBSITE_SETTINGS`
@@ -1147,6 +1453,12 @@ ALTER TABLE `authors`
     MODIFY `idauthors` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `data_descriptor`
+--
+ALTER TABLE `data_descriptor`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `doi_queue`
 --
 ALTER TABLE `doi_queue`
@@ -1156,6 +1468,18 @@ ALTER TABLE `doi_queue`
 -- AUTO_INCREMENT for table `doi_queue_volumes`
 --
 ALTER TABLE `doi_queue_volumes`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `files`
+--
+ALTER TABLE `files`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `mailing_lists`
+--
+ALTER TABLE `mailing_lists`
     MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
@@ -1177,10 +1501,22 @@ ALTER TABLE `metadata_sources`
     MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `news`
+--
+ALTER TABLE `news`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `NEWS`
 --
 ALTER TABLE `NEWS`
     MODIFY `NEWSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `pages`
+--
+ALTER TABLE `pages`
+    MODIFY `id` int NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `PAPERS`
@@ -1192,6 +1528,12 @@ ALTER TABLE `PAPERS`
 -- AUTO_INCREMENT for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `paper_classifications`
+--
+ALTER TABLE `paper_classifications`
     MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
@@ -1249,6 +1591,12 @@ ALTER TABLE `PAPER_SETTINGS`
     MODIFY `PSID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `queue_messages`
+--
+ALTER TABLE `queue_messages`
+    MODIFY `id` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `refresh_tokens`
 --
 ALTER TABLE `refresh_tokens`
@@ -1267,6 +1615,12 @@ ALTER TABLE `REVIEW`
     MODIFY `RVID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `REVIEWER_ALIAS`
+--
+ALTER TABLE `REVIEWER_ALIAS`
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `REVIEWER_REPORT`
 --
 ALTER TABLE `REVIEWER_REPORT`
@@ -1277,6 +1631,12 @@ ALTER TABLE `REVIEWER_REPORT`
 --
 ALTER TABLE `SECTION`
     MODIFY `SID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `STAT_PROCESSING_LOG`
+--
+ALTER TABLE `STAT_PROCESSING_LOG`
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `STAT_TEMP`
@@ -1301,6 +1661,18 @@ ALTER TABLE `USER_ASSIGNMENT`
 --
 ALTER TABLE `USER_INVITATION`
     MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `USER_INVITATION_ANSWER`
+--
+ALTER TABLE `USER_INVITATION_ANSWER`
+    MODIFY `ID_UIA` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `USER_INVITATION_ANSWER_DETAIL`
+--
+ALTER TABLE `USER_INVITATION_ANSWER_DETAIL`
+    MODIFY `ID_UIAD` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `USER_MERGE`
@@ -1333,6 +1705,12 @@ ALTER TABLE `VOLUME_PAPER`
     MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT for table `VOLUME_PAPER_POSITION`
+--
+ALTER TABLE `VOLUME_PAPER_POSITION`
+    MODIFY `ID` int UNSIGNED NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT for table `WEBSITE_HEADER`
 --
 ALTER TABLE `WEBSITE_HEADER`
@@ -1344,9 +1722,24 @@ ALTER TABLE `WEBSITE_HEADER`
 ALTER TABLE `WEBSITE_NAVIGATION`
     MODIFY `NAVIGATIONID` int UNSIGNED NOT NULL AUTO_INCREMENT;
 
+-- --------------------------------------------------------
+
+--
+-- Structure for view `v_mailing_lists_resolved`
+--
+DROP TABLE IF EXISTS `v_mailing_lists_resolved`;
+
+CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v_mailing_lists_resolved`  AS WITH   `list_members_data` as (select `ml`.`id` AS `list_id`,`u`.`UID` AS `UID`,`u`.`FIRSTNAME` AS `FIRSTNAME`,`u`.`LASTNAME` AS `LASTNAME`,`u`.`EMAIL` AS `EMAIL` from ((`mailing_lists` `ml` join (select `mailing_list_users`.`list_id` AS `list_id`,`mailing_list_users`.`uid` AS `uid` from `mailing_list_users` union select `mlr`.`list_id` AS `list_id`,`ur`.`UID` AS `uid` from ((`mailing_list_roles` `mlr` join `mailing_lists` `ml_inner` on((`ml_inner`.`id` = `mlr`.`list_id`))) join `USER_ROLES` `ur` on(((`ur`.`ROLEID` = `mlr`.`role`) and (`ur`.`RVID` = `ml_inner`.`rvid`))))) `lm` on((`ml`.`id` = `lm`.`list_id`))) join `USER` `u` on((`lm`.`uid` = `u`.`UID`))) where (`u`.`IS_VALID` = 1)) select `ml`.`id` AS `list_id`,`ml`.`rvid` AS `journal_id`,`ml`.`name` AS `list_name`,`ml`.`type` AS `list_type`,if((`ml`.`status` = 1),'open','closed') AS `list_status`,if((count(`lmd`.`UID`) = 0),json_array(),json_arrayagg(json_object('firstname',`lmd`.`FIRSTNAME`,'lastname',`lmd`.`LASTNAME`,'email',`lmd`.`EMAIL`))) AS `members` from (`mailing_lists` `ml` left join `list_members_data` `lmd` on((`ml`.`id` = `lmd`.`list_id`))) group by `ml`.`id`,`ml`.`rvid`,`ml`.`name`,`ml`.`type`,`ml`.`status`  ;
+
 --
 -- Constraints for dumped tables
 --
+
+--
+-- Constraints for table `data_descriptor`
+--
+ALTER TABLE `data_descriptor`
+    ADD CONSTRAINT `FK_DD_FILES` FOREIGN KEY (`fileid`) REFERENCES `files` (`id`) ON DELETE CASCADE;
 
 --
 -- Constraints for table `doi_queue_volumes`
@@ -1355,11 +1748,23 @@ ALTER TABLE `doi_queue_volumes`
     ADD CONSTRAINT `doi_queue_volumes_ibfk_1` FOREIGN KEY (`vid`) REFERENCES `VOLUME` (`VID`) ON DELETE CASCADE ON UPDATE CASCADE;
 
 --
+-- Constraints for table `mailing_list_roles`
+--
+ALTER TABLE `mailing_list_roles`
+    ADD CONSTRAINT `fk_mlr_list_id` FOREIGN KEY (`list_id`) REFERENCES `mailing_lists` (`id`) ON DELETE CASCADE;
+
+--
+-- Constraints for table `mailing_list_users`
+--
+ALTER TABLE `mailing_list_users`
+    ADD CONSTRAINT `fk_mlu_list_id` FOREIGN KEY (`list_id`) REFERENCES `mailing_lists` (`id`) ON DELETE CASCADE;
+
+--
 -- Constraints for table `paper_citations`
 --
 ALTER TABLE `paper_citations`
     ADD CONSTRAINT `paper_citations_ibfk_1` FOREIGN KEY (`docid`) REFERENCES `PAPERS` (`DOCID`),
-  ADD CONSTRAINT `paper_citations_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
+    ADD CONSTRAINT `paper_citations_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 
 --
 -- Constraints for table `paper_datasets`
@@ -1372,7 +1777,7 @@ ALTER TABLE `paper_datasets`
 --
 ALTER TABLE `paper_projects`
     ADD CONSTRAINT `paper_projects_ibfk_1` FOREIGN KEY (`paperid`) REFERENCES `PAPERS` (`PAPERID`),
-  ADD CONSTRAINT `paper_projects_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
+    ADD CONSTRAINT `paper_projects_ibfk_2` FOREIGN KEY (`source_id`) REFERENCES `metadata_sources` (`id`);
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- Drop `paper_projects_ibfk_1` (FK on `paper_projects.paperid` → `PAPERS.PAPERID`, a non-unique/nullable column) from both reference dumps — confirmed via a throwaway `mysql:8.4` container that this FK makes the schema fail to load (`ERROR 6125`, `restrict_fk_on_non_standard_key` defaults to ON in 8.4)
- Add explicit cleanup of `paper_projects` rows in `PapersManager::delete()` to preserve referential integrity now that the DB-level constraint is gone (no delete method previously existed in `Episciences_Paper_Projects_Repository`)
- Add `src/mysql/2026-07-12-drop-paper-projects-fk.sql` migration script to apply the same FK removal on environments still running the old schema (prod, preprod, etc.)
- Convert the 14 remaining `ON DUPLICATE KEY UPDATE ... VALUES(col)` calls (deprecated since 8.0.20) to the `INSERT ... AS new_row ... = new_row.col` alias syntax, across `ClassificationsManager`, `ConflictsManager`, `LicenceManager`, `DoiSettingsManager`, `AliasManager`, `Section`, `Volume`, `DoiQueueManager`, `VolumeProceeding`, `VolumesManager`, `ImportApacheLogsCommand` (×3), `UpgradeUserRoles`

## Test plan
- [x] Reloaded the fixed `episciences.sql` dump into a clean `mysql:8.4` container: 60 tables, 8 FKs created, 0 errors (previously failed at `paper_projects_ibfk_1`)
- [x] Ran targeted PHPUnit suites: Projects Manager/Repository, PapersManager, Section, Volume, VolumeProceeding, VolumesManager, LicenceManager, ImportApacheLogsCommand (unit + integration) — all green
- [x] `make phpstan` on all 13 modified PHP files — pre-existing findings only, none on the changed lines

## Follow-up (out of scope here)
- `episciences-infrastructure` (separate repo) carries the same FK in its dump and will need the same fix before its MySQL 8.4 environments can be reinitialized
- Production still needs the migration script run before/during the 8.4 upgrade