### PR TITLE
fix: allow authorized roles to visualize all bibliographic references on unpublished papers

### DIFF
--- a/application/modules/journal/controllers/PaperController.php
+++ b/application/modules/journal/controllers/PaperController.php
@@ -550,6 +550,7 @@ class PaperController extends PaperDefaultController
         }
         $this->view->enabledBib = $enabledBib;
         $this->view->enabledManageFromPublicPage = $enabledManageFromPublicPage;
+        $this->view->showAllBib = $isAllowedToSeeNoPublicDetails || $paper->isCoauthor();
 
         // Author to editor communication - extracted to helper method
         $this->handleAuthorToEditorCommunication($paper, $review);

--- a/application/modules/journal/views/scripts/partials/paper_biblio_refs.phtml
+++ b/application/modules/journal/views/scripts/partials/paper_biblio_refs.phtml
@@ -43,7 +43,7 @@
                 </div>
                 <div id="visualize-biblio-refs" data-value="<?= $this->urlcallapibib ?>"
                      data-api="<?= $this->apiEpiBibCitation ?>"
-                     <?php if ($showButton): ?>data-all="1" <?php endif; ?>
+                     <?php if ($showButton || $this->showAllBib): ?>data-all="1" <?php endif; ?>
                      hidden></div>
             </div>
         </div>


### PR DESCRIPTION
This PR resolves the issue where bibliographic references are not displayed for authors, co-authors, and reviewers of unpublished papers on the public view page. It enables passing the 'all=1' parameter to the citation service for logged-in authorized roles.