### PR TITLE
fix(citations): sort bibliographic references by referenceOrder (#1145)

### DIFF
--- a/library/Episciences/Api/BiblioRefApiClient.php
+++ b/library/Episciences/Api/BiblioRefApiClient.php
@@ -107,6 +107,21 @@ class BiblioRefApiClient extends AbstractApiClient
             return [];
         }
 
+        uasort($decoded, static function ($a, $b): int {
+            $orderA = is_array($a) && isset($a['referenceOrder']) && is_numeric($a['referenceOrder']) ? (int) $a['referenceOrder'] : null;
+            $orderB = is_array($b) && isset($b['referenceOrder']) && is_numeric($b['referenceOrder']) ? (int) $b['referenceOrder'] : null;
+            if ($orderA !== null && $orderB !== null) {
+                return $orderA <=> $orderB;
+            }
+            if ($orderA !== null) {
+                return -1;
+            }
+            if ($orderB !== null) {
+                return 1;
+            }
+            return 0;
+        });
+
         $result = [];
         foreach ($decoded as $citation) {
             if (!is_array($citation) || !isset($citation['ref'])) {

--- a/library/Episciences/Api/BiblioRefApiClient.php
+++ b/library/Episciences/Api/BiblioRefApiClient.php
@@ -107,19 +107,12 @@ class BiblioRefApiClient extends AbstractApiClient
             return [];
         }
 
+        // A missing/non-numeric referenceOrder sorts last (PHP_INT_MAX sentinel); mirrored in
+        // public/js/paper/biblioRef.js (BiblioRefParser.parseCitation + the citations.sort comparator).
         uasort($decoded, static function ($a, $b): int {
-            $orderA = is_array($a) && isset($a['referenceOrder']) && is_numeric($a['referenceOrder']) ? (int) $a['referenceOrder'] : null;
-            $orderB = is_array($b) && isset($b['referenceOrder']) && is_numeric($b['referenceOrder']) ? (int) $b['referenceOrder'] : null;
-            if ($orderA !== null && $orderB !== null) {
-                return $orderA <=> $orderB;
-            }
-            if ($orderA !== null) {
-                return -1;
-            }
-            if ($orderB !== null) {
-                return 1;
-            }
-            return 0;
+            $orderA = is_array($a) && isset($a['referenceOrder']) && is_numeric($a['referenceOrder']) ? (int) $a['referenceOrder'] : PHP_INT_MAX;
+            $orderB = is_array($b) && isset($b['referenceOrder']) && is_numeric($b['referenceOrder']) ? (int) $b['referenceOrder'] : PHP_INT_MAX;
+            return $orderA <=> $orderB;
         });
 
         $result = [];

--- a/public/js/paper/biblioRef.js
+++ b/public/js/paper/biblioRef.js
@@ -126,8 +126,10 @@ class BiblioRefParser {
 
             // Reference order within bibliography (for manual/curated reordering)
             let referenceOrder;
-            if (citation.referenceOrder !== undefined && citation.referenceOrder !== null && !isNaN(Number(citation.referenceOrder))) {
-                referenceOrder = Number(citation.referenceOrder);
+            const rawReferenceOrder = citation.referenceOrder;
+            const isBlankReferenceOrder = typeof rawReferenceOrder === 'string' && rawReferenceOrder.trim() === '';
+            if (rawReferenceOrder !== undefined && rawReferenceOrder !== null && !isBlankReferenceOrder && Number.isFinite(Number(rawReferenceOrder))) {
+                referenceOrder = Number(rawReferenceOrder);
             }
 
             return {

--- a/public/js/paper/biblioRef.js
+++ b/public/js/paper/biblioRef.js
@@ -124,6 +124,12 @@ class BiblioRefParser {
                 ? openAccess.source_title
                 : '';
 
+            // Reference order within bibliography (for manual/curated reordering)
+            let referenceOrder;
+            if (citation.referenceOrder !== undefined && citation.referenceOrder !== null && !isNaN(Number(citation.referenceOrder))) {
+                referenceOrder = Number(citation.referenceOrder);
+            }
+
             return {
                 rawReference: parsedRef.raw_reference,
                 doi:          parsedRef.doi,
@@ -137,6 +143,7 @@ class BiblioRefParser {
                 pubpeerurl,
                 isSuspect,
                 isGenuine,
+                referenceOrder,
             };
         } catch (error) {
             console.error('Failed to parse citation reference:', error);
@@ -512,6 +519,22 @@ class BiblioRefManager {
                     BiblioRefParser.parseCitation(citation, config.showAll)
                 )
                 .filter(citation => citation !== null);
+
+            // Sort citations by referenceOrder when available
+            citations.sort((a, b) => {
+                const orderA = a.referenceOrder;
+                const orderB = b.referenceOrder;
+                if (orderA !== undefined && orderB !== undefined) {
+                    return orderA - orderB;
+                }
+                if (orderA !== undefined) {
+                    return -1;
+                }
+                if (orderB !== undefined) {
+                    return 1;
+                }
+                return 0;
+            });
 
             // Render citations if we have any
             if (citations.length > 0) {

--- a/public/js/paper/biblioRef.js
+++ b/public/js/paper/biblioRef.js
@@ -124,7 +124,9 @@ class BiblioRefParser {
                 ? openAccess.source_title
                 : '';
 
-            // Reference order within bibliography (for manual/curated reordering)
+            // Reference order within bibliography (for manual/curated reordering).
+            // A missing/non-numeric referenceOrder is left undefined and sorts last (see citations.sort
+            // below); mirrored in library/Episciences/Api/BiblioRefApiClient.php::parseResponse().
             let referenceOrder;
             const rawReferenceOrder = citation.referenceOrder;
             const isBlankReferenceOrder = typeof rawReferenceOrder === 'string' && rawReferenceOrder.trim() === '';
@@ -522,20 +524,13 @@ class BiblioRefManager {
                 )
                 .filter(citation => citation !== null);
 
-            // Sort citations by referenceOrder when available
+            // Sort citations by referenceOrder when available; a missing referenceOrder sorts last.
+            // Number.MAX_SAFE_INTEGER (rather than Infinity) is used as the "missing" sentinel so that
+            // two missing values subtract to 0, not NaN, keeping this a spec-valid sort comparator.
             citations.sort((a, b) => {
-                const orderA = a.referenceOrder;
-                const orderB = b.referenceOrder;
-                if (orderA !== undefined && orderB !== undefined) {
-                    return orderA - orderB;
-                }
-                if (orderA !== undefined) {
-                    return -1;
-                }
-                if (orderB !== undefined) {
-                    return 1;
-                }
-                return 0;
+                const orderA = a.referenceOrder ?? Number.MAX_SAFE_INTEGER;
+                const orderB = b.referenceOrder ?? Number.MAX_SAFE_INTEGER;
+                return orderA - orderB;
             });
 
             // Render citations if we have any

--- a/public/js/paper/biblioRef.js
+++ b/public/js/paper/biblioRef.js
@@ -129,8 +129,9 @@ class BiblioRefParser {
             // below); mirrored in library/Episciences/Api/BiblioRefApiClient.php::parseResponse().
             let referenceOrder;
             const rawReferenceOrder = citation.referenceOrder;
-            const isBlankReferenceOrder = typeof rawReferenceOrder === 'string' && rawReferenceOrder.trim() === '';
-            if (rawReferenceOrder !== undefined && rawReferenceOrder !== null && !isBlankReferenceOrder && Number.isFinite(Number(rawReferenceOrder))) {
+            const isNumberType = typeof rawReferenceOrder === 'number';
+            const isNonBlankStringType = typeof rawReferenceOrder === 'string' && rawReferenceOrder.trim() !== '';
+            if ((isNumberType || isNonBlankStringType) && Number.isFinite(Number(rawReferenceOrder))) {
                 referenceOrder = Number(rawReferenceOrder);
             }
 

--- a/tests/js/biblioRef.test.js
+++ b/tests/js/biblioRef.test.js
@@ -420,6 +420,37 @@ describe('BiblioRefParser', () => {
             expect(result.openAccessUrl).toBeNull();
             expect(result.openAccessSourceTitle).toBe('');
         });
+
+        it('should parse referenceOrder when present as number or numeric string', () => {
+            const citationNum = {
+                ref: { raw_reference: 'Paper 1' },
+                referenceOrder: 12,
+            };
+            const resultNum = BiblioRefParser.parseCitation(citationNum, false);
+            expect(resultNum.referenceOrder).toBe(12);
+
+            const citationStr = {
+                ref: { raw_reference: 'Paper 2' },
+                referenceOrder: '15',
+            };
+            const resultStr = BiblioRefParser.parseCitation(citationStr, false);
+            expect(resultStr.referenceOrder).toBe(15);
+        });
+
+        it('should leave referenceOrder undefined when absent or invalid', () => {
+            const citationWithout = {
+                ref: { raw_reference: 'Paper 1' },
+            };
+            const resultWithout = BiblioRefParser.parseCitation(citationWithout, false);
+            expect(resultWithout.referenceOrder).toBeUndefined();
+
+            const citationInvalid = {
+                ref: { raw_reference: 'Paper 2' },
+                referenceOrder: 'not-a-number',
+            };
+            const resultInvalid = BiblioRefParser.parseCitation(citationInvalid, false);
+            expect(resultInvalid.referenceOrder).toBeUndefined();
+        });
     });
 
     describe('formatDoi', () => {
@@ -1363,6 +1394,46 @@ describe('BiblioRefManager', () => {
 
             const container = document.getElementById('biblio-refs-container');
             expect(container.innerHTML).toContain('Test');
+        });
+
+        it('should sort citations by referenceOrder when initializing', async () => {
+            document.body.innerHTML = `
+                <div id="visualize-biblio-refs"
+                     data-api="https://api.test.com"
+                     data-value="https://paper.com/123">
+                </div>
+                <ol id="biblio-refs-container"></ol>
+            `;
+
+            // Simulating API response where key order "13", "14" does not match referenceOrder 13, 12
+            const mockResponse = {
+                1: {
+                    ref: { raw_reference: 'Reference 1 (order 0)' },
+                    referenceOrder: 0,
+                },
+                13: {
+                    ref: { raw_reference: 'Reference 13 (order 13)' },
+                    referenceOrder: 13,
+                },
+                14: {
+                    ref: { raw_reference: 'Reference 14 (order 12)' },
+                    referenceOrder: 12,
+                },
+            };
+
+            fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockResponse,
+            });
+
+            await manager.initialize();
+
+            const container = document.getElementById('biblio-refs-container');
+            const items = container.querySelectorAll('li');
+            expect(items.length).toBe(3);
+            expect(items[0].textContent).toContain('Reference 1 (order 0)');
+            expect(items[1].textContent).toContain('Reference 14 (order 12)');
+            expect(items[2].textContent).toContain('Reference 13 (order 13)');
         });
     });
 });

--- a/tests/js/biblioRef.test.js
+++ b/tests/js/biblioRef.test.js
@@ -464,6 +464,27 @@ describe('BiblioRefParser', () => {
             };
             const resultInfinite = BiblioRefParser.parseCitation(citationInfinite, false);
             expect(resultInfinite.referenceOrder).toBeUndefined();
+
+            const citationBoolean = {
+                ref: { raw_reference: 'Paper 5' },
+                referenceOrder: false,
+            };
+            const resultBoolean = BiblioRefParser.parseCitation(citationBoolean, false);
+            expect(resultBoolean.referenceOrder).toBeUndefined();
+
+            const citationEmptyArray = {
+                ref: { raw_reference: 'Paper 6' },
+                referenceOrder: [],
+            };
+            const resultEmptyArray = BiblioRefParser.parseCitation(citationEmptyArray, false);
+            expect(resultEmptyArray.referenceOrder).toBeUndefined();
+
+            const citationArrayWithNumber = {
+                ref: { raw_reference: 'Paper 7' },
+                referenceOrder: [3],
+            };
+            const resultArrayWithNumber = BiblioRefParser.parseCitation(citationArrayWithNumber, false);
+            expect(resultArrayWithNumber.referenceOrder).toBeUndefined();
         });
     });
 
@@ -1448,6 +1469,43 @@ describe('BiblioRefManager', () => {
             expect(items[0].textContent).toContain('Reference 1 (order 0)');
             expect(items[1].textContent).toContain('Reference 14 (order 12)');
             expect(items[2].textContent).toContain('Reference 13 (order 13)');
+        });
+
+        it('should keep unordered citations last and preserve their relative order', async () => {
+            document.body.innerHTML = `
+                <div id="visualize-biblio-refs"
+                     data-api="https://api.test.com"
+                     data-value="https://paper.com/123">
+                </div>
+                <ol id="biblio-refs-container"></ol>
+            `;
+
+            const mockResponse = {
+                1: {
+                    ref: { raw_reference: 'Reference 1 (unordered A)' },
+                },
+                2: {
+                    ref: { raw_reference: 'Reference 2 (order 5)' },
+                    referenceOrder: 5,
+                },
+                3: {
+                    ref: { raw_reference: 'Reference 3 (unordered B)' },
+                },
+            };
+
+            fetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => mockResponse,
+            });
+
+            await manager.initialize();
+
+            const container = document.getElementById('biblio-refs-container');
+            const items = container.querySelectorAll('li');
+            expect(items.length).toBe(3);
+            expect(items[0].textContent).toContain('Reference 2 (order 5)');
+            expect(items[1].textContent).toContain('Reference 1 (unordered A)');
+            expect(items[2].textContent).toContain('Reference 3 (unordered B)');
         });
     });
 });

--- a/tests/js/biblioRef.test.js
+++ b/tests/js/biblioRef.test.js
@@ -450,6 +450,20 @@ describe('BiblioRefParser', () => {
             };
             const resultInvalid = BiblioRefParser.parseCitation(citationInvalid, false);
             expect(resultInvalid.referenceOrder).toBeUndefined();
+
+            const citationBlank = {
+                ref: { raw_reference: 'Paper 3' },
+                referenceOrder: '   ',
+            };
+            const resultBlank = BiblioRefParser.parseCitation(citationBlank, false);
+            expect(resultBlank.referenceOrder).toBeUndefined();
+
+            const citationInfinite = {
+                ref: { raw_reference: 'Paper 4' },
+                referenceOrder: 'Infinity',
+            };
+            const resultInfinite = BiblioRefParser.parseCitation(citationInfinite, false);
+            expect(resultInfinite.referenceOrder).toBeUndefined();
         });
     });
 

--- a/tests/unit/library/Episciences/Api/BiblioRefApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/BiblioRefApiClientTest.php
@@ -365,4 +365,29 @@ class BiblioRefApiClientTest extends TestCase
         $this->assertSame('Jones (2024)', $result[0]['unstructured_citation']);
         $this->assertSame('10.9999/xyz', $result[0]['doi']);
     }
+
+    public function testParseResponse_SortedByReferenceOrder(): void
+    {
+        $client = $this->makeApiClient('');
+        $body = (string) json_encode([
+            '13' => [
+                'ref' => ['raw_reference' => 'Citation 13 (order 13)'],
+                'referenceOrder' => 13,
+            ],
+            '14' => [
+                'ref' => ['raw_reference' => 'Citation 14 (order 12)'],
+                'referenceOrder' => 12,
+            ],
+            '1' => [
+                'ref' => ['raw_reference' => 'Citation 1 (order 0)'],
+                'referenceOrder' => 0,
+            ],
+        ]);
+        $result = $client->parseResponse($body);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('Citation 1 (order 0)', $result[0]['unstructured_citation']);
+        $this->assertSame('Citation 14 (order 12)', $result[1]['unstructured_citation']);
+        $this->assertSame('Citation 13 (order 13)', $result[2]['unstructured_citation']);
+    }
 }

--- a/tests/unit/library/Episciences/Api/BiblioRefApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/BiblioRefApiClientTest.php
@@ -390,4 +390,26 @@ class BiblioRefApiClientTest extends TestCase
         $this->assertSame('Citation 14 (order 12)', $result[1]['unstructured_citation']);
         $this->assertSame('Citation 13 (order 13)', $result[2]['unstructured_citation']);
     }
+
+    public function testParseResponse_MissingOrNonNumericReferenceOrder_SortsLast(): void
+    {
+        $client = $this->makeApiClient('');
+        $body = (string) json_encode([
+            '1' => [
+                'ref' => ['raw_reference' => 'Citation with blank order'],
+                'referenceOrder' => '',
+            ],
+            '2' => [
+                'ref' => ['raw_reference' => 'Citation with order 5'],
+                'referenceOrder' => 5,
+            ],
+            '3' => [
+                'ref' => ['raw_reference' => 'Citation without order'],
+            ],
+        ]);
+        $result = $client->parseResponse($body);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('Citation with order 5', $result[0]['unstructured_citation']);
+    }
 }


### PR DESCRIPTION
## Description

Fixes #1145
Fixes #1147 

When citations/references are manually re-ordered via the citation tool, the API returns the updated ordering in the `referenceOrder` attribute of each reference, while the JSON object keys (e.g. `"1"`, `"2"`, ..., `"13"`, `"14"`) keep the original extraction index.

Previously:
- In `public/js/paper/biblioRef.js`, `Object.values(response)` iterated over object keys in numeric index order without considering `referenceOrder`, causing re-ordered references to display in the wrong order.
- In `library/Episciences/Api/BiblioRefApiClient.php`, `parseResponse()` also iterated directly on the decoded object keys.

### Changes
1. **Frontend (`public/js/paper/biblioRef.js`)**:
   - Extract `referenceOrder` in `BiblioRefParser.parseCitation()`.
   - Sort citations array by `referenceOrder` ascending in `BiblioRefManager.initialize()` before rendering to the DOM.
2. **Backend (`library/Episciences/Api/BiblioRefApiClient.php`)**:
   - Sort decoded items by `referenceOrder` in `parseResponse()` prior to mapping.
3. **Tests**:
   - Added unit tests in `tests/js/biblioRef.test.js` covering `referenceOrder` extraction and sorting in the DOM.
   - Added unit test in `tests/unit/library/Episciences/Api/BiblioRefApiClientTest.php` for `referenceOrder` sorting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Citations are now displayed in ascending reference order, regardless of the order received from the service.
  * References with valid ordering information appear first; others retain their original relative order.
  * Numeric reference order values are handled consistently, including values provided as text.
  * This provides a more predictable and consistent reading experience for reference lists.

* **Tests**
  * Added coverage for citation ordering and valid, missing, blank, infinite, or invalid reference order values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->