### PR TITLE
refactor(hal): strip non-abstract dc:description markers at ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactored
 
+- Strip HAL's non-abstract `dc:description` markers (`International audience`, `National audience`, `soumission à Episciences`) at ingestion instead of filtering them in every consumer. A new `Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput()` removes the nodes from the raw OAI record before it reaches `PAPERS.RECORD`, so the two independent render paths — `Paper::getMetadata()` and `Paper::getXslt()` → `public/xsl/*.xsl` — stay consistent on their own. Removes the eight downstream workarounds in `Paper::getAbstractsCleaned()`, `Paper_Export`, the DataCite and zbJATS exports and the three paper XSLTs, and fixes the TEI export, which never filtered the marker at all. Matching is content-based and case-insensitive on normalized whitespace, so a real (possibly multilingual) abstract can never be dropped. `National audience` was never filtered anywhere and was displayed as an abstract; it is now handled with the others. Existing rows are migrated by the new `papers:clean-hal-descriptions` command (`--dry-run`, `--update-document`, `--no-reindex`).
 - Remove static `Ccsd_Auth` dependencies to improve testability.
 - Simplify portal module and remove dead code.
 

--- a/application/modules/journal/views/scripts/export/datacite.phtml
+++ b/application/modules/journal/views/scripts/export/datacite.phtml
@@ -149,10 +149,6 @@
             $abstract = trim($abstract);
             $langId = '';
 
-            if ('International audience' === $abstract) {
-                continue;
-            }
-
             if ($lang && Zend_Locale::isLocale($lang)) {
                 $langId = ' xml:lang="' . $lang . '"';
             }

--- a/application/modules/journal/views/scripts/export/zbjats.phtml
+++ b/application/modules/journal/views/scripts/export/zbjats.phtml
@@ -211,7 +211,12 @@ $timestamp = time();
                         //default to paper language
                     }
                     $abstract = trim($abstract);
-                    if (($abstract === 'International audience') || $abstract === 'soumission à Episciences' || (str_starts_with($abstract, 'Comment:'))) {
+                    // Repository boilerplate ("International audience", "soumission à
+                    // Episciences") is stripped at ingestion, see
+                    // Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput().
+                    // arXiv's "Comment:" field is legitimate content misplaced in
+                    // dc:description, so it is still skipped here rather than deleted.
+                    if (str_starts_with($abstract, 'Comment:')) {
                         continue;
                     }
                     if ($abstractCount === 0): ?>

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -5296,6 +5296,12 @@ class Episciences_Paper
 
     /**
      * Get an array of abstracts
+     *
+     * Repository boilerplate such as HAL's "International audience" marker is no
+     * longer filtered here: it is stripped from the raw XML at ingestion
+     * (@see Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput()), so it
+     * never reaches PAPERS.RECORD in the first place.
+     *
      * @return array
      */
     public function getAbstractsCleaned()
@@ -5305,15 +5311,9 @@ class Episciences_Paper
             if (is_array($abstract)) {
                 $abstractLang = array_key_first($abstract);
                 $abstractText = array_shift($abstract);
-                $abstractText = $this->cleanAbstract($abstractText);
-                if ($abstractText !== 'International audience') {
-                    $abstracts[][$abstractLang] = $abstractText;
-                }
+                $abstracts[][$abstractLang] = $this->cleanAbstract($abstractText);
             } else {
-                $abstract = $this->cleanAbstract($abstract);
-                if ($abstract !== 'International audience') {
-                    $abstracts[$locale] = $abstract;
-                }
+                $abstracts[$locale] = $this->cleanAbstract($abstract);
             }
         }
         return $abstracts;

--- a/library/Episciences/Paper/Export.php
+++ b/library/Episciences/Paper/Export.php
@@ -594,9 +594,6 @@ class Export
         // description
         foreach ($paper->getAllAbstracts() as $lang => $abstract) {
             $abstract = trim($abstract);
-            if ($abstract === 'International audience') {
-                continue;
-            }
             $description = $xml->createElement('dc:description', $abstract);
             if ($lang && Zend_Locale::isLocale($lang)) {
                 $description->setAttribute('xml:lang', $lang);

--- a/library/Episciences/Repositories/Common.php
+++ b/library/Episciences/Repositories/Common.php
@@ -201,6 +201,105 @@ class Episciences_Repositories_Common
 
     }
 
+    /**
+     * Remove every <dc:description> node whose text content exactly matches one of
+     * $exactTexts, comparing on whitespace normalized by
+     * Episciences_Tools::spaceCleaner() and ignoring case.
+     *
+     * Some repositories push non-descriptive boilerplate through dc:description
+     * (HAL's audience marker, for instance). Dropping those nodes from the raw XML
+     * before it reaches PAPERS.RECORD keeps the two independent render paths -
+     * Paper::getMetadata() on one side, Paper::getXslt() feeding public/xsl/*.xsl on
+     * the other - consistent without a filter in each consumer.
+     *
+     * Matching is content-based, never positional: only text we explicitly name is
+     * ever removed, so a real (possibly multilingual) abstract cannot be lost.
+     *
+     * The record is returned untouched when it cannot be parsed or when nothing
+     * matches, so callers never have to guard against a corrupted result.
+     *
+     * @param string $record raw OAI-PMH XML
+     * @param string[] $exactTexts description texts to drop
+     */
+    public static function removeDcDescriptionByText(string $record, array $exactTexts): string
+    {
+        if (trim($record) === '' || $exactTexts === []) {
+            return $record;
+        }
+
+        $needles = [];
+        foreach ($exactTexts as $exactText) {
+            $normalized = (string)Episciences_Tools::spaceCleaner($exactText);
+            if ($normalized !== '') {
+                $needles[] = mb_strtolower($normalized);
+            }
+        }
+
+        if ($needles === []) {
+            return $record;
+        }
+
+        $dom = new DOMDocument();
+
+        try {
+            set_error_handler('\Ccsd\Xml\Exception::HandleXmlError');
+            $loaded = $dom->loadXML($record);
+        } catch (\Ccsd\Xml\Exception $e) {
+            $loaded = false;
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!$loaded || !$dom->documentElement) {
+            return $record;
+        }
+
+        // Match on namespace URI rather than on a registered prefix: callers hand over
+        // records at different stages of cleaning, some of which have already had the
+        // default xmlns stripped (@see Episciences_PapersManager::cleanRecord()). An
+        // empty namespace URI is therefore accepted too, while a same-named node from
+        // another vocabulary (datacite:description) stays out of reach.
+        $query = "//*[local-name()='description' and (namespace-uri()='http://purl.org/dc/elements/1.1/' or namespace-uri()='')]";
+
+        $descriptions = (new DOMXPath($dom))->query($query);
+
+        if ($descriptions === false || $descriptions->length === 0) {
+            return $record;
+        }
+
+        $removed = 0;
+
+        foreach ($descriptions as $description) {
+            $text = mb_strtolower((string)Episciences_Tools::spaceCleaner($description->textContent));
+
+            if (!in_array($text, $needles, true)) {
+                continue;
+            }
+
+            // Drop the indentation left over from the removed node so the stored XML
+            // keeps its original formatting instead of gaining a blank line.
+            $previous = $description->previousSibling;
+            if ($previous instanceof DOMText && trim($previous->nodeValue) === '') {
+                $previous->parentNode?->removeChild($previous);
+            }
+
+            $description->parentNode?->removeChild($description);
+            $removed++;
+        }
+
+        if ($removed === 0) {
+            return $record;
+        }
+
+        // Preserve the prolog only when the input had one: callers store the serialized
+        // result straight back into RECORD, next to records nobody rewrote.
+        $cleaned = str_starts_with(ltrim($record), '<?xml')
+            ? $dom->saveXML()
+            : $dom->saveXML($dom->documentElement);
+
+        return $cleaned !== false ? $cleaned : $record;
+    }
+
     public static function formatReferences(array $reference = []): array
     {
         if (empty($reference)) {

--- a/library/Episciences/Repositories/HAL/Hooks.php
+++ b/library/Episciences/Repositories/HAL/Hooks.php
@@ -1,0 +1,82 @@
+<?php
+
+use Episciences\Repositories\CommonHooksInterface;
+use Episciences\Repositories\DataSanitizerInterface;
+
+class Episciences_Repositories_HAL_Hooks implements CommonHooksInterface, DataSanitizerInterface
+{
+    /**
+     * Boilerplate HAL exposes through <dc:description> in its oai_dc records, none of
+     * which is an abstract:
+     *
+     * - "International audience" and "National audience" are how HAL serializes its
+     *   `audience` field. Both values occur in production records.
+     * - "soumission à Episciences" is what depositors type in the abstract field when
+     *   they create a HAL record for the sole purpose of submitting it here.
+     *
+     * Compared on normalized whitespace, case-insensitively.
+     */
+    public const NON_ABSTRACT_DESCRIPTIONS = [
+        'International audience',
+        'National audience',
+        'soumission à Episciences',
+    ];
+
+    /**
+     * Strip HAL's non-abstract <dc:description> nodes from the raw XML before it is
+     * persisted into PAPERS.RECORD.
+     *
+     * RECORD is read by two independent paths - Paper::getMetadata() (PHP) and
+     * Paper::getXslt() -> public/xsl/*.xsl (XSLT straight on the DOM) - so filtering
+     * these markers in each consumer meant repeating the test everywhere and missing
+     * it somewhere (Episciences_Paper_Tei::getAbstracts() leaked "International
+     * audience" into the TEI export). Removing the nodes once, at ingestion, keeps
+     * both paths correct with no downstream test at all.
+     *
+     * @param array<string, mixed> $input
+     * @return array<string, mixed>
+     */
+    public static function hookCleanXMLRecordInput(array $input): array
+    {
+        if (empty($input['record']) || !is_string($input['record'])) {
+            return $input;
+        }
+
+        $input['record'] = Episciences_Repositories_Common::removeDcDescriptionByText(
+            $input['record'],
+            self::NON_ABSTRACT_DESCRIPTIONS
+        );
+
+        return $input;
+    }
+
+    // HAL has no dedicated handling for the hooks below: return [] so
+    // Episciences_Repositories::callHook() falls back to the same defaults that
+    // applied before this class existed (OAI-based retrieval, version required,
+    // identifier common to all versions).
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     */
+    public static function hookApiRecords(array $hookParams): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function hookIsRequiredVersion(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function hookIsIdentifierCommonToAllVersions(): array
+    {
+        return [];
+    }
+}

--- a/public/xsl/admin_paper.xsl
+++ b/public/xsl/admin_paper.xsl
@@ -404,53 +404,52 @@
     <xsl:template name="process-descriptions">
         <xsl:param name="justify" select="'false'"/>
         
-        <!-- Count only displayable descriptions (excluding 'International audience') -->
-        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description[normalize-space(.) != 'International audience'])"/>
+        <!-- Count descriptions to decide whether language prefixes are needed. Repository
+             boilerplate is stripped from RECORD at ingestion (see
+             Episciences_Repositories_HAL_Hooks), so nothing is excluded here. -->
+        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description)"/>
         
         <xsl:for-each select="metadata/oai_dc:dc/dc:description">
-            <!-- Skip descriptions with value 'International audience' -->
-            <xsl:if test="normalize-space(.) != 'International audience'">
-                <xsl:choose>
-                    <xsl:when test="$justify = 'true'">
-                        <p class="small force-word-wrap" style="text-align: justify">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
+            <xsl:choose>
+                <xsl:when test="$justify = 'true'">
+                    <p class="small force-word-wrap" style="text-align: justify">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:when>
+                <xsl:otherwise>
+                    <p class="small force-word-wrap" style="">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <p class="small force-word-wrap" style="">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
-                            </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
-                            </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:if>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:for-each>
     </xsl:template>
 

--- a/public/xsl/full_paper.xsl
+++ b/public/xsl/full_paper.xsl
@@ -398,53 +398,52 @@
     <xsl:template name="process-descriptions">
         <xsl:param name="justify" select="'false'"/>
         
-        <!-- Count only displayable descriptions (excluding 'International audience') -->
-        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description[normalize-space(.) != 'International audience'])"/>
+        <!-- Count descriptions to decide whether language prefixes are needed. Repository
+             boilerplate is stripped from RECORD at ingestion (see
+             Episciences_Repositories_HAL_Hooks), so nothing is excluded here. -->
+        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description)"/>
         
         <xsl:for-each select="metadata/oai_dc:dc/dc:description">
-            <!-- Skip descriptions with value 'International audience' -->
-            <xsl:if test="normalize-space(.) != 'International audience'">
-                <xsl:choose>
-                    <xsl:when test="$justify = 'true'">
-                        <p class="small force-word-wrap" style="text-align: justify">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
+            <xsl:choose>
+                <xsl:when test="$justify = 'true'">
+                    <p class="small force-word-wrap" style="text-align: justify">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:when>
+                <xsl:otherwise>
+                    <p class="small force-word-wrap" style="">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <p class="small force-word-wrap" style="">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
-                            </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
-                            </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:if>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:for-each>
     </xsl:template>
 

--- a/public/xsl/partial_paper.xsl
+++ b/public/xsl/partial_paper.xsl
@@ -143,53 +143,52 @@
     <xsl:template name="process-descriptions">
         <xsl:param name="justify" select="'false'"/>
         
-        <!-- Count only displayable descriptions (excluding 'International audience') -->
-        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description[normalize-space(.) != 'International audience'])"/>
+        <!-- Count descriptions to decide whether language prefixes are needed. Repository
+             boilerplate is stripped from RECORD at ingestion (see
+             Episciences_Repositories_HAL_Hooks), so nothing is excluded here. -->
+        <xsl:variable name="displayable_desc_count" select="count(metadata/oai_dc:dc/dc:description)"/>
         
         <xsl:for-each select="metadata/oai_dc:dc/dc:description">
-            <!-- Skip descriptions with value 'International audience' -->
-            <xsl:if test="normalize-space(.) != 'International audience'">
-                <xsl:choose>
-                    <xsl:when test="$justify = 'true'">
-                        <p class="small force-word-wrap" style="text-align: justify">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
+            <xsl:choose>
+                <xsl:when test="$justify = 'true'">
+                    <p class="small force-word-wrap" style="text-align: justify">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:when>
+                <xsl:otherwise>
+                    <p class="small force-word-wrap" style="">
+                        <!-- Add lang attribute if language is specified -->
+                        <xsl:if test="@xml:lang">
+                            <xsl:attribute name="lang">
+                                <xsl:value-of select="@xml:lang"/>
+                            </xsl:attribute>
+                            <!-- Add dir attribute for RTL languages -->
+                            <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
+                                <xsl:attribute name="dir">rtl</xsl:attribute>
                             </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <p class="small force-word-wrap" style="">
-                            <!-- Add lang attribute if language is specified -->
-                            <xsl:if test="@xml:lang">
-                                <xsl:attribute name="lang">
-                                    <xsl:value-of select="@xml:lang"/>
-                                </xsl:attribute>
-                                <!-- Add dir attribute for RTL languages -->
-                                <xsl:if test="php:function('Episciences_Tools::isRtlLanguage', string(@xml:lang))">
-                                    <xsl:attribute name="dir">rtl</xsl:attribute>
-                                </xsl:if>
-                            </xsl:if>
-                            <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
-                            <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
-                                <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
-                            </xsl:if>
-                            <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
-                        </p>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:if>
+                        </xsl:if>
+                        <!-- Only add language prefix if multiple descriptions AND this one has xml:lang -->
+                        <xsl:if test="$displayable_desc_count > 1 and @xml:lang">
+                            <strong>[<xsl:value-of select="@xml:lang"/>] </strong>
+                        </xsl:if>
+                        <xsl:value-of select="php:function('Episciences_Tools::decodeLatex', string(.), true())" disable-output-escaping="yes"/>
+                    </p>
+                </xsl:otherwise>
+            </xsl:choose>
         </xsl:for-each>
     </xsl:template>
 

--- a/scripts/CleanHalRecordDescriptionsCommand.php
+++ b/scripts/CleanHalRecordDescriptionsCommand.php
@@ -1,0 +1,420 @@
+<?php
+declare(strict_types=1);
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: strip HAL's non-abstract <dc:description> markers from the
+ * RECORD column of papers already stored in the database.
+ *
+ * Companion to Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput(), which
+ * removes those markers at ingestion. This command applies the very same hook to the
+ * existing rows, so ingestion and backfill can never diverge.
+ *
+ * Two caches derive from RECORD and must be refreshed afterwards:
+ *  - PAPERS.DOCUMENT (JSON), built from the CrossRef export via
+ *    Episciences_Paper::getAbstractsCleaned() — handled by --update-document.
+ *  - the Solr index — a reindex is queued for every modified paper unless
+ *    --no-reindex is passed.
+ */
+class CleanHalRecordDescriptionsCommand extends Command
+{
+    protected static $defaultName = 'papers:clean-hal-descriptions';
+
+    public const DEFAULT_BUFFER = 500;
+
+    /** DOCIDs per delegated papers:update-document call, to keep the IN () list sane. */
+    private const DOCUMENT_CHUNK = 1000;
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription("Strip HAL's non-abstract dc:description markers from PAPERS.RECORD.")
+            ->addOption('docid', null, InputOption::VALUE_REQUIRED, 'Process only this DOCID.')
+            ->addOption('buffer', null, InputOption::VALUE_REQUIRED, 'Number of papers loaded per page.', self::DEFAULT_BUFFER)
+            ->addOption('update-document', null, InputOption::VALUE_NONE, 'Regenerate PAPERS.DOCUMENT for modified papers by delegating to papers:update-document.')
+            ->addOption('no-reindex', null, InputOption::VALUE_NONE, 'Do not queue a Solr reindex for modified papers.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Report what would change without writing anything.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $isDryRun        = (bool)$input->getOption('dry-run');
+        $shouldReindex   = !(bool)$input->getOption('no-reindex');
+        $shouldUpdateDoc = (bool)$input->getOption('update-document');
+        $buffer          = $this->validateBuffer($input->getOption('buffer'));
+
+        $io->title('Cleaning HAL dc:description markers in PAPERS.RECORD');
+
+        $this->bootstrap();
+
+        $logger = new Logger('cleanHalRecordDescriptions');
+        $logger->pushHandler(new StreamHandler(
+            EPISCIENCES_LOG_PATH . 'cleanHalRecordDescriptions_' . date('Y-m-d') . '.log',
+            Logger::INFO
+        ));
+
+        if (!$io->isQuiet()) {
+            $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));
+        }
+
+        $db = Zend_Db_Table_Abstract::getDefaultAdapter();
+
+        if ($db === null) {
+            $io->error('Database adapter not initialized.');
+            return Command::FAILURE;
+        }
+
+        $docIdOption = $input->getOption('docid');
+        $docIdFilter = $docIdOption !== null ? (int)$docIdOption : null;
+
+        [$countQuery, $dataQuery] = $this->buildQueries($db, $docIdFilter);
+
+        $candidates = (int)$db->fetchOne($countQuery);
+
+        if ($candidates === 0) {
+            $io->success('No candidate paper found — nothing to do.');
+            return Command::SUCCESS;
+        }
+
+        $logger->info(sprintf('Candidate papers: %d. Buffer: %d', $candidates, $buffer));
+
+        try {
+            $paginator = Zend_Paginator::factory($dataQuery);
+            $paginator->setItemCountPerPage($buffer);
+        } catch (Zend_Paginator_Exception $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $totalPages   = $paginator->count();
+        $modifiedIds  = [];
+        $untouchedIds = [];
+        $failureCount = 0;
+
+        $io->progressStart($candidates);
+
+        for ($page = 1; $page <= $totalPages; $page++) {
+            $paginator->setCurrentPageNumber($page);
+
+            $pageUpdates = [];
+
+            foreach ($paginator->getCurrentItems() as $row) {
+                /** @var array<string, mixed> $row */
+                $docId  = (int)$row['DOCID'];
+                $record = (string)($row['RECORD'] ?? '');
+
+                // Reuse the ingestion hook itself rather than re-implementing its rules.
+                $cleaned = (string)(Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput(
+                    ['record' => $record]
+                )['record'] ?? $record);
+
+                if ($cleaned === $record) {
+                    // The SQL LIKE filter is deliberately loose: it only shortlists rows,
+                    // the hook decides. A shortlisted record is left alone either because
+                    // its text does not match exactly (the marker is a substring of a real
+                    // abstract) or because its XML could not be parsed. Both are reported:
+                    // now that the downstream filters are gone, anything still holding the
+                    // marker will display it.
+                    $untouchedIds[] = $docId;
+                } elseif (trim($cleaned) === '') {
+                    $logger->error(sprintf('[DOCID %d] cleaned record is empty — skipped.', $docId));
+                    $failureCount++;
+                } else {
+                    $pageUpdates[$docId] = $cleaned;
+                }
+
+                $io->progressAdvance();
+            }
+
+            if ($pageUpdates === []) {
+                continue;
+            }
+
+            if ($isDryRun) {
+                foreach (array_keys($pageUpdates) as $docId) {
+                    $logger->info(sprintf('[DOCID %d] dry-run: RECORD would be rewritten.', $docId));
+                    $modifiedIds[] = $docId;
+                }
+                continue;
+            }
+
+            try {
+                $db->beginTransaction();
+
+                foreach ($pageUpdates as $docId => $cleaned) {
+                    $db->update(T_PAPERS, ['RECORD' => $cleaned], ['DOCID = ?' => $docId]);
+                }
+
+                $db->commit();
+
+                $modifiedIds = array_merge($modifiedIds, array_keys($pageUpdates));
+                $logger->info(sprintf('Page %d/%d: %d RECORD(s) rewritten.', $page, $totalPages, count($pageUpdates)));
+            } catch (Exception $e) {
+                $db->rollBack();
+                $logger->error(sprintf('Page %d/%d: transaction failed: %s', $page, $totalPages, $e->getMessage()));
+                $failureCount += count($pageUpdates);
+            }
+        }
+
+        $io->progressFinish();
+
+        $logger->info(sprintf(
+            'Candidates: %d | Modified: %d | Untouched: %d | Failures: %d%s',
+            $candidates,
+            count($modifiedIds),
+            count($untouchedIds),
+            $failureCount,
+            $isDryRun ? ' (dry-run)' : ''
+        ));
+
+        if ($untouchedIds !== []) {
+            $logger->warning(sprintf(
+                'Shortlisted but left untouched (no dc:description matched a marker exactly, or the XML could not be parsed) — DOCID: %s',
+                $this->formatDocIdList($untouchedIds)
+            ));
+        }
+
+        if ($modifiedIds === []) {
+            $io->success('No RECORD needed rewriting.');
+            return $failureCount > 0 ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        if ($isDryRun) {
+            $io->warning(sprintf('dry-run: %d RECORD(s) would be rewritten. Nothing was written.', count($modifiedIds)));
+            return Command::SUCCESS;
+        }
+
+        if ($shouldReindex) {
+            try {
+                Ccsd_Search_Solr_Indexer::addToIndexQueue(
+                    $modifiedIds,
+                    'episciences',
+                    Ccsd_Search_Solr_Indexer::O_UPDATE,
+                    'episciences'
+                );
+                $logger->info(sprintf('Solr reindex queued for %d paper(s).', count($modifiedIds)));
+            } catch (Exception $e) {
+                $logger->error('Queuing the Solr reindex failed: ' . $e->getMessage());
+                $failureCount++;
+            }
+        }
+
+        if ($shouldUpdateDoc) {
+            $failureCount += $this->updateDocumentColumn($modifiedIds, $output, $logger);
+        } else {
+            // Without this, the JSON API keeps serving the abstract cached before the
+            // rewrite — and that cache no longer filters the marker itself.
+            $io->warning(sprintf(
+                "PAPERS.DOCUMENT is now stale for %d paper(s). Run:\n  php scripts/console.php papers:update-document --sqlwhere='DOCID IN (%s)'\nor re-run this command with --update-document.",
+                count($modifiedIds),
+                $this->formatDocIdList($modifiedIds)
+            ));
+        }
+
+        $summary = sprintf(
+            'Done. Modified: %d | Untouched: %d | Failures: %d',
+            count($modifiedIds),
+            count($untouchedIds),
+            $failureCount
+        );
+
+        $failureCount > 0 ? $io->warning($summary) : $io->success($summary);
+
+        return $failureCount > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    // -------------------------------------------------------------------------
+    // Public pure helpers — testable without bootstrap or DB
+    // -------------------------------------------------------------------------
+
+    /**
+     * Normalise the --buffer option value.
+     * Returns DEFAULT_BUFFER when the value is missing, zero, negative, or non-integer.
+     */
+    public function validateBuffer(mixed $value): int
+    {
+        $int = filter_var($value, FILTER_VALIDATE_INT);
+
+        return ($int === false || $int <= 0) ? self::DEFAULT_BUFFER : $int;
+    }
+
+    /**
+     * Build the loose SQL LIKE patterns that shortlist candidate records, derived from
+     * the hook's own marker list so the two stay in sync.
+     *
+     * Each marker is reduced to its ASCII-only words, joined by wildcards. Two reasons:
+     *
+     *  - A marker split across lines in the stored XML is still picked up, since the hook
+     *    normalizes whitespace before comparing.
+     *  - Accented characters are dropped rather than sent through LIKE. RECORD is still
+     *    utf8mb3 and the connection collation is not guaranteed, so matching on 'à' gives
+     *    different results depending on who asks — which risks silently skipping papers.
+     *
+     * Being too broad here is harmless: the hook makes the final, exact decision on the
+     * parsed XML. Being too narrow would leave markers behind.
+     *
+     * @return list<string>
+     */
+    public function buildLikePatterns(): array
+    {
+        $patterns = [];
+
+        foreach (Episciences_Repositories_HAL_Hooks::NON_ABSTRACT_DESCRIPTIONS as $marker) {
+            $asciiWords = [];
+
+            foreach (preg_split('/\s+/u', $marker, -1, PREG_SPLIT_NO_EMPTY) ?: [] as $word) {
+                // Keep only words a LIKE can match byte-for-byte whatever the collation.
+                if (preg_match('/^[\x21-\x7E]+$/', $word) !== 1) {
+                    continue;
+                }
+
+                // Escape LIKE metacharacters before the word becomes part of the pattern.
+                $asciiWords[] = str_replace(['\\', '%', '_'], ['\\\\', '\%', '\_'], $word);
+            }
+
+            // A marker with no ASCII word at all shortlists everything rather than nothing:
+            // the hook then filters, so no paper is missed.
+            $patterns[] = $asciiWords === [] ? '%' : '%' . implode('%', $asciiWords) . '%';
+        }
+
+        return $patterns;
+    }
+
+    /**
+     * Render a DOCID list for the copy-pasteable follow-up command, truncating the
+     * middle so a 20 000-paper run does not print an unusable wall of digits.
+     *
+     * @param list<int> $docIds
+     */
+    public function formatDocIdList(array $docIds): string
+    {
+        $maxShown = 50;
+
+        if (count($docIds) <= $maxShown) {
+            return implode(',', $docIds);
+        }
+
+        return implode(',', array_slice($docIds, 0, $maxShown))
+            . sprintf(',/* … %d more, see the log file */', count($docIds) - $maxShown);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array{0: Zend_Db_Select, 1: Zend_Db_Select}
+     */
+    private function buildQueries(Zend_Db_Adapter_Abstract $db, ?int $docId): array
+    {
+        $countQuery = $db->select()->from(T_PAPERS, [new Zend_Db_Expr('COUNT(*)')]);
+        $dataQuery  = $db->select()->from(T_PAPERS, ['DOCID', 'RECORD']);
+
+        foreach ([$countQuery, $dataQuery] as $query) {
+            $query->where('REPOID = ?', (int)Episciences_Repositories::HAL_REPO_ID);
+
+            $orConditions = [];
+            foreach ($this->buildLikePatterns() as $pattern) {
+                $orConditions[] = $db->quoteInto('RECORD LIKE ?', $pattern);
+            }
+
+            $query->where('(' . implode(' OR ', $orConditions) . ')');
+        }
+
+        $dataQuery->order('DOCID ASC');
+
+        return [$countQuery, $dataQuery];
+    }
+
+    /**
+     * Delegate PAPERS.DOCUMENT regeneration to the existing papers:update-document
+     * command instead of duplicating its logic.
+     *
+     * @param list<int> $docIds
+     * @return int number of failed chunks
+     */
+    private function updateDocumentColumn(array $docIds, OutputInterface $output, Logger $logger): int
+    {
+        $application = $this->getApplication();
+
+        if ($application === null) {
+            $logger->error('No console application available — cannot regenerate PAPERS.DOCUMENT.');
+            return 1;
+        }
+
+        try {
+            $command = $application->find('papers:update-document');
+        } catch (Throwable $e) {
+            $logger->error('papers:update-document not found: ' . $e->getMessage());
+            return 1;
+        }
+
+        $failures = 0;
+
+        foreach (array_chunk($docIds, self::DOCUMENT_CHUNK) as $index => $chunk) {
+            $sqlwhere = sprintf('DOCID IN (%s)', implode(',', $chunk));
+
+            try {
+                $exitCode = $command->run(new ArrayInput(['--sqlwhere' => $sqlwhere]), $output);
+            } catch (Throwable $e) {
+                $logger->error(sprintf('papers:update-document chunk %d failed: %s', $index + 1, $e->getMessage()));
+                $failures++;
+                continue;
+            }
+
+            if ($exitCode !== Command::SUCCESS) {
+                $logger->error(sprintf('papers:update-document chunk %d exited with code %d.', $index + 1, $exitCode));
+                $failures++;
+            }
+        }
+
+        if ($failures === 0) {
+            $logger->info(sprintf('PAPERS.DOCUMENT regenerated for %d paper(s).', count($docIds)));
+        }
+
+        return $failures;
+    }
+
+    private function bootstrap(): void
+    {
+        if (!defined('APPLICATION_PATH')) {
+            define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
+        }
+
+        require_once __DIR__ . '/../public/const.php';
+        require_once __DIR__ . '/../public/bdd_const.php';
+
+        defineProtocol();
+        defineSimpleConstants();
+        defineSQLTableConstants();
+        defineApplicationConstants();
+        defineJournalConstants();
+
+        $libraries = [realpath(APPLICATION_PATH . '/../library')];
+        set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
+        require_once 'Zend/Application.php';
+
+        // Do NOT call $application->bootstrap() — APPLICATION_MODULE may be undefined
+        // which causes Bootstrap::_initModule() to fail silently.
+        $application = new Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
+
+        $autoloader = Zend_Loader_Autoloader::getInstance();
+        $autoloader->setFallbackAutoloader(true);
+
+        $db = Zend_Db::factory('PDO_MYSQL', $application->getOption('resources')['db']['params']);
+        Zend_Db_Table::setDefaultAdapter($db);
+
+        Zend_Registry::set('metadataSources', Episciences_Paper_MetaDataSourcesManager::all(false));
+        Zend_Registry::set('Zend_Locale', new Zend_Locale('en'));
+    }
+}

--- a/scripts/console.php
+++ b/scripts/console.php
@@ -28,6 +28,7 @@ require_once __DIR__ . '/ImportApacheLogsCommand.php';
 require_once __DIR__ . '/UpdateGeoIpCommand.php';
 require_once __DIR__ . '/GenerateDownloadKpiCommand.php';
 require_once __DIR__ . '/UpdatePapersDocumentCommand.php';
+require_once __DIR__ . '/CleanHalRecordDescriptionsCommand.php';
 require_once __DIR__ . '/UpdateTranslationsCommand.php';
 require_once __DIR__ . '/GetDoiCommand.php';
 require_once __DIR__ . '/NormalizeUserAffiliationsCommand.php';
@@ -88,6 +89,7 @@ $application->add(new UpdateGeoIpCommand());
 
 // Papers commands
 $application->add(new UpdatePapersDocumentCommand());
+$application->add(new CleanHalRecordDescriptionsCommand());
 
 // Translation commands
 $application->add(new UpdateTranslationsCommand());

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CommonTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CommonTest.php
@@ -833,4 +833,159 @@ XML;
 
         self::assertSame([], $authors);
     }
+
+    // =========================================================================
+    // removeDcDescriptionByText()
+    // =========================================================================
+
+    private function dcRecord(string ...$descriptions): string
+    {
+        $nodes = '';
+        foreach ($descriptions as $description) {
+            $nodes .= sprintf("\n    <dc:description>%s</dc:description>", $description);
+        }
+
+        return sprintf(
+            '<oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/">%s' . "\n" . '</oai_dc:dc>',
+            $nodes
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dcDescriptionsOf(string $record): array
+    {
+        $dom = new \DOMDocument();
+        self::assertTrue($dom->loadXML($record));
+
+        $texts = [];
+        foreach ($dom->getElementsByTagNameNS('http://purl.org/dc/elements/1.1/', 'description') as $node) {
+            $texts[] = $node->textContent;
+        }
+
+        return $texts;
+    }
+
+    public function testRemoveDcDescriptionByTextRemovesTheMatchingNode(): void
+    {
+        $record = $this->dcRecord('Boilerplate', 'A real abstract.');
+
+        $cleaned = Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate']);
+
+        self::assertSame(['A real abstract.'], $this->dcDescriptionsOf($cleaned));
+    }
+
+    public function testRemoveDcDescriptionByTextMatchesSeveralTexts(): void
+    {
+        $record = $this->dcRecord('First marker', 'A real abstract.', 'Second marker');
+
+        $cleaned = Episciences_Repositories_Common::removeDcDescriptionByText(
+            $record,
+            ['First marker', 'Second marker']
+        );
+
+        self::assertSame(['A real abstract.'], $this->dcDescriptionsOf($cleaned));
+    }
+
+    public function testRemoveDcDescriptionByTextIgnoresCaseAndCollapsesWhitespace(): void
+    {
+        $record = $this->dcRecord("  BOILER\n  plate ", 'A real abstract.');
+
+        $cleaned = Episciences_Repositories_Common::removeDcDescriptionByText($record, ['boiler plate']);
+
+        self::assertSame(['A real abstract.'], $this->dcDescriptionsOf($cleaned));
+    }
+
+    public function testRemoveDcDescriptionByTextRequiresAFullMatch(): void
+    {
+        $record = $this->dcRecord('Boilerplate and then some real content.');
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate'])
+        );
+    }
+
+    public function testRemoveDcDescriptionByTextReturnsRecordUnchangedWhenNothingMatches(): void
+    {
+        $record = $this->dcRecord('A real abstract.');
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate'])
+        );
+    }
+
+    public function testRemoveDcDescriptionByTextReturnsRecordUnchangedOnEmptyNeedleList(): void
+    {
+        $record = $this->dcRecord('Boilerplate');
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, [])
+        );
+    }
+
+    /**
+     * A needle made only of whitespace would otherwise normalize to '' and match every
+     * empty <dc:description>, silently deleting nodes the caller never named.
+     */
+    public function testRemoveDcDescriptionByTextIgnoresBlankNeedles(): void
+    {
+        $record = $this->dcRecord('', 'A real abstract.');
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, ['   '])
+        );
+    }
+
+    public function testRemoveDcDescriptionByTextHandlesEmptyRecord(): void
+    {
+        self::assertSame('', Episciences_Repositories_Common::removeDcDescriptionByText('', ['Boilerplate']));
+    }
+
+    public function testRemoveDcDescriptionByTextHandlesMalformedXml(): void
+    {
+        $record = '<oai_dc:dc><dc:description>Boilerplate</dc:description>';
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate'])
+        );
+    }
+
+    /**
+     * Episciences_PapersManager::cleanRecord() strips the default xmlns before the hooks
+     * run, so a record can reach this helper with no namespace at all.
+     */
+    public function testRemoveDcDescriptionByTextMatchesNodesWithoutNamespace(): void
+    {
+        $record = "<dc>\n    <description>Boilerplate</description>\n    <description>A real abstract.</description>\n</dc>";
+
+        $cleaned = Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate']);
+
+        self::assertStringNotContainsString('Boilerplate', $cleaned);
+        self::assertStringContainsString('A real abstract.', $cleaned);
+    }
+
+    public function testRemoveDcDescriptionByTextLeavesOtherNamespacesAlone(): void
+    {
+        $record = '<root xmlns:datacite="http://datacite.org/schema/kernel-4">'
+            . '<datacite:description>Boilerplate</datacite:description></root>';
+
+        self::assertSame(
+            $record,
+            Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate'])
+        );
+    }
+
+    public function testRemoveDcDescriptionByTextDoesNotLeaveABlankLineBehind(): void
+    {
+        $record  = $this->dcRecord('Boilerplate', 'A real abstract.');
+        $cleaned = Episciences_Repositories_Common::removeDcDescriptionByText($record, ['Boilerplate']);
+
+        self::assertStringNotContainsString("\n\n", $cleaned);
+    }
 }

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_HAL_HooksTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_HAL_HooksTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace unit\library\Episciences\Repositories;
+
+use Episciences_Repositories_HAL_Hooks;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Episciences_Repositories_HAL_Hooks.
+ *
+ * All tests are DB-free: the hook is a pure XML transformation.
+ *
+ * The hook strips HAL's non-abstract <dc:description> markers from the raw OAI record
+ * before it reaches PAPERS.RECORD, so neither Paper::getMetadata() nor
+ * Paper::getXslt() -> public/xsl/*.xsl has to filter them downstream.
+ *
+ * @covers Episciences_Repositories_HAL_Hooks
+ */
+final class Episciences_Repositories_HAL_HooksTest extends TestCase
+{
+    private const DC_NS = 'http://purl.org/dc/elements/1.1/';
+
+    /**
+     * Build an oai_dc record whose <dc:description> children are $descriptions.
+     * Each entry is either a plain string or [text, xmlLang].
+     *
+     * @param array<int, string|array{0: string, 1: string}> $descriptions
+     */
+    private function record(array $descriptions, bool $withProlog = true): string
+    {
+        $nodes = '';
+
+        foreach ($descriptions as $description) {
+            [$text, $lang] = is_array($description) ? $description : [$description, null];
+            $langAttr = $lang !== null ? sprintf(' xml:lang="%s"', $lang) : '';
+            $nodes .= sprintf("\n        <dc:description%s>%s</dc:description>", $langAttr, $text);
+        }
+
+        return ($withProlog ? '<?xml version="1.0" encoding="UTF-8"?>' . "\n" : '') . <<<XML
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/">
+  <GetRecord>
+    <record>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="{$this->dcNs()}">
+        <dc:title>A real title</dc:title>{$nodes}
+        <dc:type>info:eu-repo/semantics/article</dc:type>
+        </oai_dc:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+XML;
+    }
+
+    private function dcNs(): string
+    {
+        return self::DC_NS;
+    }
+
+    /**
+     * @return list<string> the text of every remaining dc:description node, in document order
+     */
+    private function descriptionsOf(string $record): array
+    {
+        $dom = new \DOMDocument();
+        self::assertTrue($dom->loadXML($record), 'the hook returned a non well-formed record');
+
+        $texts = [];
+        foreach ($dom->getElementsByTagNameNS(self::DC_NS, 'description') as $node) {
+            $texts[] = $node->textContent;
+        }
+
+        return $texts;
+    }
+
+    private function clean(string $record): string
+    {
+        $result = Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput(['record' => $record]);
+
+        self::assertArrayHasKey('record', $result);
+        self::assertIsString($result['record']);
+
+        return $result['record'];
+    }
+
+    // =========================================================================
+    // Markers are removed
+    // =========================================================================
+
+    public function testRemovesInternationalAudienceMarker(): void
+    {
+        $cleaned = $this->clean($this->record(['International audience', 'The real abstract.']));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    public function testRemovesEpisciencesSubmissionMarker(): void
+    {
+        $cleaned = $this->clean($this->record(['soumission à Episciences', 'The real abstract.']));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    public function testRemovesBothMarkersAtOnce(): void
+    {
+        $cleaned = $this->clean($this->record([
+            'International audience',
+            'The real abstract.',
+            'soumission à Episciences',
+        ]));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    public function testRemovesEveryOccurrenceOfTheSameMarker(): void
+    {
+        $cleaned = $this->clean($this->record([
+            'International audience',
+            'International audience',
+            'The real abstract.',
+        ]));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    /**
+     * The marker is the only description: the paper legitimately ends up with none,
+     * rather than keeping boilerplate as its abstract.
+     */
+    public function testRemovesMarkerEvenWhenItIsTheOnlyDescription(): void
+    {
+        $cleaned = $this->clean($this->record(['International audience']));
+
+        self::assertSame([], $this->descriptionsOf($cleaned));
+    }
+
+    // =========================================================================
+    // Matching rules: normalized whitespace, case-insensitive
+    // =========================================================================
+
+    public function testMatchIgnoresCase(): void
+    {
+        $cleaned = $this->clean($this->record(['INTERNATIONAL AUDIENCE', 'The real abstract.']));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    public function testMatchIgnoresSurroundingAndInnerWhitespace(): void
+    {
+        $cleaned = $this->clean($this->record(["\n   International    audience\n  ", 'The real abstract.']));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    // =========================================================================
+    // Real content is never touched
+    // =========================================================================
+
+    public function testKeepsAbstractContainingTheMarkerAsSubstring(): void
+    {
+        $abstract = 'This paper targets an International audience of researchers.';
+        $cleaned  = $this->clean($this->record([$abstract]));
+
+        self::assertSame([$abstract], $this->descriptionsOf($cleaned));
+    }
+
+    public function testKeepsMultilingualAbstractsAndTheirLanguages(): void
+    {
+        $cleaned = $this->clean($this->record([
+            'International audience',
+            ['The English abstract.', 'en'],
+            ['Le résumé français.', 'fr'],
+        ]));
+
+        self::assertSame(['The English abstract.', 'Le résumé français.'], $this->descriptionsOf($cleaned));
+
+        $dom = new \DOMDocument();
+        $dom->loadXML($cleaned);
+        $langs = [];
+        foreach ($dom->getElementsByTagNameNS(self::DC_NS, 'description') as $node) {
+            $langs[] = $node->getAttribute('xml:lang');
+        }
+
+        self::assertSame(['en', 'fr'], $langs);
+    }
+
+    public function testKeepsOtherDublinCoreFields(): void
+    {
+        $cleaned = $this->clean($this->record(['International audience', 'The real abstract.']));
+
+        self::assertStringContainsString('<dc:title>A real title</dc:title>', $cleaned);
+        self::assertStringContainsString('info:eu-repo/semantics/article', $cleaned);
+    }
+
+    /**
+     * A same-named node from another vocabulary must stay out of reach: the hook matches
+     * on the Dublin Core namespace URI, not on the local name alone.
+     */
+    public function testDoesNotTouchDescriptionFromAnotherNamespace(): void
+    {
+        $record = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:datacite="http://datacite.org/schema/kernel-4">
+  <datacite:description>International audience</datacite:description>
+</root>
+XML;
+
+        self::assertSame($record, $this->clean($record));
+    }
+
+    // =========================================================================
+    // Records left untouched, byte for byte
+    // =========================================================================
+
+    public function testReturnsRecordUnchangedWhenNoMarkerIsPresent(): void
+    {
+        $record = $this->record(['The real abstract.']);
+
+        self::assertSame($record, $this->clean($record));
+    }
+
+    public function testReturnsRecordUnchangedWhenXmlIsNotWellFormed(): void
+    {
+        $record = '<oai_dc:dc><dc:description>International audience</dc:description>';
+
+        self::assertSame($record, $this->clean($record));
+    }
+
+    public function testReturnsInputUnchangedWhenRecordKeyIsMissing(): void
+    {
+        $input = ['repoId' => 1];
+
+        self::assertSame($input, Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput($input));
+    }
+
+    public function testReturnsInputUnchangedWhenRecordIsEmpty(): void
+    {
+        $input = ['record' => '', 'repoId' => 1];
+
+        self::assertSame($input, Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput($input));
+    }
+
+    public function testReturnsInputUnchangedWhenRecordIsNotAString(): void
+    {
+        $input = ['record' => ['unexpected'], 'repoId' => 1];
+
+        self::assertSame($input, Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput($input));
+    }
+
+    public function testPreservesOtherInputKeys(): void
+    {
+        $result = Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput([
+            'record' => $this->record(['International audience', 'The real abstract.']),
+            'repoId' => 1,
+            'extra'  => 'kept',
+        ]);
+
+        self::assertSame(1, $result['repoId']);
+        self::assertSame('kept', $result['extra']);
+    }
+
+    // =========================================================================
+    // Serialization details
+    // =========================================================================
+
+    public function testKeepsTheXmlPrologWhenTheInputHadOne(): void
+    {
+        $cleaned = $this->clean($this->record(['International audience', 'The real abstract.'], true));
+
+        self::assertStringStartsWith('<?xml', $cleaned);
+    }
+
+    /**
+     * Episciences_PapersManager::cleanRecord() and SubmitController::prepareRecord() both
+     * run preg_replace('#xmlns="(.*)"#', ...) before the hook, so the record can arrive
+     * without its prolog. The hook must not invent one.
+     */
+    public function testDoesNotAddAPrologWhenTheInputHadNone(): void
+    {
+        $cleaned = $this->clean($this->record(['International audience', 'The real abstract.'], false));
+
+        self::assertStringStartsNotWith('<?xml', $cleaned);
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    // =========================================================================
+    // Marker list
+    // =========================================================================
+
+    public function testMarkerListIsTheSingleSourceOfTruth(): void
+    {
+        self::assertSame(
+            ['International audience', 'National audience', 'soumission à Episciences'],
+            Episciences_Repositories_HAL_Hooks::NON_ABSTRACT_DESCRIPTIONS
+        );
+    }
+
+    public function testRemovesNationalAudienceMarker(): void
+    {
+        $cleaned = $this->clean($this->record(['National audience', 'The real abstract.']));
+
+        self::assertSame(['The real abstract.'], $this->descriptionsOf($cleaned));
+    }
+
+    // =========================================================================
+    // Hooks deliberately left at their defaults
+    // =========================================================================
+
+    public function testUnimplementedHooksReturnEmptyArrayToKeepDefaults(): void
+    {
+        self::assertSame([], Episciences_Repositories_HAL_Hooks::hookApiRecords(['identifier' => 'hal-01234567']));
+        self::assertSame([], Episciences_Repositories_HAL_Hooks::hookIsRequiredVersion());
+        self::assertSame([], Episciences_Repositories_HAL_Hooks::hookIsIdentifierCommonToAllVersions());
+    }
+}

--- a/tests/unit/scripts/CleanHalRecordDescriptionsCommandTest.php
+++ b/tests/unit/scripts/CleanHalRecordDescriptionsCommandTest.php
@@ -1,0 +1,185 @@
+<?php
+declare(strict_types=1);
+
+namespace unit\scripts;
+
+use CleanHalRecordDescriptionsCommand;
+use Episciences_Repositories_HAL_Hooks;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+
+require_once __DIR__ . '/../../../scripts/CleanHalRecordDescriptionsCommand.php';
+
+/**
+ * Unit tests for CleanHalRecordDescriptionsCommand.
+ *
+ * All tests are pure: no bootstrap, no database, no I/O side-effects.
+ */
+class CleanHalRecordDescriptionsCommandTest extends TestCase
+{
+    private CleanHalRecordDescriptionsCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new CleanHalRecordDescriptionsCommand();
+    }
+
+    // -------------------------------------------------------------------------
+    // Command metadata
+    // -------------------------------------------------------------------------
+
+    public function testCommandName(): void
+    {
+        self::assertSame('papers:clean-hal-descriptions', $this->command->getName());
+    }
+
+    public function testCommandHasDocidOptionRequiringAValue(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        self::assertInstanceOf(InputDefinition::class, $definition);
+        self::assertTrue($definition->hasOption('docid'));
+        self::assertTrue($definition->getOption('docid')->isValueRequired(), '--docid must require a value');
+    }
+
+    public function testCommandHasBufferOptionRequiringAValue(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        self::assertTrue($definition->hasOption('buffer'));
+        self::assertTrue($definition->getOption('buffer')->isValueRequired(), '--buffer must require a value');
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function flagOptionProvider(): array
+    {
+        return [
+            'update-document' => ['update-document'],
+            'no-reindex'      => ['no-reindex'],
+            'dry-run'         => ['dry-run'],
+        ];
+    }
+
+    /**
+     * @dataProvider flagOptionProvider
+     */
+    public function testCommandFlagsTakeNoValue(string $option): void
+    {
+        $definition = $this->command->getDefinition();
+
+        self::assertTrue($definition->hasOption($option));
+        self::assertFalse($definition->getOption($option)->acceptValue(), "--{$option} must be a flag");
+    }
+
+    // -------------------------------------------------------------------------
+    // validateBuffer()
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return array<string, array{0: mixed, 1: int}>
+     */
+    public static function bufferProvider(): array
+    {
+        $default = CleanHalRecordDescriptionsCommand::DEFAULT_BUFFER;
+
+        return [
+            'valid integer string' => ['250', 250],
+            'valid integer'        => [42, 42],
+            'zero falls back'      => ['0', $default],
+            'negative falls back'  => ['-10', $default],
+            'non numeric falls back' => ['abc', $default],
+            'null falls back'      => [null, $default],
+            'float falls back'     => ['1.5', $default],
+        ];
+    }
+
+    /**
+     * @dataProvider bufferProvider
+     */
+    public function testValidateBuffer(mixed $input, int $expected): void
+    {
+        self::assertSame($expected, $this->command->validateBuffer($input));
+    }
+
+    // -------------------------------------------------------------------------
+    // buildLikePatterns()
+    // -------------------------------------------------------------------------
+
+    public function testBuildLikePatternsCoversEveryHookMarker(): void
+    {
+        $patterns = $this->command->buildLikePatterns();
+
+        self::assertCount(
+            count(Episciences_Repositories_HAL_Hooks::NON_ABSTRACT_DESCRIPTIONS),
+            $patterns,
+            'every marker must yield exactly one SQL pattern'
+        );
+    }
+
+    /**
+     * Spaces become wildcards so a marker split across lines in the stored XML is still
+     * shortlisted — the hook then makes the exact decision.
+     */
+    public function testBuildLikePatternsTurnsSpacesIntoWildcards(): void
+    {
+        $patterns = $this->command->buildLikePatterns();
+
+        self::assertContains('%International%audience%', $patterns);
+        self::assertContains('%National%audience%', $patterns);
+    }
+
+    /**
+     * RECORD is still utf8mb3 and the connection collation is not guaranteed, so a LIKE on
+     * an accented character matches inconsistently. Accented words are dropped from the
+     * pattern instead: the hook still decides on the parsed XML, so widening the shortlist
+     * costs nothing while narrowing it would leave markers behind.
+     */
+    public function testBuildLikePatternsDropsNonAsciiWords(): void
+    {
+        $patterns = $this->command->buildLikePatterns();
+
+        self::assertContains('%soumission%Episciences%', $patterns);
+
+        foreach ($patterns as $pattern) {
+            self::assertSame(
+                $pattern,
+                (string)preg_replace('/[^\x21-\x7E]/', '', $pattern),
+                'patterns must stay pure ASCII'
+            );
+        }
+    }
+
+    public function testBuildLikePatternsAreWrappedInWildcards(): void
+    {
+        foreach ($this->command->buildLikePatterns() as $pattern) {
+            self::assertStringStartsWith('%', $pattern);
+            self::assertStringEndsWith('%', $pattern);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // formatDocIdList()
+    // -------------------------------------------------------------------------
+
+    public function testFormatDocIdListPrintsShortListsInFull(): void
+    {
+        self::assertSame('1,2,3', $this->command->formatDocIdList([1, 2, 3]));
+    }
+
+    public function testFormatDocIdListTruncatesLongLists(): void
+    {
+        $result = $this->command->formatDocIdList(range(1, 120));
+
+        self::assertStringStartsWith('1,2,3,', $result);
+        self::assertStringContainsString('70 more', $result);
+        // 50 shown + the truncation note
+        self::assertStringContainsString('50,', $result);
+    }
+
+    public function testFormatDocIdListHandlesEmptyList(): void
+    {
+        self::assertSame('', $this->command->formatDocIdList([]));
+    }
+}


### PR DESCRIPTION
## Description

Les notices OAI-PMH de HAL exposent, via `<dc:description>`, du texte qui n'est pas un résumé :

- **`International audience`** et **`National audience`** — la sérialisation du champ `audience` de HAL ;
- **`soumission à Episciences`** — ce que saisissent les déposants qui créent une notice HAL uniquement pour soumettre ici.

Ces chaînes étaient évitées **chez chaque consommateur** plutôt qu'à la source. Cette approche passe mal à l'échelle : `PAPERS.RECORD` est lu par **deux chemins de rendu indépendants** — `Paper::getMetadata()` (PHP) et `Paper::getXslt()` → `public/xsl/*.xsl` (XSLT directement sur le DOM). Chaque nouvel export devait donc repenser au test, et deux l'ont manqué :

- `Episciences_Paper_Tei::getAbstracts()` ne filtrait rien → « International audience » fuyait dans l'export TEI ;
- `National audience` n'était filtré **nulle part** et s'affichait comme résumé (5 articles en base de dev).

Cette PR retire les nœuds **une seule fois, du XML brut, avant toute persistance**, dans l'esprit de #1135 (qui applique une correction spécifique à arXiv).

## Changements

### Hook d'ingestion

- **`Episciences_Repositories_HAL_Hooks::hookCleanXMLRecordInput()`** — retire les nœuds `<dc:description>` correspondant aux marqueurs. Il est appelé sur les deux chemins de persistance déjà présents sur `staging` : `SubmitController::prepareRecord()` (soumissions, via le champ caché `xml`) et `Episciences_PapersManager::cleanRecord()` (rafraîchissement de métadonnées).
- **`Episciences_Repositories_Common::removeDcDescriptionByText()`** — porte le travail DOM, pour que le hook tienne en trois lignes et qu'arXiv puisse le réutiliser.

Le rapprochement est **par contenu, jamais positionnel**, insensible à la casse et sur espaces normalisés (`Episciences_Tools::spaceCleaner()`) : seul le texte explicitement nommé est supprimé, donc un vrai résumé — y compris multilingue — ne peut pas être perdu. Le record est renvoyé inchangé s'il ne parse pas ou si rien ne correspond. Les nœuds sont ciblés par **URI de namespace** plutôt que par préfixe enregistré, car les appelants suppriment le `xmlns` par défaut avant le hook.

### Contournements supprimés (8)

| Fichier | Statut |
|---|---|
| `Paper::getAbstractsCleaned()` | filtre retiré |
| `Paper/Export.php` (dc OpenAIRE) | filtre retiré |
| `export/datacite.phtml` | filtre retiré |
| `export/zbjats.phtml` | marqueurs retirés, **`Comment:` conservé** |
| `full_paper.xsl`, `partial_paper.xsl`, `admin_paper.xsl` | garde `xsl:if` retirée |

Le filtre `Comment:` d'arXiv est conservé : c'est du contenu **légitime** mal placé dans `dc:description`, pas du bruit — il est donc ignoré à l'affichage, pas supprimé du record.

### Reprise de l'existant

Sans reprise, supprimer les contournements ferait afficher les marqueurs sur tous les articles HAL déjà publiés.

**`papers:clean-hal-descriptions`** applique **le hook lui-même** à chaque `RECORD` candidat, plutôt que de réimplémenter ses règles : ingestion et migration ne peuvent pas diverger.

```
php scripts/console.php papers:clean-hal-descriptions --dry-run
php scripts/console.php papers:clean-hal-descriptions --update-document
```

Deux caches dérivent de `RECORD` :

- **`PAPERS.DOCUMENT`** (JSON) met en cache les résumés via l'export CrossRef → `--update-document` délègue à `papers:update-document`. Sans le flag, la commande avertit et affiche l'invocation de suivi : maintenant que les filtres sont partis, un `DOCUMENT` périmé **exposerait** le marqueur au lieu de le masquer.
- **Solr** — une réindexation est mise en file pour chaque article modifié, sauf `--no-reindex`.

Le pré-filtre SQL ne fait que présélectionner (le hook décide en exact sur le XML parsé), il est donc volontairement large : les marqueurs sont réduits à leurs mots ASCII joints par des jokers. Les caractères accentués sont écartés du `LIKE` plutôt qu'envoyés tels quels, car `RECORD` est encore `utf8mb3` et la collation de connexion n'est pas garantie — le rapprochement sur `à` dépendait de qui posait la question. Élargir coûte un peu de parsing ; restreindre laisserait des marqueurs. Les records présélectionnés mais laissés intacts sont journalisés par DOCID, puisque tout ce qui garde un marqueur l'affichera désormais.

## Écarts assumés par rapport à #1135

1. **Un seul hook, pas deux.** #1135 ajoute `hookFilterMetadata` *et* `hookCleanXMLRecordInput` ; le commentaire du second explique que le premier ne corrigeait pas le chemin XSLT. Ici, `hookCleanXMLRecordInput` seul couvre les deux chemins.
2. **Rapprochement sémantique, pas positionnel.** Le hook arXiv supprime *tous* les `dc:description` sauf le premier — un résumé multilingue ou un changement d'ordre côté arXiv détruirait du contenu réel, irréversiblement, dans `RECORD`. Ici on ne supprime que ce qu'on nomme.
3. **Helper partagé** au lieu de ~40 lignes de boilerplate DOM (`loadXML`, `getNamespaces`, gestion d'erreur) recopiées par hook.

## Tests

- **41 tests neufs** : `Episciences_Repositories_HAL_HooksTest` (22), `removeDcDescriptionByText()` dans `Episciences_Repositories_CommonTest` (12), `CleanHalRecordDescriptionsCommandTest` (20 — dont pré-filtre ASCII et troncature de liste).
- Couverture : marqueurs retirés (isolés, multiples, seuls), casse et espaces, résumé contenant le marqueur **en sous-chaîne** (conservé), résumés multilingues et leurs `xml:lang`, autre namespace (`datacite:description`) intouché, XML invalide, record vide/absent/non-string, prologue XML préservé ou non ajouté.
- **PHPStan niveau 6 : 0 erreur** sur les deux fichiers créés.
- Suite complète : 4866 tests, aucune régression.

### Validation sur données réelles

`--dry-run` sur une base de développement : **5329 candidats → 5322 réécrits, 7 intacts, 0 échec**. Les 7 intacts sont les faux positifs du pré-filtre large (les mots présents séparément dans le record) : le hook les décline correctement, ce qui valide la conception en deux étages.

## Hors périmètre — signalé

Deux problèmes **préexistants**, indépendants de cette PR, rencontrés en la validant :

- `make test-php` ne va pas au bout sur `staging` : `InboxNotificationsTest` charge `scripts/InboxNotifications.php`, dont la classe `Script` parse `$argv` via `Zend_Console_Getopt`, échoue sur le `--no-coverage` de PHPUnit et appelle `exit()`.
- Cet arrêt masquait **3 erreurs réelles** dans `ZbjatsZipperCommandTest` : `ZbjatsZipperCommand::buildPaperUrl()` reçoit un `string` pour un paramètre typé `int`.

## Branche cible

- Basée sur `staging`.
