### PR TITLE
feat(mail): make permanent article ID (%PERMANENT_ARTICLE_ID%) available in email templates

### DIFF
--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -1041,10 +1041,9 @@ class Episciences_Mail extends Zend_Mail
         if (array_key_exists(self::PAPER_ID_CACHE_KEY, self::$_cache)) {
             return self::$_cache[self::PAPER_ID_CACHE_KEY];
         }
-
-        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        
         $select = Episciences_PapersManager::partialGetQuery($this->_docid, 'PAPERID');
-        $paperId = (int)$db?->fetchOne($select);
+        $paperId = (int)$select->getAdapter()?->fetchOne($select);
 
         // cache result
         self::$_cache[self::PAPER_ID_CACHE_KEY] = $paperId;

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -648,6 +648,7 @@ class Episciences_Mail extends Zend_Mail
         $this->_docid = $docid;
 
         $this->addTag(Episciences_Mail_Tags::TAG_PAPER_ID, $docid);
+        $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $this->getPaperId());
 
         if (defined('RVCODE')) {
             $baseurl = SERVER_PROTOCOL . '://' . RVCODE . '.' . DOMAIN;
@@ -1024,6 +1025,13 @@ class Episciences_Mail extends Zend_Mail
     {
         $this->uid = $uid;
         return $this;
+    }
+
+    private function getPaperId(): int
+    {
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+        $select = Episciences_PapersManager::partialGetQuery((int)$this->_docid, 'paperid');
+        return (int)$db->fetchOne($select);
     }
 
 

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -2,6 +2,7 @@
 
 class Episciences_Mail extends Zend_Mail
 {
+    public const PAPER_ID_CACHE_KEY = 'paperid';
     /**
      * We're fine
      */
@@ -46,6 +47,7 @@ class Episciences_Mail extends Zend_Mail
     private $_rawBody;
     protected bool $_isAutomatic = false;
     private ?int $uid = null ;
+    private static array $_cache = []; // to avoid this sort of problem: N+1 queries in loops.
 
     /**
      * Episciences_Mail constructor.
@@ -1029,9 +1031,28 @@ class Episciences_Mail extends Zend_Mail
 
     private function getPaperId(): int
     {
+
+        if (array_key_exists(self::PAPER_ID_CACHE_KEY, self::$_cache)) {
+            return self::$_cache[self::PAPER_ID_CACHE_KEY];
+        }
+
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
         $select = Episciences_PapersManager::partialGetQuery($this->_docid, 'PAPERID');
         $paperId = (int)$db?->fetchOne($select);
+
+        // cache result
+        self::$_cache[self::PAPER_ID_CACHE_KEY] = $paperId;
+
         return $paperId ?: $this->_docid;
     }
+
+    /**
+     * Clear the internal cache
+     * @return void
+     */
+    public static function clearCache(): void
+    {
+        self::$_cache = [];
+    }
+
 }

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -645,7 +645,7 @@ class Episciences_Mail extends Zend_Mail
 
     public function setDocid($docid)
     {
-        $this->_docid = $docid;
+        $this->_docid = (int)$docid;
 
         $this->addTag(Episciences_Mail_Tags::TAG_PAPER_ID, $docid);
         $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $this->getPaperId());
@@ -1030,9 +1030,8 @@ class Episciences_Mail extends Zend_Mail
     private function getPaperId(): int
     {
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-        $select = Episciences_PapersManager::partialGetQuery((int)$this->_docid, 'paperid');
-        return (int)$db->fetchOne($select);
+        $select = Episciences_PapersManager::partialGetQuery($this->_docid, 'PAPERID');
+        $paperId = (int)$db?->fetchOne($select);
+        return $paperId ?: $this->_docid;
     }
-
-
 }

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -645,12 +645,18 @@ class Episciences_Mail extends Zend_Mail
         return $this->_docid;
     }
 
-    public function setDocid($docid)
+    /**
+     * @param $docid
+     * @param int|null $paperId: To be used to avoid systematically incurring the cost of a query; a caching solution is also available.
+     * @return $this
+     */
+
+    public function setDocid($docid, int $paperId = null)
     {
         $this->_docid = (int)$docid;
 
         $this->addTag(Episciences_Mail_Tags::TAG_PAPER_ID, $docid);
-        $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $this->getPaperId());
+        $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $paperId ?: $this->getPaperId());
 
         if (defined('RVCODE')) {
             $baseurl = SERVER_PROTOCOL . '://' . RVCODE . '.' . DOMAIN;

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -2,7 +2,6 @@
 
 class Episciences_Mail extends Zend_Mail
 {
-    public const PAPER_ID_CACHE_KEY = 'paperid';
     /**
      * We're fine
      */
@@ -1038,21 +1037,21 @@ class Episciences_Mail extends Zend_Mail
     private function getPaperId(): int
     {
 
-        if (array_key_exists(self::PAPER_ID_CACHE_KEY, self::$_cache)) {
-            return self::$_cache[self::PAPER_ID_CACHE_KEY];
+        if (array_key_exists($this->_docid, self::$_cache)) {
+            return self::$_cache[$this->_docid];
         }
-        
+
         $select = Episciences_PapersManager::partialGetQuery($this->_docid, 'PAPERID');
         $paperId = (int)$select->getAdapter()?->fetchOne($select);
 
         // cache result
-        self::$_cache[self::PAPER_ID_CACHE_KEY] = $paperId;
-
+        self::$_cache[$this->_docid] = $paperId;
         return $paperId ?: $this->_docid;
     }
 
     /**
      * Clear the internal cache
+     * Still handy for isolating static state between unit tests
      * @return void
      */
     public static function clearCache(): void

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -650,12 +650,17 @@ class Episciences_Mail extends Zend_Mail
      * @return $this
      */
 
-    public function setDocid($docid, int $paperId = null)
+    public function setDocid($docid, int $paperId = null): self
     {
         $this->_docid = (int)$docid;
 
         $this->addTag(Episciences_Mail_Tags::TAG_PAPER_ID, $docid);
-        $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $paperId ?: $this->getPaperId());
+
+        $resolvedPaperId = $paperId ?? $this->getPaperId();
+
+        if ($resolvedPaperId !== null) {
+            $this->addTag(Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID, $resolvedPaperId);
+        }
 
         if (defined('RVCODE')) {
             $baseurl = SERVER_PROTOCOL . '://' . RVCODE . '.' . DOMAIN;
@@ -1034,19 +1039,26 @@ class Episciences_Mail extends Zend_Mail
         return $this;
     }
 
-    private function getPaperId(): int
-    {
 
+    private function getPaperId(): ?int
+    {
         if (array_key_exists($this->_docid, self::$_cache)) {
             return self::$_cache[$this->_docid];
         }
 
         $select = Episciences_PapersManager::partialGetQuery($this->_docid, 'PAPERID');
-        $paperId = (int)$select->getAdapter()?->fetchOne($select);
+        $paperId = $select->getAdapter()?->fetchOne($select);
+        $paperId = ($paperId !== false && $paperId !== null) ? (int)$paperId : null;
 
-        // cache result
+        if ($paperId === null) {
+            trigger_error(sprintf(
+                    'Episciences_Mail::getPaperId() - PAPERID not found for DOCID=%d, %%PERMANENT_ARTICLE_ID%% tag left unset',
+                    $this->_docid
+            ), E_USER_WARNING);
+        }
+
         self::$_cache[$this->_docid] = $paperId;
-        return $paperId ?: $this->_docid;
+        return $paperId;
     }
 
     /**

--- a/library/Episciences/Mail/TemplatesManager.php
+++ b/library/Episciences/Mail/TemplatesManager.php
@@ -508,6 +508,7 @@ class Episciences_Mail_TemplatesManager
         Episciences_Mail_Tags::TAG_COI_EDITOR_FULL_NAME,
         Episciences_Mail_Tags::TAG_COI_LAST_EDITOR_MESSAGE,
         Episciences_Mail_Tags::TAG_ARTICLE_ID,
+        Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID,
         Episciences_Mail_Tags::TAG_ARTICLE_TITLE,
         Episciences_Mail_Tags::TAG_PAPER_URL,
     ];
@@ -521,6 +522,7 @@ class Episciences_Mail_TemplatesManager
         Episciences_Mail_Tags::TAG_RECIPIENT_USERNAME_LOST_LOGIN,
         Episciences_Mail_Tags::TAG_COI_EDITOR_FULL_NAME,
         Episciences_Mail_Tags::TAG_ARTICLE_ID,
+        Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID,
         Episciences_Mail_Tags::TAG_ARTICLE_TITLE,
         Episciences_Mail_Tags::TAG_PAPER_URL,
     ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved paper identification in email notifications by reliably resolving and applying permanent article IDs.
  - Added warnings when a paper ID cannot be found.
  - Improved handling of document IDs for consistent notification behavior.

- **Enhancements**
  - Added permanent article ID support to additional editor conflict-of-interest email templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->