### PR TITLE
refactor(repo): add hookFilterMetadata to handle repository specific metadata filtering (#793)

### DIFF
--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1986,6 +1986,14 @@ class Episciences_Paper
             $metadata['description'] = 'Merci de contacter le support pour vérifier le document et ses métadonnées';
         }
 
+        $hookResult = Episciences_Repositories::callHook('hookFilterMetadata', [
+            'repoId'   => $this->getRepoid(),
+            'metadata' => $metadata,
+            'xml'      => $xml
+        ]);
+        if (isset($hookResult['metadata']) && is_array($hookResult['metadata'])) {
+            $metadata = $hookResult['metadata'];
+        }
 
         $this->_metadata = $metadata;
         return $this;

--- a/library/Episciences/Repositories/ArXiv/Hooks.php
+++ b/library/Episciences/Repositories/ArXiv/Hooks.php
@@ -1,0 +1,120 @@
+<?php
+
+use Episciences\Repositories\CommonHooksInterface;
+
+class Episciences_Repositories_ArXiv_Hooks implements CommonHooksInterface
+{
+    /**
+     * Filter extracted metadata specifically for arXiv records (#793).
+     * Keeps only the first dc:description element as the paper abstract.
+     *
+     * @param array<string, mixed> $hookParams
+     * @return array{metadata: array<string, mixed>}
+     */
+    public static function hookFilterMetadata(array $hookParams): array
+    {
+        $metadata = $hookParams['metadata'] ?? [];
+        $xml = $hookParams['xml'] ?? '';
+
+        if (isset($metadata['description']) && is_array($metadata['description']) && $xml !== '') {
+            // Episciences_Tools::xpath($xml, ..., true) overwrites entries sharing the same
+            // xml:lang in place, so array_slice(0, 1) on that result could silently keep a
+            // later node's text instead of the true first <dc:description>. Re-query without
+            // lang-collapsing to get the real document order.
+            $orderedDescriptions = Episciences_Tools::xpath($xml, '//dc:description', true, false);
+            if (is_array($orderedDescriptions) && $orderedDescriptions !== []) {
+                $firstDescription = reset($orderedDescriptions);
+                $metadata['description'] = is_array($firstDescription) ? $firstDescription : [$firstDescription];
+            } else {
+                $metadata['description'] = [];
+            }
+        }
+
+        return ['metadata' => $metadata];
+    }
+
+    /**
+     * arXiv's OAI-PMH oai_dc record carries the "Comments" field (e.g. "to be
+     * published in JFP") as a second, separate <dc:description> sibling after the
+     * real abstract. hookFilterMetadata() above only filters the already-parsed
+     * $metadata array, so it never affected PAPERS.RECORD itself - the paper view
+     * page (Paper::getXslt() -> public/xsl/full_paper.xsl) renders every
+     * <dc:description> node directly from the stored RECORD XML and still showed
+     * the surplus node. Strip it here, from the raw XML, before it's ever
+     * persisted, so both the parsed-metadata path and the XSLT path stay in sync.
+     *
+     * @param array<string, mixed> $input
+     * @return array<string, mixed>
+     */
+    public static function hookCleanXMLRecordInput(array $input): array
+    {
+        if (empty($input['record'])) {
+            return $input;
+        }
+
+        $dom = new DOMDocument();
+
+        try {
+            set_error_handler('\Ccsd\Xml\Exception::HandleXmlError');
+            $loaded = $dom->loadXML($input['record']);
+        } catch (\Ccsd\Xml\Exception $e) {
+            $loaded = false;
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!$loaded || !$dom->documentElement) {
+            return $input;
+        }
+
+        $xpath = new DOMXPath($dom);
+        foreach (Ccsd_Tools::getNamespaces($dom->documentElement) as $prefix => $namespace) {
+            $xpath->registerNamespace($prefix, $namespace);
+        }
+
+        $descriptions = $xpath->query('//dc:description');
+
+        if ($descriptions === false || $descriptions->length <= 1) {
+            return $input;
+        }
+
+        for ($i = $descriptions->length - 1; $i > 0; $i--) {
+            $node = $descriptions->item($i);
+            $node->parentNode->removeChild($node);
+        }
+
+        $input['record'] = $dom->saveXML($dom->documentElement);
+
+        return $input;
+    }
+
+    // arXiv has no dedicated handling for these hooks: return [] so
+    // Episciences_Repositories::callHook() falls back to the same defaults
+    // used before this class existed (OAI-based retrieval, version required,
+    // identifier common to all versions).
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     */
+    public static function hookApiRecords(array $hookParams): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function hookIsRequiredVersion(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function hookIsIdentifierCommonToAllVersions(): array
+    {
+        return [];
+    }
+}

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -1108,6 +1108,15 @@ class Episciences_Submit
             $oai = new Episciences_Oai_Client($baseUrl, 'xml');
             $record = $oai->getRecord($identifier);
 
+            $cleanedRecord = Episciences_Repositories::callHook('hookCleanXMLRecordInput', [
+                'record' => $record,
+                'repoId' => (int)$repoId
+            ]);
+
+            if (isset($cleanedRecord['record'])) {
+                $record = $cleanedRecord['record'];
+            }
+
             $type = Episciences_Tools::xpath($record, '//dc:type');
 
             if (!empty($type)) {

--- a/tests/unit/library/Episciences/Repositories/Episciences_RepositoriesTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_RepositoriesTest.php
@@ -106,14 +106,30 @@ final class Episciences_RepositoriesTest extends TestCase
         ];
     }
 
+    private bool $hadMetadataSources;
+    /** @var mixed */
+    private $originalMetadataSources;
+
     protected function setUp(): void
     {
+        $this->hadMetadataSources = Zend_Registry::isRegistered('metadataSources');
+        if ($this->hadMetadataSources) {
+            $this->originalMetadataSources = Zend_Registry::get('metadataSources');
+        }
         Zend_Registry::set('metadataSources', self::$fakeSources);
         $this->resetRepositoriesCache();
     }
 
     protected function tearDown(): void
     {
+        // Zend_Registry is a process-wide singleton: restore whatever was registered
+        // before this test so the fake sources above don't leak into other test files
+        // running later in the same PHPUnit process.
+        if ($this->hadMetadataSources) {
+            Zend_Registry::set('metadataSources', $this->originalMetadataSources);
+        } else {
+            Zend_Registry::getInstance()->offsetUnset('metadataSources');
+        }
         $this->resetRepositoriesCache();
     }
 

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_ArXiv_HooksTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_ArXiv_HooksTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_Repositories_ArXiv_Hooks.
+ *
+ * @covers Episciences_Repositories_ArXiv_Hooks
+ */
+class Episciences_Repositories_ArXiv_HooksTest extends TestCase
+{
+    private const RECORD_WITH_MULTIPLE_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description>Primary abstract text for arXiv paper</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+</episciences>
+XML;
+
+    private const RECORD_WITH_SINGLE_DESCRIPTION = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description>Single abstract text</dc:description>
+</episciences>
+XML;
+
+    private const RECORD_WITH_SAME_LANG_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description xml:lang="en">Primary abstract text for arXiv paper</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+    <dc:description xml:lang="en">Updated abstract text</dc:description>
+</episciences>
+XML;
+
+    public function testHookFilterMetadataFiltersMultipleDescriptions(): void
+    {
+        $input = [
+            'xml' => self::RECORD_WITH_MULTIPLE_DESCRIPTIONS,
+            'metadata' => [
+                'title' => 'Sample ArXiv Paper Title',
+                'description' => [
+                    'Primary abstract text for arXiv paper',
+                    'to be published in JFP'
+                ]
+            ]
+        ];
+
+        $result = Episciences_Repositories_ArXiv_Hooks::hookFilterMetadata($input);
+
+        self::assertArrayHasKey('metadata', $result);
+        self::assertSame(['Primary abstract text for arXiv paper'], $result['metadata']['description']);
+        self::assertSame('Sample ArXiv Paper Title', $result['metadata']['title']);
+    }
+
+    public function testHookFilterMetadataHandlesSingleDescription(): void
+    {
+        $input = [
+            'xml' => self::RECORD_WITH_SINGLE_DESCRIPTION,
+            'metadata' => [
+                'description' => ['Single abstract text']
+            ]
+        ];
+
+        $result = Episciences_Repositories_ArXiv_Hooks::hookFilterMetadata($input);
+
+        self::assertSame(['Single abstract text'], $result['metadata']['description']);
+    }
+
+    public function testHookFilterMetadataHandlesEmptyOrMissingDescription(): void
+    {
+        $input = ['metadata' => []];
+
+        $result = Episciences_Repositories_ArXiv_Hooks::hookFilterMetadata($input);
+
+        self::assertSame([], $result['metadata']);
+    }
+
+    public function testHookFilterMetadataKeepsFirstDescriptionOnLanguageCollision(): void
+    {
+        $input = [
+            'xml' => self::RECORD_WITH_SAME_LANG_DESCRIPTIONS,
+            'metadata' => [
+                'description' => [
+                    'en' => 'Updated abstract text',
+                    0 => 'to be published in JFP'
+                ]
+            ]
+        ];
+
+        $result = Episciences_Repositories_ArXiv_Hooks::hookFilterMetadata($input);
+
+        self::assertSame(['en' => 'Primary abstract text for arXiv paper'], $result['metadata']['description']);
+    }
+
+    // =========================================================================
+    // hookCleanXMLRecordInput()
+    // =========================================================================
+
+    private const RAW_RECORD_WITH_COMMENT = <<<'XML'
+<record>
+    <header>
+        <identifier>oai:arXiv.org:2603.15855</identifier>
+        <datestamp>2026-07-13</datestamp>
+    </header>
+    <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>Mixing visual and textual code</dc:title>
+            <dc:description>Main abstract text</dc:description>
+            <dc:description>to be published in JFP</dc:description>
+        </oai_dc:dc>
+    </metadata>
+</record>
+XML;
+
+    private const RAW_RECORD_WITH_SINGLE_DESCRIPTION = <<<'XML'
+<record>
+    <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:description>Only abstract</dc:description>
+        </oai_dc:dc>
+    </metadata>
+</record>
+XML;
+
+    public function testHookCleanXMLRecordInputDiscardsSurplusDescription(): void
+    {
+        $result = Episciences_Repositories_ArXiv_Hooks::hookCleanXMLRecordInput(['record' => self::RAW_RECORD_WITH_COMMENT]);
+
+        self::assertSame(1, substr_count($result['record'], '<dc:description>'));
+        self::assertStringContainsString('Main abstract text', $result['record']);
+        self::assertStringNotContainsString('to be published in JFP', $result['record']);
+        self::assertStringContainsString('Mixing visual and textual code', $result['record']);
+    }
+
+    public function testHookCleanXMLRecordInputLeavesSingleDescriptionUntouched(): void
+    {
+        $result = Episciences_Repositories_ArXiv_Hooks::hookCleanXMLRecordInput(['record' => self::RAW_RECORD_WITH_SINGLE_DESCRIPTION]);
+
+        self::assertSame(1, substr_count($result['record'], '<dc:description>'));
+        self::assertStringContainsString('Only abstract', $result['record']);
+    }
+
+    public function testHookCleanXMLRecordInputWithEmptyRecordReturnsInputUnchanged(): void
+    {
+        $input = ['record' => ''];
+        self::assertSame($input, Episciences_Repositories_ArXiv_Hooks::hookCleanXMLRecordInput($input));
+    }
+
+    public function testHookCleanXMLRecordInputWithMissingRecordKeyReturnsInputUnchanged(): void
+    {
+        $input = ['repoId' => 2];
+        self::assertSame($input, Episciences_Repositories_ArXiv_Hooks::hookCleanXMLRecordInput($input));
+    }
+
+    public function testHookCleanXMLRecordInputWithInvalidXmlReturnsInputUnchanged(): void
+    {
+        $input = ['record' => '<not-valid-xml'];
+        self::assertSame($input, Episciences_Repositories_ArXiv_Hooks::hookCleanXMLRecordInput($input));
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_DataDescriptorUrlTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_DataDescriptorUrlTest.php
@@ -48,14 +48,30 @@ final class Episciences_Paper_DataDescriptorUrlTest extends TestCase
         ],
     ];
 
+    private bool $hadMetadataSources;
+    /** @var mixed */
+    private $originalMetadataSources;
+
     protected function setUp(): void
     {
+        $this->hadMetadataSources = Zend_Registry::isRegistered('metadataSources');
+        if ($this->hadMetadataSources) {
+            $this->originalMetadataSources = Zend_Registry::get('metadataSources');
+        }
         Zend_Registry::set('metadataSources', self::$fakeMetadataSources);
         $this->resetRepositoriesCache();
     }
 
     protected function tearDown(): void
     {
+        // Zend_Registry is a process-wide singleton: restore whatever was registered
+        // before this test so the fake sources above don't leak into other test files
+        // running later in the same PHPUnit process.
+        if ($this->hadMetadataSources) {
+            Zend_Registry::set('metadataSources', $this->originalMetadataSources);
+        } else {
+            Zend_Registry::getInstance()->offsetUnset('metadataSources');
+        }
         $this->resetRepositoriesCache();
     }
 

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_EntityTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_EntityTest.php
@@ -3,8 +3,11 @@
 namespace unit\library\Episciences\paper;
 
 use Episciences_Paper;
+use Episciences_Repositories;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
+use Zend_Registry;
+use Zend_Translate;
 
 /**
  * Unit tests for Episciences_Paper entity: getters/setters, DOI, identifier,
@@ -15,10 +18,55 @@ use ReflectionProperty;
 final class Episciences_Paper_EntityTest extends TestCase
 {
     private Episciences_Paper $paper;
+    private bool $hadMetadataSources;
+    /** @var mixed */
+    private $originalMetadataSources;
 
     protected function setUp(): void
     {
         $this->paper = new Episciences_Paper();
+
+        // getAbstract() → Episciences_Tools::getLocale() → Zend_Registry::get('Zend_Translate')
+        if (!Zend_Registry::isRegistered('Zend_Translate')) {
+            Zend_Registry::set('Zend_Translate', new Zend_Translate([
+                'adapter' => Zend_Translate::AN_ARRAY,
+                'content' => ['' => ''],
+                'locale'  => 'en',
+            ]));
+        }
+
+        // setMetadata()'s hookFilterMetadata call resolves the arXiv Hooks class from
+        // Episciences_Repositories::getLabel(ARXIV_REPO_ID), which reads Zend_Registry's
+        // 'metadataSources'. Save/restore it around each test so this suite stays
+        // independent of run order instead of leaking a fake value to other test files.
+        $this->hadMetadataSources = Zend_Registry::isRegistered('metadataSources');
+        if ($this->hadMetadataSources) {
+            $this->originalMetadataSources = Zend_Registry::get('metadataSources');
+        }
+        Zend_Registry::set('metadataSources', [
+            (int)Episciences_Repositories::ARXIV_REPO_ID => [
+                'name' => 'arXiv',
+                'type' => 'repository',
+            ],
+        ]);
+        $this->resetRepositoriesCache();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadMetadataSources) {
+            Zend_Registry::set('metadataSources', $this->originalMetadataSources);
+        } else {
+            Zend_Registry::getInstance()->offsetUnset('metadataSources');
+        }
+        $this->resetRepositoriesCache();
+    }
+
+    private function resetRepositoriesCache(): void
+    {
+        $repositoriesCache = new ReflectionProperty(Episciences_Repositories::class, '_repositories');
+        $repositoriesCache->setAccessible(true);
+        $repositoriesCache->setValue(null, []);
     }
 
     // -----------------------------------------------------------------------
@@ -325,5 +373,38 @@ XML;
             $this->paper->getMetadata('licenses'),
             $this->paper->getMetadata('type')
         );
+    }
+
+    private const RECORD_WITH_MULTIPLE_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description>Main abstract text</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+</episciences>
+XML;
+
+    public function testGetMetadataTriggersHookFilterMetadataForArXiv(): void
+    {
+        $this->paper->setRepoid((int)Episciences_Repositories::ARXIV_REPO_ID);
+        $this->paper->setMetadata(self::RECORD_WITH_MULTIPLE_DESCRIPTIONS);
+        self::assertSame(['Main abstract text'], $this->paper->getMetadata('description'));
+        self::assertSame('Main abstract text', $this->paper->getAbstract());
+    }
+
+    private const RECORD_WITH_SAME_LANG_DESCRIPTIONS = <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<episciences xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:description xml:lang="en">Main abstract text</dc:description>
+    <dc:description>to be published in JFP</dc:description>
+    <dc:description xml:lang="en">Updated abstract text</dc:description>
+</episciences>
+XML;
+
+    public function testGetMetadataArXivHookKeepsFirstDescriptionOnLanguageCollision(): void
+    {
+        $this->paper->setRepoid((int)Episciences_Repositories::ARXIV_REPO_ID);
+        $this->paper->setMetadata(self::RECORD_WITH_SAME_LANG_DESCRIPTIONS);
+        self::assertSame(['en' => 'Main abstract text'], $this->paper->getMetadata('description'));
+        self::assertSame('Main abstract text', $this->paper->getAbstract());
     }
 }


### PR DESCRIPTION
## Description

Resolves #793.

When harvesting arXiv records via OAI-PMH (`oai_dc`), arXiv returns multiple `<dc:description>` elements where the first element is the paper abstract and subsequent elements contain author comments or publication notes (e.g., *"to be published in JFP"*).

This PR introduces an extensible repository hook event `hookFilterMetadata` to filter extracted metadata cleanly per repository provider without hardcoding repository-specific conditions inside domain entities.

## Changes

- **Core Hook Call**: Modified `Episciences_Paper::setMetadata()` to trigger `Episciences_Repositories::callHook('hookFilterMetadata', ...)` after Dublin Core XPath parsing.
- **ArXiv Hook Handler**: Created `Episciences_Repositories_Arxiv_Hooks` implementing `hookFilterMetadata()`, which retains only the first `<dc:description>` element as the paper abstract.
- **Unit Tests**:
  - Added `Episciences_Repositories_Arxiv_HooksTest` covering arXiv metadata filtering logic.
  - Added `testGetMetadataTriggersHookFilterMetadataForArXiv` in `Episciences_Paper_EntityTest`.

## Target Branch

- Based on `staging`.