### PR TITLE
feat(export): expose secondary volumes in the JSON v2 paper export (#1140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add constraint description helper text to the volume year field in volume management.
 - Add TomSelect component to paper filters on `/paper/submitted` and `/paper/ratings`.
 - Configure local SonarQube support (`make sonar`) and XML-based PHPUnit coverage report generation.
+- [#1140](https://github.com/CCSDForge/episciences/issues/1140) Export secondary volumes under `database.current.secondary_volumes` in the JSON v2 paper export.
 
 ### Fixed
 
+- [#1140](https://github.com/CCSDForge/episciences/issues/1140) Refresh the `PAPERS.DOCUMENT` JSON column after a secondary volume change, so API consumers no longer read stale volume data.
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Block review report attachment downloads for users with a declared Conflict of Interest (COI).
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Ensure paper authors' access precedence over editorial staff COI checks when downloading review report attachments.
 - [#1132](https://github.com/CCSDForge/episciences/pull/1132) Pass `previousVersion` context to `hookVersion` in `savenewpostedversionAction` to correctly update Zenodo version identifiers when posting a new version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1140](https://github.com/CCSDForge/episciences/issues/1140) Refresh the `PAPERS.DOCUMENT` JSON column after a secondary volume change, so API consumers no longer read stale volume data.
+- [#1140](https://github.com/CCSDForge/episciences/issues/1140) Refresh the `PAPERS.DOCUMENT` JSON column after a secondary volume change, so API consumers no longer read stale volume data. Papers already in database keep a `DOCUMENT` without the new key until resaved: run `php scripts/console.php papers:update-document` after deploying (API consumers should read the key as `?? null` in the meantime).
 - Report `database.current.graphical_abstract_file` as `null` instead of `""` in the JSON v2 paper export when the paper has no graphical abstract, and drop the dead `unset()` that was meant to do it. Consumers must treat both `null` and a missing key as "no graphical abstract".
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Block review report attachment downloads for users with a declared Conflict of Interest (COI).
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Ensure paper authors' access precedence over editorial staff COI checks when downloading review report attachments.

--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -2758,6 +2758,9 @@ class AdministratepaperController extends PaperDefaultController
 
             $paper->setOtherVolumes($paper_volumes);
             $paper->saveOtherVolumes();
+            // VOLUME_PAPER is a satellite table: refresh PAPERS.DOCUMENT so API consumers,
+            // which read the stored JSON, do not keep serving stale secondary volumes.
+            Episciences_PapersManager::updateJsonDocumentData((int)$docid);
             $oOVolumes = $paper->getOtherVolumes(true);
             $oVolumes = [];
 

--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -2760,7 +2760,9 @@ class AdministratepaperController extends PaperDefaultController
             $paper->saveOtherVolumes();
             // VOLUME_PAPER is a satellite table: refresh PAPERS.DOCUMENT so API consumers,
             // which read the stored JSON, do not keep serving stale secondary volumes.
-            Episciences_PapersManager::updateJsonDocumentData((int)$docid);
+            if (!Episciences_PapersManager::updateJsonDocumentData((int)$docid)) {
+                $errors[] = 'PAPERS.DOCUMENT refresh failed';
+            }
             $oOVolumes = $paper->getOtherVolumes(true);
             $oVolumes = [];
 

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1429,6 +1429,7 @@ class Episciences_Paper
                         'publication_date' => $this->getPublication_date()
                     ],
                     'volume' => $sVolume,
+                    'secondary_volumes' => $this->getSecondaryVolumesToJson(),
                     'position_in_volume' => $this->getPosition(),
                     'section' => $sSection,
                     'journal' => [
@@ -1496,6 +1497,78 @@ class Episciences_Paper
         $identifier = str_replace('"', '\"', $this->getIdentifier());
         $xmlToArray = null;
         return str_replace(array('"#"', '%%ID', '%%VERSION'), array('"value"', $identifier, $this->getVersion()), $result);
+    }
+
+    /**
+     * Build the public JSON representation of the paper's secondary volumes,
+     * exposed under database.current.secondary_volumes.
+     *
+     * Returns null when the paper has no secondary volume, to stay consistent with
+     * the other empty keys of database.current (volume, section, cited_by, ...).
+     *
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function getSecondaryVolumesToJson(): ?array
+    {
+        $primaryVid = (int)$this->getVid();
+        $vids = [];
+
+        foreach ($this->getOtherVolumes() as $volumePaper) {
+            $vid = (int)$volumePaper->getVid();
+            // a paper's primary volume is never one of its secondary volumes
+            if ($vid > 0 && $vid !== $primaryVid) {
+                $vids[$vid] = $vid;
+            }
+        }
+
+        if ($vids === []) {
+            return null;
+        }
+
+        $secondaryVolumes = [];
+
+        foreach ($this->resolveSecondaryVolumes($vids) as $oVolume) {
+            $secondaryVolumes[] = self::formatSecondaryVolumeToJson($oVolume);
+        }
+
+        return $secondaryVolumes !== [] ? $secondaryVolumes : null;
+    }
+
+    /**
+     * Load the volumes behind a list of VIDs, with their settings.
+     *
+     * Two queries in total, instead of the three per volume that
+     * Episciences_VolumesManager::find() would cost: toJson() runs on every Paper::save().
+     *
+     * @param int[] $vids
+     * @return array<int, Episciences_Volume> keyed by VID, ordered by volume position
+     */
+    protected function resolveSecondaryVolumes(array $vids): array
+    {
+        $volumes = Episciences_VolumesManager::getList(['where' => 'VID IN (' . implode(',', $vids) . ')']);
+        Episciences_VolumesManager::loadSettingsForVolumes($volumes);
+
+        return $volumes;
+    }
+
+    /**
+     * Public volume metadata exposed under database.current.secondary_volumes.
+     * Private settings (access code, ...) are deliberately left out.
+     *
+     * @return array<string, mixed>
+     */
+    private static function formatSecondaryVolumeToJson(Episciences_Volume $oVolume): array
+    {
+        return [
+            'id' => $oVolume->getVid() ?: null,
+            'position' => $oVolume->getPosition(),
+            'number' => $oVolume->getVol_num(),
+            'year' => $oVolume->getVol_year(),
+            'has_proceedings' => $oVolume->isProceeding() === 1,
+            'titles' => $oVolume->getTitles(),
+            'descriptions' => $oVolume->getDescriptions(),
+            'bibliographical_references' => $oVolume->getBib_reference(),
+        ];
     }
 
     private function processTmpVersion(Episciences_Paper $paper): void

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -4566,7 +4566,7 @@ class Episciences_PapersManager
         // invalidate the getJsonV2 metadata cache entry (up to CACHE_EXPIRE_METADATA_PUBLISHED = 31 days)
         // so callers going through Episciences_Paper::get('json', 2) don't keep serving the stale DOCUMENT
         (new FilesystemAdapter(Episciences_Paper::CACHE_CLASS_NAMESPACE, 0, CACHE_PATH_METADATA))
-            ->deleteItem($docId . '-getJsonV2');
+            ->deleteItem($paper->getPaperid() . '-getJsonV2');
 
         return true;
     }

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -1,6 +1,7 @@
 <?php
 
 use GuzzleHttp\Exception\GuzzleException;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 class Episciences_PapersManager
 {
@@ -4544,17 +4545,30 @@ class Episciences_PapersManager
         return $db->fetchOne($select);
     }
 
-    public static function updateJsonDocumentData(int $docId): void
+    public static function updateJsonDocumentData(int $docId): bool
     {
+        $paper = self::get($docId, false);
+
+        if (!$paper) {
+            return false;
+        }
+
         try {
             $db = Zend_Db_Table_Abstract::getDefaultAdapter();
-            $paper = self::get($docId, false);
             $toJson = $paper->toJson();
             $str = sprintf('UPDATE `PAPERS` set `DOCUMENT` = %s  WHERE DOCID = %s;', $db->quote($toJson), $docId);
             $db->query($str)->closeCursor();
         } catch (Zend_Db_Statement_Exception $e) {
             trigger_error($e->getMessage());
+            return false;
         }
+
+        // invalidate the getJsonV2 metadata cache entry (up to CACHE_EXPIRE_METADATA_PUBLISHED = 31 days)
+        // so callers going through Episciences_Paper::get('json', 2) don't keep serving the stale DOCUMENT
+        (new FilesystemAdapter(Episciences_Paper::CACHE_CLASS_NAMESPACE, 0, CACHE_PATH_METADATA))
+            ->deleteItem($docId . '-getJsonV2');
+
+        return true;
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_SecondaryVolumesJsonTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_SecondaryVolumesJsonTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace unit\library\Episciences\paper;
+
+use Episciences_Paper;
+use Episciences_Volume;
+use Episciences_Volume_Paper;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the secondary volumes block of the JSON v2 paper export
+ * (database.current.secondary_volumes), see issue #1140.
+ *
+ * Tested methods:
+ *   - Episciences_Paper::getSecondaryVolumesToJson()
+ *   - Episciences_Paper::formatSecondaryVolumeToJson()
+ *
+ * All tests are DB-free: the null paths return before any query, and the
+ * populated paths stub resolveSecondaryVolumes() via createPartialMock().
+ *
+ * @covers Episciences_Paper
+ */
+final class Episciences_Paper_SecondaryVolumesJsonTest extends TestCase
+{
+    /**
+     * @param Episciences_Paper $paper
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function callGetSecondaryVolumesToJson(Episciences_Paper $paper): ?array
+    {
+        $method = new ReflectionMethod(Episciences_Paper::class, 'getSecondaryVolumesToJson');
+        $method->setAccessible(true);
+
+        return $method->invoke($paper);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function callFormatSecondaryVolumeToJson(Episciences_Volume $volume): array
+    {
+        $method = new ReflectionMethod(Episciences_Paper::class, 'formatSecondaryVolumeToJson');
+        $method->setAccessible(true);
+
+        return $method->invoke(null, $volume);
+    }
+
+    /**
+     * Builds a volume without ever touching the database: no loadSettings(),
+     * no loadMetadatas(), and no array constructor (setOptions() would generate
+     * an access code).
+     *
+     * @param array<string, string>|null $titles
+     * @param array<string, string>|null $descriptions
+     * @param array<string, string> $settings
+     */
+    private function makeVolume(
+        int     $vid,
+        int     $position = 1,
+        ?string $num = '1',
+        ?string $year = '2024',
+        ?array  $titles = null,
+        ?array  $descriptions = null,
+        ?string $bibReference = null,
+        array   $settings = []
+    ): Episciences_Volume
+    {
+        $volume = new Episciences_Volume();
+        $volume->setVid($vid);
+        $volume->setPosition($position);
+        $volume->setVol_num($num);
+        $volume->setVol_year($year);
+        $volume->setTitles($titles);
+        $volume->setDescriptions($descriptions);
+        $volume->setBib_reference($bibReference);
+        $volume->setSettings($settings);
+
+        return $volume;
+    }
+
+    public function testReturnsNullWhenNoSecondaryVolume(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->setVid(12);
+        $paper->setOtherVolumes([]);
+
+        self::assertNull($this->callGetSecondaryVolumesToJson($paper));
+    }
+
+    public function testReturnsNullWhenOnlyThePrimaryVolumeIsAttached(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->setVid(12);
+        $paper->setOtherVolumes([
+            new Episciences_Volume_Paper(['id' => 1, 'vid' => 12, 'docid' => 99]),
+        ]);
+
+        self::assertNull($this->callGetSecondaryVolumesToJson($paper));
+    }
+
+    public function testIgnoresInvalidVids(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->setVid(12);
+        $paper->setOtherVolumes([
+            new Episciences_Volume_Paper(['id' => 1, 'vid' => 0, 'docid' => 99]),
+        ]);
+
+        self::assertNull($this->callGetSecondaryVolumesToJson($paper));
+    }
+
+    public function testReturnsOneFormattedSecondaryVolume(): void
+    {
+        $volume = $this->makeVolume(
+            vid: 15,
+            position: 3,
+            num: '2',
+            year: '2024',
+            titles: ['en' => 'Special Track on AI', 'fr' => 'Session spéciale sur l\'IA'],
+            descriptions: ['en' => 'Description...', 'fr' => 'Description...'],
+        );
+
+        $paper = $this->createPartialMock(Episciences_Paper::class, ['resolveSecondaryVolumes']);
+        $paper->setVid(12);
+        $paper->setOtherVolumes([
+            new Episciences_Volume_Paper(['id' => 1, 'vid' => 15, 'docid' => 99]),
+        ]);
+        $paper->method('resolveSecondaryVolumes')->willReturn([15 => $volume]);
+
+        $result = $this->callGetSecondaryVolumesToJson($paper);
+
+        self::assertSame([
+            [
+                'id' => 15,
+                'position' => 3,
+                'number' => '2',
+                'year' => '2024',
+                'has_proceedings' => false,
+                'titles' => ['en' => 'Special Track on AI', 'fr' => 'Session spéciale sur l\'IA'],
+                'descriptions' => ['en' => 'Description...', 'fr' => 'Description...'],
+                'bibliographical_references' => null,
+            ],
+        ], $result);
+    }
+
+    public function testDeduplicatesVidsAndKeepsResolvedOrder(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, ['resolveSecondaryVolumes']);
+        $paper->setVid(12);
+        $paper->setOtherVolumes([
+            new Episciences_Volume_Paper(['id' => 1, 'vid' => 15, 'docid' => 99]),
+            new Episciences_Volume_Paper(['id' => 2, 'vid' => 20, 'docid' => 99]),
+            // duplicated row for the same volume
+            new Episciences_Volume_Paper(['id' => 3, 'vid' => 15, 'docid' => 99]),
+            // primary volume, must be filtered out
+            new Episciences_Volume_Paper(['id' => 4, 'vid' => 12, 'docid' => 99]),
+        ]);
+
+        $paper
+            ->expects(self::once())
+            ->method('resolveSecondaryVolumes')
+            ->with([15 => 15, 20 => 20])
+            ->willReturn([
+                20 => $this->makeVolume(vid: 20, position: 1),
+                15 => $this->makeVolume(vid: 15, position: 3),
+            ]);
+
+        $result = $this->callGetSecondaryVolumesToJson($paper);
+
+        self::assertIsArray($result);
+        self::assertCount(2, $result);
+        // a JSON array, not an object: keys must be 0..n
+        self::assertSame([0, 1], array_keys($result));
+        // resolveSecondaryVolumes() orders by volume position
+        self::assertSame([20, 15], array_column($result, 'id'));
+    }
+
+    public function testReturnsNullWhenNoVolumeCouldBeResolved(): void
+    {
+        $paper = $this->createPartialMock(Episciences_Paper::class, ['resolveSecondaryVolumes']);
+        $paper->setVid(12);
+        $paper->setOtherVolumes([
+            new Episciences_Volume_Paper(['id' => 1, 'vid' => 4242, 'docid' => 99]),
+        ]);
+        $paper->method('resolveSecondaryVolumes')->willReturn([]);
+
+        self::assertNull($this->callGetSecondaryVolumesToJson($paper));
+    }
+
+    public function testFormatExposesAllPublicFields(): void
+    {
+        $volume = $this->makeVolume(
+            vid: 15,
+            position: 3,
+            num: '2',
+            year: '2024',
+            titles: ['en' => 'Main Volume Title'],
+            descriptions: ['en' => 'Description in English'],
+            bibReference: 'Some reference',
+        );
+
+        self::assertSame([
+            'id' => 15,
+            'position' => 3,
+            'number' => '2',
+            'year' => '2024',
+            'has_proceedings' => false,
+            'titles' => ['en' => 'Main Volume Title'],
+            'descriptions' => ['en' => 'Description in English'],
+            'bibliographical_references' => 'Some reference',
+        ], $this->callFormatSecondaryVolumeToJson($volume));
+    }
+
+    public function testFormatReturnsNullIdForAnEmptyVid(): void
+    {
+        $result = $this->callFormatSecondaryVolumeToJson($this->makeVolume(vid: 0));
+
+        self::assertNull($result['id']);
+    }
+
+    public function testFormatHasProceedingsIsTrueWhenTheVolumeIsAProceeding(): void
+    {
+        $volume = $this->makeVolume(vid: 15, settings: [Episciences_Volume::VOLUME_IS_PROCEEDING => '1']);
+
+        self::assertTrue($this->callFormatSecondaryVolumeToJson($volume)['has_proceedings']);
+    }
+
+    public function testFormatHasProceedingsIsFalseWhenTheSettingIsAbsentOrOff(): void
+    {
+        $withoutSetting = $this->makeVolume(vid: 15);
+        $withSettingOff = $this->makeVolume(vid: 16, settings: [Episciences_Volume::VOLUME_IS_PROCEEDING => '0']);
+
+        self::assertFalse($this->callFormatSecondaryVolumeToJson($withoutSetting)['has_proceedings']);
+        self::assertFalse($this->callFormatSecondaryVolumeToJson($withSettingOff)['has_proceedings']);
+    }
+
+    public function testFormatDoesNotLeakPrivateSettings(): void
+    {
+        $volume = $this->makeVolume(vid: 15, settings: [
+            Episciences_Volume::SETTING_ACCESS_CODE => 'super-secret-code',
+            Episciences_Volume::SETTING_STATUS => '1',
+            Episciences_Volume::SETTING_SPECIAL_ISSUE => '1',
+        ]);
+
+        $result = $this->callFormatSecondaryVolumeToJson($volume);
+
+        self::assertArrayNotHasKey('settings', $result);
+        self::assertArrayNotHasKey(Episciences_Volume::SETTING_ACCESS_CODE, $result);
+        self::assertStringNotContainsString('super-secret-code', json_encode($result, JSON_THROW_ON_ERROR));
+    }
+
+    public function testFormatKeysMatchTheDocumentedPayload(): void
+    {
+        self::assertSame([
+            'id',
+            'position',
+            'number',
+            'year',
+            'has_proceedings',
+            'titles',
+            'descriptions',
+            'bibliographical_references',
+        ], array_keys($this->callFormatSecondaryVolumeToJson($this->makeVolume(vid: 15))));
+    }
+}


### PR DESCRIPTION
Closes #1140

## Ce que ça fait

Ajoute `database.current.secondary_volumes` à `Episciences_Paper::toJson()` : la liste des volumes rattachés à l'article via la table `VOLUME_PAPER`, avec leurs seules métadonnées publiques, ou `null` quand il n'y en a aucun (cohérent avec `volume`, `section`, `cited_by`, `previous_versions`).

```json
"secondary_volumes": [
  {
    "id": 162,
    "position": "12",
    "number": null,
    "year": null,
    "has_proceedings": false,
    "titles": { "en": "2016", "fr": "2016" },
    "descriptions": null,
    "bibliographical_references": ""
  }
]
```

## Choix d'implémentation

- **Export inconditionnel** : le réglage revue `displaySecondaryVolumesOnPublicPage` n'est pas pris en compte. C'est un choix d'affichage de la page publique ; l'indexation Solr (`indexSecondaryVolumes()`) expose déjà ces volumes sans condition.
- **Aucun réglage privé exposé** : pas de clé `settings`, donc l'`access_code` du volume ne peut pas fuir. Vérifié sur un payload réel.
- **`has_proceedings`** dérive de `Episciences_Volume::isProceeding()`, propre à chaque volume. À noter : le bloc `volume` principal, lui, le dérive de la présence de la clé `conference` dans le XML Crossref (`Paper.php:1365`) — les deux clés n'ont donc pas exactement la même sémantique. Je n'y ai pas touché pour ne pas changer une valeur déjà exportée, mais ça vaut peut-être une issue de suivi.
- **2 requêtes au lieu de 3 par volume** : `VolumesManager::getList(['where' => 'VID IN (…)'])` + `loadSettingsForVolumes()` plutôt que `find()` en boucle. Ça compte parce que `toJson()` tourne à chaque `Paper::save()`.
- **Le volume principal est filtré** : `findPaperVolumes()` ne l'exclut pas, et le cas existe pour de vrai en base (docid 2618 sur lmcs a son VID principal 289 dans `VOLUME_PAPER`).

## Le point qui n'était pas dans l'issue : `PAPERS.DOCUMENT`

`toJson()` a deux consommateurs : `jsonv2Action()` qui recalcule à chaud, et la colonne `PAPERS.DOCUMENT` — **c'est celle-là que lit l'API**.

Or `saveothervolumesAction()` écrivait dans `VOLUME_PAPER` puis appelait `log()` et `indexUpdatePaper()`, mais **jamais** `Paper::save()`. La colonne restait donc figée après toute modification des volumes secondaires : l'URL `/jsonv2` aurait été juste, l'API périmée. D'où l'appel ajouté à `Episciences_PapersManager::updateJsonDocumentData()`, qui est déjà le pattern utilisé exactement dans ce cas de figure par `AdministratelinkeddataController` (lignes 149 et 188) et `GetZbReviewsCommand`.

`savemastervolumeAction()` n'a pas besoin de changer : elle fait `save()` **puis** `deletePaperVolume()`, donc au moment du `save()` le nouveau volume principal est encore listé dans `VOLUME_PAPER` — c'est précisément ce que neutralise le filtre défensif.

## ⚠️ À faire au déploiement

Les articles déjà en base n'ont pas la clé dans `DOCUMENT` tant qu'ils ne sont pas resauvegardés :

```bash
php scripts/console.php papers:update-document
# ou, pour ne traiter d'abord que les articles concernés :
php scripts/console.php papers:update-document --sqlwhere='DOCID IN (SELECT DOCID FROM VOLUME_PAPER)'
```

En attendant, côté API il faut lire la clé en `?? null`.

## Tests

Nouveau fichier `Episciences_Paper_SecondaryVolumesJsonTest.php` : 12 tests, 19 assertions, sans DB. `resolveSecondaryVolumes()` est `protected` exprès, pour servir de seam à `createPartialMock()` — c'est le seul moyen de tester le chemin peuplé, `VolumesManager::find()`/`getList()` étant des statiques non injectables.

Couvre : les trois chemins retournant `null` (aucun volume, seulement le principal, VID invalide), un et plusieurs volumes secondaires, la déduplication des VID, l'ordre issu de la résolution, les clés exactes du payload, `has_proceedings` dans les trois états, et l'absence de fuite d'`access_code`.

## Vérifications

| Contrôle | Résultat |
|---|---|
| PHPStan L6 nouveau test | 0 erreur |
| PHPStan L6 `Paper.php` | 230 → 230 (aucune nouvelle) |
| PHPStan L6 `AdministratepaperController.php` | 58 → 58 (aucune nouvelle) |
| 12 nouveaux tests | passent |
| docid 1385 (jdmdh, 1 vol. secondaire) | tableau peuplé |
| docid 11 (aucun vol. secondaire) | clé présente, `null` |
| docid 2618 (lmcs, VID principal dans `VOLUME_PAPER`) | `null` — filtre défensif validé sur données réelles |
| `access_code` / clé `settings` dans le payload | absents |

**`make test-php` reste à lancer sur un environnement complet** : ma base locale n'a pas de revue `dev`, donc `application/Bootstrap.php:83` sort sur `Configuration Error: dev journal does not exists.` — un test non modifié (`Episciences_Paper_MiscTest`) échoue à l'identique, c'est préexistant et sans lien avec cette PR. J'ai validé les 12 tests avec un bootstrap minimal, hors dépôt.

## Défauts adjacents repérés, pas corrigés ici

- `Paper.php:1454-1456` : `unset()` mort, il cible `$extraData[PUBLIC_KEY][DATABASE_KEY]…` alors que `$extraData` n'a pas de clé `public_properties`.
- Le volume principal est chargé deux fois par appel à `toJson()` : une fois dans `XmlExportManager::xmlExport()` (qui relance en plus `loadSettings()` via `getProceedingInfo()`), une fois ligne 1358.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON v2 exports now include associated secondary volumes with public metadata.
  * Secondary-volume results are filtered, deduplicated, and ordered consistently.
  * Empty secondary-volume results are represented consistently in exports.
* **Bug Fixes**
  * Updated paper JSON data now refreshes after secondary-volume changes, ensuring exports reflect the latest associations.
  * Failed refreshes are reported instead of silently succeeding.
* **Documentation**
  * Added changelog entries describing secondary-volume export support and JSON refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->