### PR TITLE
perf(export): load the paper's primary volume once per export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add TomSelect component to paper filters on `/paper/submitted` and `/paper/ratings`.
 - Configure local SonarQube support (`make sonar`) and XML-based PHPUnit coverage report generation.
 
+### Performances
+
+- Memoise the paper's primary volume on the `Episciences_Paper` instance, so `toJson()`, `getXml()` and `XmlExportManager::xmlExport()` share a single lookup instead of loading it twice: 38 to 34 queries per paper export.
+- Stop reloading volume settings from `Episciences_Volume::getProceedingInfo()`; every caller reaches it through `isProceeding()`, which already needs them loaded.
+- Load every volume's settings in one query on `/browse/volumes` via `Episciences_VolumesManager::loadSettingsForVolumes()`, instead of one query per volume.
+
 ### Fixed
 
 - [#1125](https://github.com/CCSDForge/episciences/pull/1125) Block review report attachment downloads for users with a declared Conflict of Interest (COI).

--- a/application/modules/journal/controllers/BrowseController.php
+++ b/application/modules/journal/controllers/BrowseController.php
@@ -176,9 +176,13 @@ class BrowseController extends Zend_Controller_Action
             return;
         }
 
+        // one query for every volume's settings, instead of one per volume: the
+        // partial reads them through getSetting(), and getProceedingInfo() no longer
+        // loads them as a side effect
+        Episciences_VolumesManager::loadSettingsForVolumes($volumes);
+
         foreach ($volumes as &$volume) {
             $volume->loadMetadatas();
-            $volume->getProceedingInfo();
             $volume->getSolrCountOfVolumePapers();
         }
 

--- a/library/Episciences/Paper.php
+++ b/library/Episciences/Paper.php
@@ -411,6 +411,8 @@ class Episciences_Paper
     private $_publication_date;
     private $_settings;
     private $_otherVolumes;
+    private ?Episciences_Volume $_primaryVolume = null;
+    private bool $_primaryVolumeLoaded = false;
     private $_withxsl = true;
     /**
      * @var array
@@ -833,7 +835,14 @@ class Episciences_Paper
      */
     public function setVid($id = 0): self
     {
-        $this->_vId = (int)$id;
+        $newVid = (int)$id;
+
+        if ($newVid !== $this->_vId) {
+            // the memoised volume belongs to the previous VID
+            $this->resetPrimaryVolume();
+        }
+
+        $this->_vId = $newVid;
         return $this;
     }
 
@@ -1355,7 +1364,7 @@ class Episciences_Paper
         }
 
         if ($this->getVid()) {
-            $oVolume = Episciences_VolumesManager::find($this->getVid());
+            $oVolume = $this->getPrimaryVolume();
             if ($oVolume) {
                 $sVolume = [
                     'id' => $oVolume->getVid() ?: null,
@@ -1496,6 +1505,45 @@ class Episciences_Paper
         $identifier = str_replace('"', '\"', $this->getIdentifier());
         $xmlToArray = null;
         return str_replace(array('"#"', '%%ID', '%%VERSION'), array('"value"', $identifier, $this->getVersion()), $result);
+    }
+
+    /**
+     * The paper's primary volume, loaded at most once per Paper instance.
+     *
+     * Exporting a paper reads the primary volume from several places in the same
+     * pass — Paper::toJson(), Paper::getXml() and XmlExportManager::xmlExport() —
+     * and Episciences_VolumesManager::find() costs three queries every time
+     * (volume, settings, metadata). Memoising on the instance keeps the lifetime
+     * tied to the paper rather than to the whole request, so a volume edited
+     * elsewhere in the same request cannot be served from a stale cache.
+     */
+    public function getPrimaryVolume(): ?Episciences_Volume
+    {
+        if ($this->_primaryVolumeLoaded) {
+            return $this->_primaryVolume;
+        }
+
+        $this->_primaryVolumeLoaded = true;
+
+        $vid = (int)$this->getVid();
+
+        if ($vid > 0) {
+            $oVolume = Episciences_VolumesManager::find($vid);
+            $this->_primaryVolume = $oVolume instanceof Episciences_Volume ? $oVolume : null;
+        }
+
+        return $this->_primaryVolume;
+    }
+
+    /**
+     * Drops the memoised primary volume, so the next read reloads it.
+     */
+    public function resetPrimaryVolume(): self
+    {
+        $this->_primaryVolume = null;
+        $this->_primaryVolumeLoaded = false;
+
+        return $this;
     }
 
     private function processTmpVersion(Episciences_Paper $paper): void
@@ -3324,10 +3372,9 @@ class Episciences_Paper
 
         // fetch volume data
         if ($this->getVid()) {
-            $oVolume = Episciences_VolumesManager::find($this->getVid());
+            $oVolume = $this->getPrimaryVolume();
             if ($oVolume instanceof Episciences_Volume) {
                 $node->appendChild($dom->createElement('volumeName', $oVolume->getNameKey()));
-                $oVolume->loadSettings();
             }
         }
 
@@ -3413,7 +3460,7 @@ class Episciences_Paper
         // et qu'on est rédacteur de l'article
         if ($this->getDocid() &&
             $oReview->getSetting(Episciences_Review::SETTING_EDITORS_CAN_REASSIGN_ARTICLES) &&
-            isset($oVolume) && $oVolume instanceof Episciences_Volume && $oVolume->getSetting(Episciences_Volume::SETTING_SPECIAL_ISSUE) &&
+            isset($oVolume) && $oVolume->getSetting(Episciences_Volume::SETTING_SPECIAL_ISSUE) &&
             array_key_exists(Episciences_Auth::getUid(), $this->getEditors(true, true))
         ) {
 

--- a/library/Episciences/Paper/XmlExportManager.php
+++ b/library/Episciences/Paper/XmlExportManager.php
@@ -44,8 +44,7 @@ class Episciences_Paper_XmlExportManager
         $section = '';
         $proceedingInfo = '';
         if ($paper->getVid()) {
-            /* @var $oVolume Episciences_Volume */
-            $oVolume = Episciences_VolumesManager::find($paper->getVid());
+            $oVolume = $paper->getPrimaryVolume();
             if ($oVolume) {
                 $volume = $oVolume->getName('en');
                 if ($oVolume->isProceeding()) {

--- a/library/Episciences/Volume.php
+++ b/library/Episciences/Volume.php
@@ -1514,9 +1514,16 @@ class Episciences_Volume
     /**
      * @return array
      */
+    /**
+     * Conference metadata of a proceedings volume.
+     *
+     * Settings are expected to be loaded already: every caller reaches this method
+     * through isProceeding(), which reads one of them. Load them explicitly —
+     * Episciences_VolumesManager::loadSettingsForVolumes() does it for a whole list
+     * in one query — rather than relying on a side effect here.
+     */
     public function getProceedingInfo(): array
     {
-        $this->loadSettings();
         return [
             self::VOLUME_IS_PROCEEDING => $this->getSetting(self::VOLUME_IS_PROCEEDING),
             self::VOLUME_CONFERENCE_NAME => $this->getSetting(self::VOLUME_CONFERENCE_NAME),

--- a/tests/unit/library/Episciences/Episciences_VolumeProceedingInfoTest.php
+++ b/tests/unit/library/Episciences/Episciences_VolumeProceedingInfoTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace unit\library\Episciences;
+
+use Episciences_Volume;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Episciences_Volume::getProceedingInfo() used to call loadSettings() on every
+ * invocation, re-querying settings that Episciences_VolumesManager::find() had
+ * already loaded. It now reads whatever is in memory.
+ *
+ * Most of these tests error out against the old implementation: the volume built
+ * here has no database adapter, so the loadSettings() call raised
+ * "Call to a member function select() on null".
+ *
+ * @covers Episciences_Volume
+ */
+final class Episciences_VolumeProceedingInfoTest extends TestCase
+{
+    /**
+     * @param array<string, string> $settings
+     */
+    private function makeVolume(array $settings): Episciences_Volume
+    {
+        $volume = new Episciences_Volume();
+        $volume->setVid(15);
+        $volume->setSettings($settings);
+
+        return $volume;
+    }
+
+    public function testReturnsTheInMemorySettingsWithoutQuerying(): void
+    {
+        $volume = $this->makeVolume([
+            Episciences_Volume::VOLUME_IS_PROCEEDING => '1',
+            Episciences_Volume::VOLUME_CONFERENCE_NAME => 'Some Conference',
+            Episciences_Volume::VOLUME_CONFERENCE_ACRONYM => 'SC',
+        ]);
+
+        $info = $volume->getProceedingInfo();
+
+        self::assertSame('1', $info[Episciences_Volume::VOLUME_IS_PROCEEDING]);
+        self::assertSame('Some Conference', $info[Episciences_Volume::VOLUME_CONFERENCE_NAME]);
+        self::assertSame('SC', $info[Episciences_Volume::VOLUME_CONFERENCE_ACRONYM]);
+    }
+
+    public function testExposesAllNineConferenceKeys(): void
+    {
+        self::assertSame([
+            Episciences_Volume::VOLUME_IS_PROCEEDING,
+            Episciences_Volume::VOLUME_CONFERENCE_NAME,
+            Episciences_Volume::VOLUME_CONFERENCE_THEME,
+            Episciences_Volume::VOLUME_CONFERENCE_ACRONYM,
+            Episciences_Volume::VOLUME_CONFERENCE_NUMBER,
+            Episciences_Volume::VOLUME_CONFERENCE_LOCATION,
+            Episciences_Volume::VOLUME_CONFERENCE_START_DATE,
+            Episciences_Volume::VOLUME_CONFERENCE_END_DATE,
+            Episciences_Volume::VOLUME_CONFERENCE_DOI,
+        ], array_keys($this->makeVolume([])->getProceedingInfo()));
+    }
+
+    public function testMissingSettingsAreReportedAsFalse(): void
+    {
+        $info = $this->makeVolume([])->getProceedingInfo();
+
+        self::assertFalse($info[Episciences_Volume::VOLUME_CONFERENCE_NAME]);
+        self::assertFalse($info[Episciences_Volume::VOLUME_IS_PROCEEDING]);
+    }
+
+    public function testIsProceedingReadsTheInMemorySetting(): void
+    {
+        self::assertSame(1, $this->makeVolume([Episciences_Volume::VOLUME_IS_PROCEEDING => '1'])->isProceeding());
+        self::assertSame(0, $this->makeVolume([])->isProceeding());
+    }
+}

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_PrimaryVolumeTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_PrimaryVolumeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace unit\library\Episciences\paper;
+
+use Episciences_Paper;
+use Episciences_Volume;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Unit tests for the primary volume memoisation added to Episciences_Paper.
+ *
+ * Episciences_VolumesManager::find() is a static DB call with no seam, so these
+ * tests exercise the cache contract only: the no-VID short circuit, the memo hit,
+ * and — the part that would silently export the wrong volume if it broke — the
+ * invalidation performed by setVid().
+ *
+ * @covers Episciences_Paper
+ */
+final class Episciences_Paper_PrimaryVolumeTest extends TestCase
+{
+    private function readLoadedFlag(Episciences_Paper $paper): bool
+    {
+        $property = new ReflectionProperty(Episciences_Paper::class, '_primaryVolumeLoaded');
+        $property->setAccessible(true);
+
+        return $property->getValue($paper);
+    }
+
+    private function seedMemo(Episciences_Paper $paper, ?Episciences_Volume $volume): void
+    {
+        foreach (['_primaryVolume' => $volume, '_primaryVolumeLoaded' => true] as $name => $value) {
+            $property = new ReflectionProperty(Episciences_Paper::class, $name);
+            $property->setAccessible(true);
+            $property->setValue($paper, $value);
+        }
+    }
+
+    public function testReturnsNullWithoutHittingTheDatabaseWhenThePaperHasNoVolume(): void
+    {
+        $paper = new Episciences_Paper();
+
+        self::assertNull($paper->getPrimaryVolume());
+    }
+
+    public function testTheMemoIsMarkedLoadedEvenWithoutAVolume(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->getPrimaryVolume();
+
+        // a paper without a volume must not retry the lookup on every read
+        self::assertTrue($this->readLoadedFlag($paper));
+    }
+
+    public function testReturnsTheMemoisedVolume(): void
+    {
+        $volume = new Episciences_Volume();
+        $volume->setVid(15);
+
+        $paper = new Episciences_Paper();
+        $paper->setVid(15);
+        $this->seedMemo($paper, $volume);
+
+        self::assertSame($volume, $paper->getPrimaryVolume());
+        // second read must come from the memo, not from a fresh lookup
+        self::assertSame($volume, $paper->getPrimaryVolume());
+    }
+
+    public function testChangingTheVidDropsTheMemo(): void
+    {
+        $volume = new Episciences_Volume();
+        $volume->setVid(15);
+
+        $paper = new Episciences_Paper();
+        $paper->setVid(15);
+        $this->seedMemo($paper, $volume);
+
+        $paper->setVid(20);
+
+        self::assertFalse($this->readLoadedFlag($paper));
+    }
+
+    public function testSettingTheSameVidKeepsTheMemo(): void
+    {
+        $volume = new Episciences_Volume();
+        $volume->setVid(15);
+
+        $paper = new Episciences_Paper();
+        $paper->setVid(15);
+        $this->seedMemo($paper, $volume);
+
+        $paper->setVid(15);
+
+        self::assertTrue($this->readLoadedFlag($paper));
+        self::assertSame($volume, $paper->getPrimaryVolume());
+    }
+
+    public function testResetPrimaryVolumeDropsTheMemo(): void
+    {
+        $paper = new Episciences_Paper();
+        $paper->setVid(15);
+        $this->seedMemo($paper, new Episciences_Volume());
+
+        self::assertSame($paper, $paper->resetPrimaryVolume());
+        self::assertFalse($this->readLoadedFlag($paper));
+    }
+}


### PR DESCRIPTION
Second of the two adjacent defects spotted while working on #1140 (see #1141 and #1142). Independent of both.

**No payload change** — verified byte-identical output on three papers.

## The problem

Exporting one paper loaded its primary volume twice:

| site | cost |
|---|---|
| `XmlExportManager::xmlExport()` line 48 | `VolumesManager::find()` = 3 queries (volume, settings, metadata) |
| `Paper::toJson()` line 1358 | `VolumesManager::find()` again = 3 more |
| `Paper::getXml()` line 3327 | a third `find()`, **plus** a `loadSettings()` that `find()` had already done at `VolumesManager.php:927` |

On top of that, `Episciences_Volume::getProceedingInfo()` called `loadSettings()` on **every** invocation, re-querying settings that `find()` had just loaded.

## The fix

**1. Memoise the primary volume on the `Episciences_Paper` instance**, behind `getPrimaryVolume()`.

Per-instance rather than a `Zend_Registry` cache on purpose: the lifetime is tied to the paper, not to the whole request, so a volume edited elsewhere in the same request cannot be served stale. And `setVid()` drops the memo when the VID actually changes — that one matters, because `savemastervolumeAction()` does `setVid()` then `save()`, and `save()` regenerates the JSON. Without the invalidation this change would silently export the previous volume; there is a test pinning it.

`Export.php` keeps its own `Zend_Registry` cache (lines 113 and 631) — it is cross-paper, which is the better trade-off when exporting a whole volume, so I left it alone. Two caches coexist; unifying them would mean touching the 28 `find()` call sites, several of which (`VolumeController`) **mutate** volumes.

**2. Drop `loadSettings()` from `getProceedingInfo()`.** Every caller reaches it through `isProceeding()`, which itself reads a setting — so by the time you get there the settings are loaded by definition.

The one exception was the trap in this change: `BrowseController.php:181` called `$volume->getProceedingInfo();` and **discarded the result**, purely for that side effect. `partials/volume.phtml` then reads 11 settings through `getSetting()`, and neither `Review::getVolumes()` nor `getVolumesWithPapers()` loads them. Removing the call blindly would have emptied the conference block on `/browse/volumes`.

Replaced with a single `VolumesManager::loadSettingsForVolumes($volumes)` before the loop — which also removes an N+1 on that page.

## Measurements

`papers:update-document --docid=… --json --dry-run`, MySQL `Questions` delta, 5 runs each, identical every time:

| paper | before | after |
|---|---|---|
| docid 4604 (elpub, proceedings volume) | 38 | **34** |
| docid 1385 (jdmdh, plain volume) | 37 | **34** |

`toJson()` runs on every `Paper::save()` and every `/jsonv2` hit, so this is on a hot path.

## Verification

| Check | Result |
|---|---|
| PHPStan L6 on both new test files | 0 errors |
| PHPStan L6 `Paper.php` | 230 → 230 |
| PHPStan L6 `Volume.php` / `XmlExportManager.php` / `BrowseController.php` | 90 / 1 / 15, unchanged |
| 10 new tests, plus the 57 existing volume tests | pass |
| Payload identical, docid 1385 / 4604 / 2618 | byte-for-byte |

The `instanceof Episciences_Volume` at `Paper.php:3463` goes away with the change: after `isset()`, the narrowed type is already `Episciences_Volume`, which PHPStan started reporting once `getPrimaryVolume()` replaced `find()`'s `Episciences_Volume|bool`. Removing it is what brings the file back to its 230 baseline.

New tests:
- `Episciences_Paper_PrimaryVolumeTest` — the no-VID short circuit, the memo hit, invalidation on a VID change, no invalidation when the VID is unchanged, and `resetPrimaryVolume()`.
- `Episciences_VolumeProceedingInfoTest` — `getProceedingInfo()` reads in-memory settings without querying. Three of its four tests error out against the old implementation (`Call to a member function select() on null`), which is how I confirmed the side effect is really gone.

## Still to check by hand

Two paths I could not exercise locally:

- **`/browse/volumes`** — confirm the conference block still renders for a proceedings volume (docid 4604 belongs to vid 339 on elpub).
- **`getXml()`** on the paper admin page. The removed `loadSettings()` was provably redundant — `find()` performs it at `VolumesManager.php:927`, `getNameKey()` only reads titles, and the later `getSetting(SETTING_SPECIAL_ISSUE)` at line 3463 works off the settings `find()` loaded — but the rendering itself is worth one look.

**`make test-php` also needs a run on a full environment**: my local database has no `dev` journal, so `application/Bootstrap.php:83` exits with `Configuration Error: dev journal does not exists.` An untouched test (`Episciences_Paper_MiscTest`) fails identically, so this is pre-existing and unrelated. I validated the new tests with a minimal bootstrap, kept out of the repository.
