### PR TITLE
fix(paper): mise à jour de version Zenodo écrase VERSION avec l'identifiant

### DIFF
--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -5102,7 +5102,11 @@ class AdministratepaperController extends PaperDefaultController
             return false;
         }
 
-        $hookedVersion = Episciences_Repositories::callHook('hookVersion', ['identifier' => $latestPostedVersion, 'repoId' => $paper->getRepoid()]);
+        $hookedVersion = Episciences_Repositories::callHook('hookVersion', [
+            'identifier' => $latestPostedVersion,
+            'repoId' => $paper->getRepoid(),
+            'context' => ['previousVersion' => $paper->getVersion()],
+        ]);
 
         if (isset($hookedVersion['version']) || $hasDateTime) {
             $paper->setIdentifier($latestPostedVersion); // posted identifier

--- a/tests/unit/modules/journal/controllers/AdministratepaperControllerTest.php
+++ b/tests/unit/modules/journal/controllers/AdministratepaperControllerTest.php
@@ -1384,4 +1384,32 @@ class AdministratepaperControllerTest extends TestCase
             'BUG #1010: savenewdeadlineAction should no longer use today\'s date for range calculation'
         );
     }
+
+    // ---------------------------------------------------------------
+    // BUG — Zenodo: posted identifier overwrites VERSION, IDENTIFIER not saved
+    // ---------------------------------------------------------------
+
+    /**
+     * @covers AdministratepaperController::savenewpostedversionAction
+     *
+     * Bug: for repositories where the posted value is an identifier rather than
+     * a version number (e.g. Zenodo), the 'hookVersion' hook must be given
+     * 'context' => ['previousVersion' => ...] so it can fall back to
+     * previousVersion + 1 when the repository does not expose an explicit
+     * version number. Without it, Episciences_Repositories_Zenodo_Hooks::hookVersion()
+     * returns [], the whole conversion block is skipped, and the raw posted
+     * identifier is written into VERSION while IDENTIFIER is never updated.
+     */
+    public function testSavenewpostedversionActionPassesPreviousVersionContextToHookVersion(): void
+    {
+        $method = $this->extractMethod('savenewpostedversionAction');
+
+        $this->assertMatchesRegularExpression(
+            '/callHook\(\s*\'hookVersion\'\s*,\s*\[.*?\'context\'\s*=>\s*\[\s*\'previousVersion\'\s*=>\s*\$paper->getVersion\(\)/s',
+            $method,
+            "BUG: savenewpostedversionAction must pass 'context' => ['previousVersion' => \$paper->getVersion()] "
+            . "to the 'hookVersion' hook, otherwise Zenodo's hookVersion() cannot increment the version and "
+            . 'the posted identifier ends up written into VERSION while IDENTIFIER is left untouched'
+        );
+    }
 }


### PR DESCRIPTION
## Résumé
- `savenewpostedversionAction` postait l'identifiant Zenodo choisi par l'utilisateur sans transmettre `context.previousVersion` au hook `hookVersion`, ce qui faisait échouer silencieusement la conversion identifiant → version pour Zenodo (pas de `metadata.version` renseigné dans la majorité des cas).
- Conséquence : la colonne `VERSION` recevait l'identifiant Zenodo brut au lieu d'être incrémentée, et la colonne `IDENTIFIER` n'était jamais mise à jour.
- Correctif : transmettre `'context' => ['previousVersion' => $paper->getVersion()]` au hook, comme le fait déjà `Episciences_Submit::getDoc()` via `addContext()`. `Episciences_Repositories_Zenodo_Hooks::hookVersion()` peut alors retomber sur `previousVersion + 1`, ce qui restaure à la fois l'incrément de version et la mise à jour de `IDENTIFIER`.

## Test plan
- [x] Ajout d'un test de régression (`testSavenewpostedversionActionPassesPreviousVersionContextToHookVersion`) qui vérifie que l'appel à `callHook('hookVersion', ...)` transmet bien `context.previousVersion`.
- [x] `make test-php TARGET=tests/unit/modules/journal/controllers/AdministratepaperControllerTest.php` — vert (les 3 erreurs restantes dans `ZbjatsZipperCommandTest` sont préexistantes sur `main`, sans rapport avec ce correctif).
- [ ] Vérification manuelle en environnement de dev sur un article avec dépôt Zenodo multi-versions (test réel recommandé côté utilisateur).