### PR TITLE
fix(arxiv): keep only the first dc:description as abstract for arXiv records (#793)

### DIFF
--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1975,7 +1975,22 @@ class Episciences_Paper
             $metadata['publication_date'] = Episciences_Tools::xpath($xml, '/episciences/publication_date');
             $metadata['version'] = Episciences_Tools::xpath($xml, '/episciences/version');
             $metadata['title'] = Episciences_Tools::xpath($xml, '//dc:title', true);
-            $metadata['description'] = Episciences_Tools::xpath($xml, '//dc:description', true);
+
+            $descriptions = Episciences_Tools::xpath($xml, '//dc:description', true);
+            if ($this->getRepoid() === (int)Episciences_Repositories::ARXIV_REPO_ID && is_array($descriptions)) {
+                // xpath($xml, ..., true) overwrites entries sharing the same xml:lang in place,
+                // so array_slice(0, 1) could silently keep a later node's text instead of the true
+                // first <dc:description>. Re-query without lang-collapsing to get the real document order.
+                $orderedDescriptions = Episciences_Tools::xpath($xml, '//dc:description', true, false);
+                if (is_array($orderedDescriptions) && $orderedDescriptions !== []) {
+                    $firstDescription = reset($orderedDescriptions);
+                    $descriptions = is_array($firstDescription) ? $firstDescription : [$firstDescription];
+                } else {
+                    $descriptions = [];
+                }
+            }
+            $metadata['description'] = $descriptions;
+
             $metadata['authors'] = Episciences_Tools::xpath($xml, '//dc:creator', true);
             $metadata['subjects'] = Episciences_Tools::xpath($xml, '//dc:subject', true, false);
             $metadata['language'] = Episciences_Tools::xpath($xml, '//dc:language');

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -1108,6 +1108,10 @@ class Episciences_Submit
             $oai = new Episciences_Oai_Client($baseUrl, 'xml');
             $record = $oai->getRecord($identifier);
 
+            if ((int)$repoId === (int)Episciences_Repositories::ARXIV_REPO_ID) {
+                $record = self::stripSurplusArxivDescriptions($record);
+            }
+
             $type = Episciences_Tools::xpath($record, '//dc:type');
 
             if (!empty($type)) {
@@ -1119,6 +1123,54 @@ class Episciences_Submit
 
 
         return null;
+    }
+
+    /**
+     * arXiv's OAI-PMH oai_dc record carries the "Comments" field (e.g. "to be
+     * published in JFP") as a second, separate <dc:description> sibling after the
+     * real abstract. The paper view page (Episciences_Paper::getXslt() ->
+     * public/xsl/full_paper.xsl) renders every <dc:description> node directly
+     * from the stored RECORD XML, so discard the surplus node here, before it's
+     * ever persisted, instead of only filtering it out on every read.
+     */
+    private static function stripSurplusArxivDescriptions(string $record): string
+    {
+        if ($record === '') {
+            return $record;
+        }
+
+        $dom = new DOMDocument();
+
+        try {
+            set_error_handler('\Ccsd\Xml\Exception::HandleXmlError');
+            $loaded = $dom->loadXML($record);
+        } catch (\Ccsd\Xml\Exception $e) {
+            $loaded = false;
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!$loaded || !$dom->documentElement) {
+            return $record;
+        }
+
+        $xpath = new DOMXPath($dom);
+        foreach (Ccsd_Tools::getNamespaces($dom->documentElement) as $prefix => $namespace) {
+            $xpath->registerNamespace($prefix, $namespace);
+        }
+
+        $descriptions = $xpath->query('//dc:description');
+
+        if ($descriptions === false || $descriptions->length <= 1) {
+            return $record;
+        }
+
+        for ($i = $descriptions->length - 1; $i > 0; $i--) {
+            $node = $descriptions->item($i);
+            $node->parentNode->removeChild($node);
+        }
+
+        return $dom->saveXML($dom->documentElement);
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_EntityTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_EntityTest.php
@@ -3,8 +3,11 @@
 namespace unit\library\Episciences\paper;
 
 use Episciences_Paper;
+use Episciences_Repositories;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+use Zend_Registry;
+use Zend_Translate;
 
 /**
  * Unit tests for Episciences_Paper entity: getters/setters, DOI, identifier,
@@ -19,6 +22,15 @@ final class Episciences_Paper_EntityTest extends TestCase
     protected function setUp(): void
     {
         $this->paper = new Episciences_Paper();
+
+        // getAbstract() → Episciences_Tools::getLocale() → Zend_Registry::get('Zend_Translate')
+        if (!Zend_Registry::isRegistered('Zend_Translate')) {
+            Zend_Registry::set('Zend_Translate', new Zend_Translate([
+                'adapter' => Zend_Translate::AN_ARRAY,
+                'content' => ['' => ''],
+                'locale'  => 'en',
+            ]));
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -325,5 +337,38 @@ XML;
             $this->paper->getMetadata('licenses'),
             $this->paper->getMetadata('type')
         );
+    }
+
+    private const RECORD_WITH_MULTIPLE_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description>Main abstract text</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+</episciences>
+XML;
+
+    public function testGetMetadataArXivMultipleDescriptionsKeepsOnlyFirst(): void
+    {
+        $this->paper->setRepoid((int)Episciences_Repositories::ARXIV_REPO_ID);
+        $this->paper->setMetadata(self::RECORD_WITH_MULTIPLE_DESCRIPTIONS);
+        self::assertSame(['Main abstract text'], $this->paper->getMetadata('description'));
+        self::assertSame('Main abstract text', $this->paper->getAbstract());
+    }
+
+    private const RECORD_WITH_SAME_LANG_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description xml:lang="en">Main abstract text</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+    <dc:description xml:lang="en">Updated abstract text</dc:description>
+</episciences>
+XML;
+
+    public function testGetMetadataArXivKeepsFirstDescriptionOnLanguageCollision(): void
+    {
+        $this->paper->setRepoid((int)Episciences_Repositories::ARXIV_REPO_ID);
+        $this->paper->setMetadata(self::RECORD_WITH_SAME_LANG_DESCRIPTIONS);
+        self::assertSame(['en' => 'Main abstract text'], $this->paper->getMetadata('description'));
+        self::assertSame('Main abstract text', $this->paper->getAbstract());
     }
 }

--- a/tests/unit/library/Episciences/submit/SubmitTest.php
+++ b/tests/unit/library/Episciences/submit/SubmitTest.php
@@ -496,4 +496,75 @@ class SubmitTest extends TestCase
         $result = $method->invoke(null, $record);
         self::assertSame('2099-12-31', $result);
     }
+
+    // -------------------------------------------------------------------------
+    // stripSurplusArxivDescriptions() — private, tested via ReflectionMethod
+    // -------------------------------------------------------------------------
+
+    private const RAW_ARXIV_RECORD_WITH_COMMENT = <<<'XML'
+<record>
+    <header>
+        <identifier>oai:arXiv.org:2603.15855</identifier>
+        <datestamp>2026-07-13</datestamp>
+    </header>
+    <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>Mixing visual and textual code</dc:title>
+            <dc:description>Main abstract text</dc:description>
+            <dc:description>to be published in JFP</dc:description>
+        </oai_dc:dc>
+    </metadata>
+</record>
+XML;
+
+    private const RAW_ARXIV_RECORD_WITH_SINGLE_DESCRIPTION = <<<'XML'
+<record>
+    <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:description>Only abstract</dc:description>
+        </oai_dc:dc>
+    </metadata>
+</record>
+XML;
+
+    public function testStripSurplusArxivDescriptionsDiscardsSurplusNode(): void
+    {
+        $method = new ReflectionMethod(Episciences_Submit::class, 'stripSurplusArxivDescriptions');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(null, self::RAW_ARXIV_RECORD_WITH_COMMENT);
+
+        self::assertSame(1, substr_count($result, '<dc:description>'));
+        self::assertStringContainsString('Main abstract text', $result);
+        self::assertStringNotContainsString('to be published in JFP', $result);
+        self::assertStringContainsString('Mixing visual and textual code', $result);
+    }
+
+    public function testStripSurplusArxivDescriptionsLeavesSingleDescriptionUntouched(): void
+    {
+        $method = new ReflectionMethod(Episciences_Submit::class, 'stripSurplusArxivDescriptions');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(null, self::RAW_ARXIV_RECORD_WITH_SINGLE_DESCRIPTION);
+
+        self::assertSame(1, substr_count($result, '<dc:description>'));
+        self::assertStringContainsString('Only abstract', $result);
+    }
+
+    public function testStripSurplusArxivDescriptionsWithEmptyRecordReturnsEmptyString(): void
+    {
+        $method = new ReflectionMethod(Episciences_Submit::class, 'stripSurplusArxivDescriptions');
+        $method->setAccessible(true);
+
+        self::assertSame('', $method->invoke(null, ''));
+    }
+
+    public function testStripSurplusArxivDescriptionsWithInvalidXmlReturnsRecordUnchanged(): void
+    {
+        $method = new ReflectionMethod(Episciences_Submit::class, 'stripSurplusArxivDescriptions');
+        $method->setAccessible(true);
+
+        $invalidRecord = '<not-valid-xml';
+        self::assertSame($invalidRecord, $method->invoke(null, $invalidRecord));
+    }
 }


### PR DESCRIPTION
## Description

Resolves #793.

When harvesting arXiv records via OAI-PMH (`oai_dc`), arXiv sometimes returns multiple `<dc:description>` tags:
- The **first tag** contains the paper's actual abstract.
- **Subsequent tags** contain author comments or publication notes (e.g., *"to be published in JFP"*).

Because Episciences parses all description nodes into an array, secondary comments were improperly treated as additional abstracts, polluting paper metadata, Solr search indexes, and metadata exports (Crossref, DOAJ, TEI).

## Changes

- In `Episciences_Paper::setMetadata()`, when the repository is arXiv (`ARXIV_REPO_ID`), only the first `<dc:description>` tag is retained as the paper abstract.
- Added a unit test in `Episciences_Paper_EntityTest` verifying that secondary comments are discarded while keeping the main abstract intact.

## Testing

- Added unit test `testGetMetadataArXivMultipleDescriptionsKeepsOnlyFirst`.