### PR TITLE
fix(export): report an empty graphical_abstract_file as null in JSON v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report `database.current.graphical_abstract_file` as `null` instead of `""` in the JSON v2 paper export when the paper has no graphical abstract, and drop the dead `unset()` that was meant to do it. Consumers must treat both `null` and a missing key as "no graphical abstract".
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Block review report attachment downloads for users with a declared Conflict of Interest (COI).
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Ensure paper authors' access precedence over editorial staff COI checks when downloading review report attachments.
 - [#1132](https://github.com/CCSDForge/episciences/pull/1132) Pass `previousVersion` context to `hookVersion` in `savenewpostedversionAction` to correctly update Zenodo version identifiers when posting a new version.

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -1389,11 +1389,6 @@ class Episciences_Paper
                 ];
             }
         }
-        $graphical_abstract_file = '';
-        $current = $this->getDocument()['database']['current'] ?? null;
-        if (isset($current['graphical_abstract_file'])) {
-            $graphical_abstract_file = $current['graphical_abstract_file'];
-        }
         $extraData = [
 
             Episciences_Paper_XmlExportManager::JOURNAL_ARTICLE_KEY => [
@@ -1441,7 +1436,7 @@ class Episciences_Paper
                     'repository' => Episciences_Repositories::getRepositories()[$this->getRepoid()] ?? null,
                     'cited_by' => $citedBy,
                     'classifications' => $classifications,
-                    'graphical_abstract_file' => $graphical_abstract_file,
+                    'graphical_abstract_file' => $this->getGraphicalAbstractFileToJson(),
                     'metrics' => Episciences_Paper_Visits::getPaperMetricsByPaperId($this->getPaperid()),
 
                 ],
@@ -1451,9 +1446,6 @@ class Episciences_Paper
             ]
 
         ];
-        if ($graphical_abstract_file === '') {
-            unset($extraData[Episciences_Paper_XmlExportManager::PUBLIC_KEY][Episciences_Paper_XmlExportManager::DATABASE_KEY]['current']['graphical_abstract_file']);
-        }
 // Define the keys for better readability
         $keyBody = Episciences_Paper_XmlExportManager::BODY_KEY;
         $keyJournal = Episciences_Paper_XmlExportManager::JOURNAL_KEY;
@@ -1496,6 +1488,25 @@ class Episciences_Paper
         $identifier = str_replace('"', '\"', $this->getIdentifier());
         $xmlToArray = null;
         return str_replace(array('"#"', '%%ID', '%%VERSION'), array('"value"', $identifier, $this->getVersion()), $result);
+    }
+
+    /**
+     * Filename of the paper's graphical abstract, carried over from the stored JSON.
+     *
+     * The file is written straight into PAPERS.DOCUMENT by
+     * AdministrategraphabstractController (JSON_SET on upload, JSON_REMOVE on delete),
+     * so toJson() has to read the previous value back rather than rebuild it.
+     *
+     * Returns null, not an empty string, when the paper has no graphical abstract:
+     * consistent with the other empty keys of database.current (volume, section,
+     * cited_by, previous_versions).
+     */
+    private function getGraphicalAbstractFileToJson(): ?string
+    {
+        $current = $this->getDocument()[Episciences_Paper_XmlExportManager::DATABASE_KEY]['current'] ?? null;
+        $file = trim((string)($current['graphical_abstract_file'] ?? ''));
+
+        return $file !== '' ? $file : null;
     }
 
     private function processTmpVersion(Episciences_Paper $paper): void

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_GraphicalAbstractJsonTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_GraphicalAbstractJsonTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace unit\library\Episciences\paper;
+
+use Episciences_Paper;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the graphical_abstract_file key of the JSON v2 paper export.
+ *
+ * The value is carried over from the stored PAPERS.DOCUMENT column, which
+ * AdministrategraphabstractController writes to directly (JSON_SET on upload,
+ * JSON_REMOVE on delete). It must be null, not '', when there is no file.
+ *
+ * All tests are DB-free: the value is read from the in-memory document set
+ * through Episciences_Paper::setDocument().
+ *
+ * @covers Episciences_Paper
+ */
+final class Episciences_Paper_GraphicalAbstractJsonTest extends TestCase
+{
+    private function callGetGraphicalAbstractFileToJson(Episciences_Paper $paper): ?string
+    {
+        $method = new ReflectionMethod(Episciences_Paper::class, 'getGraphicalAbstractFileToJson');
+        $method->setAccessible(true);
+
+        return $method->invoke($paper);
+    }
+
+    /**
+     * @param array<string, mixed> $current
+     */
+    private function makePaperWithCurrent(array $current): Episciences_Paper
+    {
+        $paper = new Episciences_Paper();
+        $paper->setDocument(json_encode(
+            ['database' => ['current' => $current]],
+            JSON_THROW_ON_ERROR
+        ));
+
+        return $paper;
+    }
+
+    public function testReturnsTheStoredFilename(): void
+    {
+        $paper = $this->makePaperWithCurrent(['graphical_abstract_file' => 'graphical_abstract.png']);
+
+        self::assertSame('graphical_abstract.png', $this->callGetGraphicalAbstractFileToJson($paper));
+    }
+
+    public function testReturnsNullWhenTheKeyWasRemovedFromTheStoredDocument(): void
+    {
+        // JSON_REMOVE path: AdministrategraphabstractController drops the key on delete
+        $paper = $this->makePaperWithCurrent(['volume' => null]);
+
+        self::assertNull($this->callGetGraphicalAbstractFileToJson($paper));
+    }
+
+    public function testReturnsNullWhenTheStoredValueIsAnEmptyString(): void
+    {
+        // legacy value: the dead unset() used to leave '' behind on regeneration
+        $paper = $this->makePaperWithCurrent(['graphical_abstract_file' => '']);
+
+        self::assertNull($this->callGetGraphicalAbstractFileToJson($paper));
+    }
+
+    public function testReturnsNullWhenTheStoredValueIsBlank(): void
+    {
+        $paper = $this->makePaperWithCurrent(['graphical_abstract_file' => "  \n"]);
+
+        self::assertNull($this->callGetGraphicalAbstractFileToJson($paper));
+    }
+
+    public function testTrimsTheStoredFilename(): void
+    {
+        $paper = $this->makePaperWithCurrent(['graphical_abstract_file' => ' graphical_abstract.jpg ']);
+
+        self::assertSame('graphical_abstract.jpg', $this->callGetGraphicalAbstractFileToJson($paper));
+    }
+
+    public function testReturnsNullWhenNoDocumentIsStoredAtAll(): void
+    {
+        self::assertNull($this->callGetGraphicalAbstractFileToJson(new Episciences_Paper()));
+    }
+
+    public function testReturnsNullWhenTheStoredDocumentHasNoDatabaseKey(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->setDocument(json_encode(['journal' => []], JSON_THROW_ON_ERROR));
+
+        self::assertNull($this->callGetGraphicalAbstractFileToJson($paper));
+    }
+}


### PR DESCRIPTION
Spotted while working on #1140 (see #1141). Independent of that PR.

## The bug

`Episciences_Paper::toJson()` carried a dead `unset()`:

```php
if ($graphical_abstract_file === '') {
    unset($extraData[PUBLIC_KEY][DATABASE_KEY]['current']['graphical_abstract_file']);
}
```

`$extraData` only ever has the `journal_article` and `database` keys, so `$extraData['public_properties']` never existed and the statement was a no-op. PHPStan already flagged it (the file drops from 230 to 229 errors at level 6).

Its intent is clear once you look at `AdministrategraphabstractController`: it writes the filename straight into `PAPERS.DOCUMENT` with `JSON_SET` on upload and drops the key with `JSON_REMOVE` on delete (line 121). The `unset()` was there to preserve that symmetry. Because it was dead, **every regeneration of `DOCUMENT` resurrects the key as an empty string**.

The local database shows the scale of it:

| state of `database.current.graphical_abstract_file` | papers |
|---|---|
| key absent | 0 |
| `""` | **18 603** |
| real filename | 0 |

So the key is currently pure noise across the whole corpus.

## The fix

Report `null` rather than `""`, and keep the key present. That is consistent with the other empty keys of `database.current` (`volume`, `section`, `cited_by`, `previous_versions`, and `secondary_volumes` from #1141), and it does not break a consumer that reads the key unguarded — which removing it would have.

A blank value is normalised as well, so the 18 603 legacy `""` rows converge on `null` as they get regenerated.

The derivation moves out of the `toJson()` body into `getGraphicalAbstractFileToJson()`, which is unit-testable through `setDocument()` without a database — the same approach as `Export::buildCslFromDocumentArray()`.

## Impact on consumers

`""` and `null` are both falsy, so any `if (value)` guard keeps working. A consumer doing a strict `=== ""` comparison would need updating — worth a heads-up to whoever maintains the API client.

Internal readers are unaffected: `Episciences_Paper::getGraphical_abstract()` guards on `is_null()`, and `paper_graphical_abstract.phtml:6` on `!== ""`.

## To do on deploy

Existing papers keep `""` until their `DOCUMENT` column is regenerated:

```bash
php scripts/console.php papers:update-document
```

## Verification

| Check | Result |
|---|---|
| PHPStan L6 on the new test file | 0 errors |
| PHPStan L6 on `Paper.php` | 230 → **229** (the dead statement was one of them) |
| 7 new tests | pass |
| docid 13293 (afm, stored `""`) | key present, value `null` |

Tests cover: a stored filename is returned as-is and trimmed; the `JSON_REMOVE` path (key absent), the legacy `""` value, a blank value, no stored document at all, and a stored document with no `database` key — all yield `null`.

**`make test-php` still needs a run on a full environment**: my local database has no `dev` journal, so `application/Bootstrap.php:83` exits with `Configuration Error: dev journal does not exists.` An untouched test (`Episciences_Paper_MiscTest`) fails identically, so this is pre-existing and unrelated. I validated the 7 tests with a minimal bootstrap, kept out of the repository.
