### PR TITLE
feat(routing): add /articles/{docid} URL aliases for the CLOCKSS transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [CLOCKSS] Additional article URLs, published ahead of the actual switch to ease harvesting during the transition period: `/articles/{docid}` and `/articles/{docid}/download`, both also accepting an optional `en`, `fr` or `es` language prefix (e.g. `/en/articles/{docid}`). These are pure routing aliases: the historical `/{docid}` and `/{docid}/pdf` URLs are unchanged.
+
 ### Fixed
 
 - Allow paper authors to download review report attachments after an editorial decision by aligning authorization checks in `FileController::reportAction()`.

--- a/application/configs/application.ini
+++ b/application/configs/application.ini
@@ -195,6 +195,46 @@ resources.router.routes.csl.defaults.action = "csl"
 resources.router.routes.csl.map.id = 1
 resources.router.routes.csl.reverse = "%d/csl"
 
+; CLOCKSS transition: additional article URLs, published ahead of the actual switch.
+; The historical routes above are left untouched: these are pure aliases to the same
+; controllers/actions. The language prefix is optional, hence two sets of routes: a single
+; route with an optional group would set an empty "lang" param, which the translation plugin
+; would resolve to French instead of falling back to the cookie/browser detection.
+
+; /articles/18732
+resources.router.routes.articles.type = "Zend_Controller_Router_Route_Regex"
+resources.router.routes.articles.route = "articles/(\d+)"
+resources.router.routes.articles.defaults.controller = "paper"
+resources.router.routes.articles.defaults.action = "view"
+resources.router.routes.articles.map.id = 1
+resources.router.routes.articles.reverse = "articles/%d"
+
+; /articles/18732/download
+resources.router.routes.articles_download.type = "Zend_Controller_Router_Route_Regex"
+resources.router.routes.articles_download.route = "articles/(\d+)/download"
+resources.router.routes.articles_download.defaults.controller = "paper"
+resources.router.routes.articles_download.defaults.action = "pdf"
+resources.router.routes.articles_download.map.id = 1
+resources.router.routes.articles_download.reverse = "articles/%d/download"
+
+; /en/articles/18732
+resources.router.routes.articles_lang.type = "Zend_Controller_Router_Route_Regex"
+resources.router.routes.articles_lang.route = "(en|fr|es)/articles/(\d+)"
+resources.router.routes.articles_lang.defaults.controller = "paper"
+resources.router.routes.articles_lang.defaults.action = "view"
+resources.router.routes.articles_lang.map.lang = 1
+resources.router.routes.articles_lang.map.id = 2
+resources.router.routes.articles_lang.reverse = "%s/articles/%d"
+
+; /en/articles/18732/download
+resources.router.routes.articles_lang_download.type = "Zend_Controller_Router_Route_Regex"
+resources.router.routes.articles_lang_download.route = "(en|fr|es)/articles/(\d+)/download"
+resources.router.routes.articles_lang_download.defaults.controller = "paper"
+resources.router.routes.articles_lang_download.defaults.action = "pdf"
+resources.router.routes.articles_lang_download.map.lang = 1
+resources.router.routes.articles_lang_download.map.id = 2
+resources.router.routes.articles_lang_download.reverse = "%s/articles/%d/download"
+
 [preprod : production]
 
 [testing : preprod]

--- a/tests/unit/modules/RouterAliasTest.php
+++ b/tests/unit/modules/RouterAliasTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unit\modules;
+
+use PHPUnit\Framework\TestCase;
+use Zend_Controller_Front;
+use Zend_Controller_Router_Rewrite;
+
+/**
+ * Routing checks for the article URLs declared in application/configs/application.ini.
+ *
+ * Covers both the historical routes (non-regression) and the /articles/... aliases
+ * added for the CLOCKSS transition.
+ */
+final class RouterAliasTest extends TestCase
+{
+    private const DOCID = '18732';
+
+    /**
+     * The historical routes must keep matching exactly what they used to match.
+     */
+    public function testLegacyPaperRoutesAreUnchanged(): void
+    {
+        self::assertSame(
+            ['id' => self::DOCID, 'controller' => 'paper', 'action' => 'view'],
+            $this->match('paper', self::DOCID)
+        );
+
+        self::assertSame(
+            ['id' => self::DOCID, 'controller' => 'paper', 'action' => 'pdf'],
+            $this->match('pdf', self::DOCID . '/pdf')
+        );
+    }
+
+    /**
+     * Regex routes are anchored (#^...$#i), so an aliased path can never be swallowed
+     * by the legacy "(\d+)" route.
+     */
+    public function testLegacyPaperRouteDoesNotMatchAliases(): void
+    {
+        $this->assertNoMatch('paper', 'articles/' . self::DOCID);
+        $this->assertNoMatch('paper', 'en/articles/' . self::DOCID);
+        $this->assertNoMatch('pdf', 'articles/' . self::DOCID . '/download');
+    }
+
+    public function testArticlesAliasMatchesPaperView(): void
+    {
+        self::assertSame(
+            ['id' => self::DOCID, 'controller' => 'paper', 'action' => 'view'],
+            $this->match('articles', 'articles/' . self::DOCID)
+        );
+    }
+
+    public function testArticlesDownloadAliasMatchesPaperPdf(): void
+    {
+        self::assertSame(
+            ['id' => self::DOCID, 'controller' => 'paper', 'action' => 'pdf'],
+            $this->match('articles_download', 'articles/' . self::DOCID . '/download')
+        );
+    }
+
+    /**
+     * The language prefix is mapped to the "lang" parameter, which
+     * Episciences_Translation_Plugin reads through $request->getParam('lang').
+     *
+     * @dataProvider languagePrefixProvider
+     */
+    public function testLanguagePrefixedAliases(string $lang): void
+    {
+        self::assertSame(
+            ['lang' => $lang, 'id' => self::DOCID, 'controller' => 'paper', 'action' => 'view'],
+            $this->match('articles_lang', $lang . '/articles/' . self::DOCID)
+        );
+
+        self::assertSame(
+            ['lang' => $lang, 'id' => self::DOCID, 'controller' => 'paper', 'action' => 'pdf'],
+            $this->match('articles_lang_download', $lang . '/articles/' . self::DOCID . '/download')
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function languagePrefixProvider(): array
+    {
+        return [
+            'english' => ['en'],
+            'french' => ['fr'],
+            'spanish' => ['es'],
+        ];
+    }
+
+    public function testUnsupportedPathsAreRejected(): void
+    {
+        // no document id
+        $this->assertNoMatch('articles', 'articles');
+        $this->assertNoMatch('articles', 'articles/');
+        // unsupported language prefix
+        $this->assertNoMatch('articles_lang', 'de/articles/' . self::DOCID);
+        $this->assertNoMatch('articles_lang_download', 'de/articles/' . self::DOCID . '/download');
+        // a language prefix is not accepted on the legacy routes
+        $this->assertNoMatch('paper', 'en/' . self::DOCID);
+        // non-numeric document id
+        $this->assertNoMatch('articles', 'articles/abc');
+        // trailing segment
+        $this->assertNoMatch('articles', 'articles/' . self::DOCID . '/download');
+    }
+
+    /**
+     * assemble() is what the url() view helper calls when no route name is given:
+     * it uses the currently matched route, so every alias needs a usable reverse.
+     */
+    public function testAliasesCanBeAssembled(): void
+    {
+        $params = ['controller' => 'paper', 'action' => 'view', 'id' => self::DOCID];
+
+        self::assertSame('articles/' . self::DOCID, $this->assemble('articles', $params));
+        self::assertSame(
+            'articles/' . self::DOCID . '/download',
+            $this->assemble('articles_download', ['id' => self::DOCID])
+        );
+        self::assertSame(
+            'en/articles/' . self::DOCID,
+            $this->assemble('articles_lang', $params + ['lang' => 'en'])
+        );
+        self::assertSame(
+            'fr/articles/' . self::DOCID . '/download',
+            $this->assemble('articles_lang_download', ['lang' => 'fr', 'id' => self::DOCID])
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function match(string $routeName, string $path): array
+    {
+        $values = $this->router()->getRoute($routeName)->match($path);
+
+        if (!is_array($values)) {
+            self::fail(sprintf('Route "%s" was expected to match "%s"', $routeName, $path));
+        }
+
+        return $values;
+    }
+
+    private function assertNoMatch(string $routeName, string $path): void
+    {
+        self::assertFalse(
+            $this->router()->getRoute($routeName)->match($path),
+            sprintf('Route "%s" must not match "%s"', $routeName, $path)
+        );
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function assemble(string $routeName, array $params): string
+    {
+        return (string)$this->router()->getRoute($routeName)->assemble($params);
+    }
+
+    private function router(): Zend_Controller_Router_Rewrite
+    {
+        $router = Zend_Controller_Front::getInstance()->getRouter();
+
+        if (!$router instanceof Zend_Controller_Router_Rewrite) {
+            self::fail('The front controller router is not a Zend_Controller_Router_Rewrite');
+        }
+
+        return $router;
+    }
+}


### PR DESCRIPTION
## Objectif

Publier à l'avance les futures URL d'article afin que CLOCKSS puisse les moissonner pendant la période de transition, **sans changer les URL actuelles**.

| Nouvelle URL | Sert |
|---|---|
| `/articles/{docid}` | `paper/view` |
| `/articles/{docid}/download` | `paper/pdf` |
| `/{en\|fr\|es}/articles/{docid}` | `paper/view` |
| `/{en\|fr\|es}/articles/{docid}/download` | `paper/pdf` |

## Portée

**Zéro ligne de code applicatif.** 40 lignes de configuration dans `application/configs/application.ini` (`Zend_Controller_Router_Route_Regex`) et un test de routage.

Ce sont de purs alias de routage vers les contrôleurs/actions existants : les routes historiques `/{docid}` et `/{docid}/pdf` sont intactes, et l'ACL, les exports et les métadonnées (qui construisent leurs URL depuis `APPLICATION_URL`) ne sont pas affectés.

Le préfixe de langue est déclaré en **deux jeux de routes** plutôt qu'en un groupe optionnel unique : un groupe optionnel non satisfait positionne un paramètre `lang` vide, que `Episciences_Translation_Plugin` résout en français au lieu de retomber sur la détection cookie/navigateur.

## Vérifications

`make test-php` : **4698 tests OK**, identique à `main`. Le nouveau `RouterAliasTest` couvre 9 cas (routes historiques inchangées, chaque alias, les 3 préfixes de langue, chemins rejetés, `assemble()`).

Sur l'instance de dev :

| URL | Code |
|---|---|
| `/18732`, `/18732/pdf` | 200 — inchangées |
| `/articles/18732`, `/articles/18732/download` | 200 |
| `/en/`, `/fr/`, `/es/` + les deux formes | 200 |
| `/de/articles/18732`, `/articles`, `/articles/abc`, `/articles/999999999` | 404 |

`/18732` et `/articles/18732` renvoient une réponse identique à l'octet (84505). `/fr/articles/18732` renvoie bien `set-cookie: lang=fr`.

## Limites assumées

Aucune ne bloque le moissonnage, mais il faut les connaître pour ce qu'on transmet à CLOCKSS :

1. **Le Signposting reste sur les URL historiques.** Sur `/articles/18732`, une requête HEAD annonce `Link: <…/articles/18732/tei>; rel="describedby"` → 404. Les URL à moissonner doivent donc être fournies explicitement, sans passer par la découverte Signposting.
2. **Les formats d'export n'ont pas d'alias** : `/18732/tei` → 200, `/articles/18732/tei` → 404.
3. **Le sitemap n'expose que `/{docid}`** (`SitemapController.php:53`) : un moissonneur partant du sitemap ne découvrira pas les nouvelles URL.

Les URL à transmettre sont `/articles/{docid}` et `/articles/{docid}/download`, construites depuis la liste des docid publiés — jamais depuis un paperid, ce qui évite la redirection vers la version publiée (302 hors du namespace `/articles/`, comportement préexistant, non traité ici).

## Retrait après la transition

`git revert 4a68b4233`, rien d'autre à défaire.