### PR TITLE
fix: stream Crossref DOI XML in-memory, nest volume/DOAJ caches under rvcode

### DIFF
--- a/library/Episciences/Api/CrossrefSubmissionApiClient.php
+++ b/library/Episciences/Api/CrossrefSubmissionApiClient.php
@@ -35,20 +35,13 @@ class CrossrefSubmissionApiClient
     /**
      * POST XML metadata to the Crossref deposit API.
      *
-     * @throws \RuntimeException  if the XML file cannot be read.
+     * @param string $xmlContent  Raw XML body, kept in memory only (no disk write).
+     * @param string $fileName    Filename Crossref associates with the submission; also
+     *                            reused as the correlation key by fetchStatus().
      * @throws GuzzleException    on HTTP/network failure (propagated to caller).
      */
-    public function postMetadata(string $xmlFilePath, string $fileName, bool $dryRun): ResponseInterface
+    public function postMetadata(string $xmlContent, string $fileName, bool $dryRun): ResponseInterface
     {
-        if (!is_readable($xmlFilePath)) {
-            throw new \RuntimeException("Cannot open XML file for reading: {$xmlFilePath}");
-        }
-
-        $handle = fopen($xmlFilePath, 'rb');
-        if ($handle === false) {
-            throw new \RuntimeException("fopen failed for: {$xmlFilePath}");
-        }
-
         $url = $dryRun ? $this->depositTestUrl : $this->depositUrl;
         $this->logger->info("Posting {$fileName} to {$url}");
 
@@ -57,7 +50,7 @@ class CrossrefSubmissionApiClient
                 ['name' => 'operation',    'contents' => 'doMDUpload'],
                 ['name' => 'login_id',     'contents' => $this->login],
                 ['name' => 'login_passwd', 'contents' => $this->password],
-                ['name' => 'fname',        'filename' => $fileName, 'contents' => $handle],
+                ['name' => 'fname',        'filename' => $fileName, 'contents' => $xmlContent],
             ],
         ]);
     }

--- a/scripts/CreateDoajVolumeExportsCommand.php
+++ b/scripts/CreateDoajVolumeExportsCommand.php
@@ -67,7 +67,7 @@ class CreateDoajVolumeExportsCommand extends Command
             $this->initLoggerForJournal($journal, $io->isQuiet());
             try {
                 if ($removeCache) {
-                    $cache = new FilesystemAdapter("doaj-volume-export-{$journal}", 0, CACHE_PATH_METADATA);
+                    $cache = new FilesystemAdapter('doaj-volume-export', 0, CACHE_PATH_METADATA . $journal);
                     $cache->clear();
                     $this->logger->info("Cache cleared for RV code: {$journal}");
                 }
@@ -252,7 +252,7 @@ class CreateDoajVolumeExportsCommand extends Command
      */
     public static function getCacheDocIdsList(string $vid, string $rvCode): string
     {
-        $cache = new FilesystemAdapter("doaj-volume-export-{$rvCode}", 0, CACHE_PATH_METADATA);
+        $cache = new FilesystemAdapter('doaj-volume-export', 0, CACHE_PATH_METADATA . $rvCode);
         $item  = $cache->getItem($vid);
         if (!$item->isHit()) {
             return json_encode([''], JSON_THROW_ON_ERROR);
@@ -269,7 +269,7 @@ class CreateDoajVolumeExportsCommand extends Command
      */
     public static function setCacheDocIdsList(string $vid, array $jsonVidList, string $rvCode): void
     {
-        $cache = new FilesystemAdapter("doaj-volume-export-{$rvCode}", 0, CACHE_PATH_METADATA);
+        $cache = new FilesystemAdapter('doaj-volume-export', 0, CACHE_PATH_METADATA . $rvCode);
         $item  = $cache->getItem($vid);
         $item->set(json_encode($jsonVidList, JSON_THROW_ON_ERROR));
         $cache->save($item);

--- a/scripts/GetDoiCommand.php
+++ b/scripts/GetDoiCommand.php
@@ -266,14 +266,12 @@ class GetDoiCommand extends Command
             }
 
             $xmlFileName = sprintf('%s-%d.xml', $rvcode, $paperId);
-            $xmlFilePath = CACHE_PATH . $xmlFileName;
             $paperUrl    = sprintf('%spapers/export/%d/crossref?code=%s', EPISCIENCES_API_URL, $docId, $rvcode);
 
             $logger->info("Requesting metadata: {$paperUrl}");
 
             try {
                 $body = $http->request('GET', $paperUrl)->getBody()->getContents();
-                file_put_contents($xmlFilePath, $body);
             } catch (GuzzleException $e) {
                 $logger->error("Metadata fetch failed for paper #{$paperId}: " . $e->getMessage());
                 $io->progressAdvance();
@@ -281,7 +279,7 @@ class GetDoiCommand extends Command
             }
 
             try {
-                $response = $crossrefClient->postMetadata($xmlFilePath, $xmlFileName, $dryRun);
+                $response = $crossrefClient->postMetadata($body, $xmlFileName, $dryRun);
                 $doiQueue->setDoi_status(Episciences_Paper_DoiQueue::STATUS_REQUESTED);
                 Episciences_Paper_DoiQueueManager::update($doiQueue);
                 $logger->info(sprintf('%s: Crossref answered: %s', $rvcode, $response->getBody()));
@@ -438,14 +436,12 @@ class GetDoiCommand extends Command
             }
 
             $xmlFileName = sprintf('%s-%d.xml', $rvcode, $currentPaperId);
-            $xmlFilePath = CACHE_PATH . $xmlFileName;
             $paperUrl    = sprintf('%spapers/export/%d/crossref?code=%s', EPISCIENCES_API_URL, $docId, $rvcode);
 
             $logger->info("Fetching metadata: {$paperUrl}");
 
             try {
                 $body = $http->request('GET', $paperUrl)->getBody()->getContents();
-                file_put_contents($xmlFilePath, $body);
             } catch (GuzzleException $e) {
                 $logger->error("Metadata fetch failed for paper #{$currentPaperId}: " . $e->getMessage());
                 $io->progressAdvance();
@@ -453,7 +449,7 @@ class GetDoiCommand extends Command
             }
 
             try {
-                $response = $crossrefClient->postMetadata($xmlFilePath, $xmlFileName, $dryRun);
+                $response = $crossrefClient->postMetadata($body, $xmlFileName, $dryRun);
                 /** @var Episciences_Paper_DoiQueue $doiQueue */
                 $doiQueue = $doiToProcess['doiq'];
                 $doiQueue->setDoi_status(Episciences_Paper_DoiQueue::STATUS_UPDATE_PENDING);

--- a/scripts/MergePdfVolCommand.php
+++ b/scripts/MergePdfVolCommand.php
@@ -84,7 +84,7 @@ class MergePdfVolCommand extends Command
             ]);
 
             if ($removeCache) {
-                $cache = new FilesystemAdapter("volume-pdf-{$rvCode}", 0, CACHE_PATH_METADATA);
+                $cache = new FilesystemAdapter('volume-pdf', 0, CACHE_PATH_METADATA . $rvCode);
                 $cache->clear();
                 $this->logger->info('Cache cleared', ['rvCode' => $rvCode]);
             }
@@ -404,7 +404,7 @@ class MergePdfVolCommand extends Command
      */
     public static function getCacheDocIdsList(string $vid, string $rvCode): string
     {
-        $cache  = new FilesystemAdapter("volume-pdf-{$rvCode}", 0, CACHE_PATH_METADATA);
+        $cache  = new FilesystemAdapter('volume-pdf', 0, CACHE_PATH_METADATA . $rvCode);
         $item   = $cache->getItem($vid);
         if (!$item->isHit()) {
             return json_encode([''], JSON_THROW_ON_ERROR);
@@ -419,7 +419,7 @@ class MergePdfVolCommand extends Command
      */
     public static function setCacheDocIdsList(string $vid, array $jsonVidList, string $rvCode): void
     {
-        $cache = new FilesystemAdapter("volume-pdf-{$rvCode}", 0, CACHE_PATH_METADATA);
+        $cache = new FilesystemAdapter('volume-pdf', 0, CACHE_PATH_METADATA . $rvCode);
         $item  = $cache->getItem($vid);
         $item->set(json_encode($jsonVidList, JSON_THROW_ON_ERROR));
         $cache->save($item);

--- a/tests/unit/library/Episciences/Api/CrossrefSubmissionApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/CrossrefSubmissionApiClientTest.php
@@ -26,20 +26,7 @@ class CrossrefSubmissionApiClientTest extends TestCase
     private const LOGIN            = 'test_login';
     private const PASSWORD         = 'test_password';
 
-    private string $tmpFile;
-
-    protected function setUp(): void
-    {
-        $this->tmpFile = tempnam(sys_get_temp_dir(), 'crossref_test_') . '.xml';
-        file_put_contents($this->tmpFile, '<doi_batch><batch_data><success_count>1</success_count></batch_data></doi_batch>');
-    }
-
-    protected function tearDown(): void
-    {
-        if (file_exists($this->tmpFile)) {
-            unlink($this->tmpFile);
-        }
-    }
+    private const XML_CONTENT = '<doi_batch><batch_data><success_count>1</success_count></batch_data></doi_batch>';
 
     // -------------------------------------------------------------------------
     // Helpers
@@ -75,7 +62,7 @@ class CrossrefSubmissionApiClientTest extends TestCase
     {
         $apiClient = $this->makeApiClient($this->makeClient([new Response(200, [], 'OK')]));
 
-        $response = $apiClient->postMetadata($this->tmpFile, 'epiga-42.xml', false);
+        $response = $apiClient->postMetadata(self::XML_CONTENT, 'epiga-42.xml', false);
 
         $this->assertSame(200, $response->getStatusCode());
     }
@@ -85,7 +72,7 @@ class CrossrefSubmissionApiClientTest extends TestCase
         $history   = [];
         $apiClient = $this->makeApiClient($this->makeClient([new Response(200)], $history));
 
-        $apiClient->postMetadata($this->tmpFile, 'epiga-42.xml', false);
+        $apiClient->postMetadata(self::XML_CONTENT, 'epiga-42.xml', false);
 
         $uri = (string) $history[0]['request']->getUri();
         $this->assertSame(self::DEPOSIT_URL, $uri);
@@ -96,7 +83,7 @@ class CrossrefSubmissionApiClientTest extends TestCase
         $history   = [];
         $apiClient = $this->makeApiClient($this->makeClient([new Response(200)], $history));
 
-        $apiClient->postMetadata($this->tmpFile, 'epiga-42.xml', true);
+        $apiClient->postMetadata(self::XML_CONTENT, 'epiga-42.xml', true);
 
         $uri = (string) $history[0]['request']->getUri();
         $this->assertSame(self::DEPOSIT_TEST_URL, $uri);
@@ -107,20 +94,14 @@ class CrossrefSubmissionApiClientTest extends TestCase
         $history   = [];
         $apiClient = $this->makeApiClient($this->makeClient([new Response(200)], $history));
 
-        $apiClient->postMetadata($this->tmpFile, 'epiga-42.xml', false);
+        $apiClient->postMetadata(self::XML_CONTENT, 'epiga-42.xml', false);
 
         $body = (string) $history[0]['request']->getBody();
         $this->assertStringContainsString('doMDUpload', $body);
         $this->assertStringContainsString(self::LOGIN, $body);
         $this->assertStringContainsString(self::PASSWORD, $body);
         $this->assertStringContainsString('epiga-42.xml', $body);
-    }
-
-    public function testPostMetadata_MissingFile_ThrowsRuntimeException(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $apiClient = $this->makeApiClient($this->makeClient([new Response(200)]));
-        $apiClient->postMetadata('/nonexistent/path/does-not-exist.xml', 'file.xml', false);
+        $this->assertStringContainsString(self::XML_CONTENT, $body);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/unit/scripts/GetDoiCommandTest.php
+++ b/tests/unit/scripts/GetDoiCommandTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace unit\scripts;
+
+use Episciences\Api\CrossrefSubmissionApiClient;
+use Episciences_Paper;
+use Episciences_Review;
+use Episciences_Review_DoiSettings;
+use GetDoiCommand;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+require_once __DIR__ . '/../../../scripts/GetDoiCommand.php';
+
+/**
+ * Unit tests for GetDoiCommand.
+ *
+ * execute() and bootstrap() are never invoked directly: bootstrap() re-creates a
+ * Zend_Application in 'production' mode, which would be unsafe to run from a test
+ * process. Instead, the private per-action methods are called directly via
+ * Reflection with an unknown rvid/rvcode — same convention as
+ * Episciences_ReviewsManagerTest: the real (fixture-less) test DB safely returns
+ * an empty result set for an unknown journal, exercising the guard-clause branches
+ * without needing fixtures or mocking the static Managers.
+ */
+class GetDoiCommandTest extends TestCase
+{
+    private const UNKNOWN_RVID = 999999999;
+    private const UNKNOWN_CODE = 'unknown-test-journal';
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** @param array<int, mixed> $args */
+    private function invokePrivate(object $object, string $method, array $args): mixed
+    {
+        $reflection = new ReflectionMethod($object, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($object, $args);
+    }
+
+    /** @return array{0: SymfonyStyle, 1: BufferedOutput} */
+    private function makeIo(): array
+    {
+        $output = new BufferedOutput();
+        return [new SymfonyStyle(new ArrayInput([]), $output), $output];
+    }
+
+    private function makeReview(): Episciences_Review
+    {
+        $review = new Episciences_Review();
+        $review->setRvid(self::UNKNOWN_RVID);
+        $review->setCode(self::UNKNOWN_CODE);
+        return $review;
+    }
+
+    /** Never actually invoked in the guard-clause branches under test. */
+    private function makeCrossrefClient(): CrossrefSubmissionApiClient
+    {
+        $client = new Client(['handler' => HandlerStack::create(new MockHandler([]))]);
+
+        return new CrossrefSubmissionApiClient(
+            $client,
+            new Logger('test'),
+            'https://deposit.example',
+            'https://deposit-test.example',
+            'https://query.example',
+            'https://query-test.example',
+            'login',
+            'password'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Command metadata
+    // -------------------------------------------------------------------------
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('doi:manage', (new GetDoiCommand())->getName());
+    }
+
+    public function testCommandHasExpectedOptions(): void
+    {
+        $definition = (new GetDoiCommand())->getDefinition();
+
+        foreach ([
+            'rvcode', 'rvid', 'paperid', 'assign-accepted', 'assign-published',
+            'request', 'check', 'update', 'fetch-journals', 'dry-run',
+        ] as $option) {
+            $this->assertTrue($definition->hasOption($option), "Missing option: --{$option}");
+        }
+    }
+
+    public function testRvcodeOptionRequiresValue(): void
+    {
+        $definition = (new GetDoiCommand())->getDefinition();
+        $this->assertTrue($definition->getOption('rvcode')->isValueRequired());
+    }
+
+    public function testDryRunOptionIsAFlag(): void
+    {
+        $definition = (new GetDoiCommand())->getDefinition();
+        $this->assertFalse($definition->getOption('dry-run')->acceptValue());
+    }
+
+    // -------------------------------------------------------------------------
+    // requestDois() — empty submission queue guard
+    // -------------------------------------------------------------------------
+
+    public function testRequestDois_NoAssignedDois_ReturnsSuccessWithoutCallingCrossref(): void
+    {
+        [$io, $output] = $this->makeIo();
+
+        $result = $this->invokePrivate(new GetDoiCommand(), 'requestDois', [
+            $io,
+            $this->makeReview(),
+            false,
+            new Client(),
+            $this->makeCrossrefClient(),
+            new Logger('test'),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $result);
+        $this->assertStringContainsString('No DOIs to submit', $output->fetch());
+    }
+
+    // -------------------------------------------------------------------------
+    // updateDois() — empty registered-DOI queue guard
+    // -------------------------------------------------------------------------
+
+    public function testUpdateDois_NoRegisteredDois_ReturnsSuccessWithoutCallingCrossref(): void
+    {
+        [$io, $output] = $this->makeIo();
+
+        $result = $this->invokePrivate(new GetDoiCommand(), 'updateDois', [
+            $io,
+            $this->makeReview(),
+            false,
+            new Client(),
+            $this->makeCrossrefClient(),
+            new Logger('test'),
+            null,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $result);
+        $this->assertStringContainsString('No registered DOIs found to update', $output->fetch());
+    }
+
+    // -------------------------------------------------------------------------
+    // checkDois() — empty collection, status query never issued
+    // -------------------------------------------------------------------------
+
+    public function testCheckDois_NoPendingDois_ReturnsSuccessWithoutFetchingStatus(): void
+    {
+        [$io, $output] = $this->makeIo();
+
+        $result = $this->invokePrivate(new GetDoiCommand(), 'checkDois', [
+            $io,
+            $this->makeReview(),
+            false,
+            $this->makeCrossrefClient(),
+            new Logger('test'),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $result);
+        $this->assertStringContainsString('DOI status check completed', $output->fetch());
+    }
+
+    // -------------------------------------------------------------------------
+    // assignDois() — empty paper list, loop never entered
+    // -------------------------------------------------------------------------
+
+    public function testAssignDois_NoEligiblePapers_ReturnsSuccessWithZeroAssigned(): void
+    {
+        [$io, $output] = $this->makeIo();
+
+        $result = $this->invokePrivate(new GetDoiCommand(), 'assignDois', [
+            Episciences_Paper::STATUS_PUBLISHED,
+            $io,
+            $this->makeReview(),
+            new Episciences_Review_DoiSettings(),
+            new Logger('test'),
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $result);
+        $this->assertStringContainsString('Assigned 0 DOI(s)', $output->fetch());
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchJournals() — HTTP mocked, no DB involved
+    // -------------------------------------------------------------------------
+
+    public function testFetchJournals_Success_WritesJournalsFileAndReturnsSuccess(): void
+    {
+        $targetFile = CACHE_PATH_METADATA . 'journals.json';
+        $previous   = is_file($targetFile) ? file_get_contents($targetFile) : null;
+
+        try {
+            $http = new Client([
+                'handler' => HandlerStack::create(new MockHandler([
+                    new Response(200, [], '[{"rvcode":"epiga"}]'),
+                ])),
+            ]);
+            [$io, $output] = $this->makeIo();
+
+            $result = $this->invokePrivate(new GetDoiCommand(), 'fetchJournals', [$io, $http, new Logger('test')]);
+
+            $this->assertSame(Command::SUCCESS, $result);
+            $this->assertStringContainsString('Journals list saved to', $output->fetch());
+            $this->assertSame('[{"rvcode":"epiga"}]', file_get_contents($targetFile));
+        } finally {
+            if ($previous === null) {
+                @unlink($targetFile);
+            } else {
+                file_put_contents($targetFile, $previous);
+            }
+        }
+    }
+
+    public function testFetchJournals_HttpFailure_ReturnsFailure(): void
+    {
+        $http = new Client([
+            'handler' => HandlerStack::create(new MockHandler([
+                new ConnectException('Connection refused', new Request('GET', 'https://example.test')),
+            ])),
+        ]);
+        [$io, $output] = $this->makeIo();
+
+        $result = $this->invokePrivate(new GetDoiCommand(), 'fetchJournals', [$io, $http, new Logger('test')]);
+
+        $this->assertSame(Command::FAILURE, $result);
+        $this->assertStringContainsString('API request failed', $output->fetch());
+    }
+
+    // -------------------------------------------------------------------------
+    // setJournalConstants() — filesystem only, idempotent once RVCODE/CACHE_PATH
+    // are already defined (as they are under the test bootstrap, RVCODE=dev)
+    // -------------------------------------------------------------------------
+
+    public function testSetJournalConstants_ConstantsAlreadyDefined_DoesNotWarn(): void
+    {
+        // The test bootstrap already defines RVCODE/CACHE_PATH for RVCODE=dev,
+        // so setJournalConstants()'s own define() calls are all no-ops here.
+        [$io, $output] = $this->makeIo();
+
+        $this->invokePrivate(new GetDoiCommand(), 'setJournalConstants', ['some-other-code', $io]);
+
+        $this->assertStringNotContainsString('Could not create cache directory', $output->fetch());
+    }
+}


### PR DESCRIPTION
## Summary
- `CrossrefSubmissionApiClient::postMetadata()` now accepts the XML body directly instead of writing it to `cache/<rvcode>/<rvcode>-<paperid>.xml` and re-reading it via `fopen()`. That intermediate file was never reused after the POST (only its name, as a correlation key for the later status check) and accumulated indefinitely with no cleanup or TTL.
- `MergePdfVolCommand` and `CreateDoajVolumeExportsCommand` filesystem caches now nest the journal code as a directory instead of encoding it in the cache namespace:
  - `cache/volume-pdf-<rvcode>` → `cache/<rvcode>/volume-pdf`
  - `cache/doaj-volume-export-<rvcode>` → `cache/<rvcode>/doaj-volume-export`

## Notes
- `Symfony\Component\Cache\Adapter\FilesystemAdapter` namespaces only allow `[-+_.A-Za-z0-9]` (no `/`), so the rvcode is moved into the adapter's `$directory` parameter instead of the namespace.
- Existing cache directories on disk under the old naming (`cache/volume-pdf-<rvcode>`, `cache/doaj-volume-export-<rvcode>`) become orphaned after deploy — nothing in the code cleans them up automatically; safe to leave (ignored) or remove manually.

## Test plan
- [x] `make phpstan LEVEL=6` on all touched files — no errors
- [x] `CrossrefSubmissionApiClientTest` (adapted to new in-memory contract, dropped obsolete missing-file test) — 9/9 pass
- [x] `MergePdfVolCommandTest` — 12/12 pass
- [x] `CreateDoajVolumeExportsCommandTest` — 12/12 pass