### PR TITLE
fix(papers): scope the vid filter subquery to the requested rvid

### DIFF
--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -166,9 +166,19 @@ class Episciences_PapersManager
             $volumes = (array_key_exists('volumes', $settings)) ? $settings['volumes'] : [];
             $sections = (array_key_exists('sections', $settings)) ? $settings['sections'] : [];
 
-            $select = self::dataTableSearchQuery($select, $word, $volumes, $sections);
+            $select = self::dataTableSearchQuery($select, $word, $volumes, $sections, self::extractFilteredRvid($settings));
         }
         return $select;
+    }
+
+    /**
+     * @param array $settings
+     * @return int|null Journal to scope the query to, or null to fall back to the global RVID constant
+     */
+    private static function extractFilteredRvid(array $settings): ?int
+    {
+        $rvid = $settings['is']['rvid'] ?? $settings['is']['RVID'] ?? null;
+        return is_numeric($rvid) ? (int)$rvid : null;
     }
 
     /**
@@ -182,9 +192,7 @@ class Episciences_PapersManager
     {
         $validFilters = ['rvid', 'repoid', 'uid', 'docid', 'vid', 'sid', 'status'];
         if (array_key_exists('is', $settings)) {
-            $filteredRvid = isset($settings['is']['rvid']) && is_numeric($settings['is']['rvid'])
-                ? (int) $settings['is']['rvid']
-                : null;
+            $filteredRvid = self::extractFilteredRvid($settings);
             foreach ($settings['is'] as $setting => $value) {
                 if (in_array(strtolower($setting), $validFilters)) {
                     $setting = strtoupper($setting);
@@ -512,10 +520,11 @@ class Episciences_PapersManager
      * @param String $word
      * @param array $volumes
      * @param array $sections
+     * @param int|null $rvid Journal to scope the secondary-volume lookup to; falls back to the global RVID constant when null
      * @return Zend_Db_Select
      * @throws Zend_Db_Select_Exception
      */
-    private static function dataTableSearchQuery(Zend_Db_Select $select, string $word = '', array $volumes = [], array $sections = []): \Zend_Db_Select
+    private static function dataTableSearchQuery(Zend_Db_Select $select, string $word = '', array $volumes = [], array $sections = [], ?int $rvid = null): \Zend_Db_Select
     {
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
 
@@ -553,7 +562,7 @@ class Episciences_PapersManager
                 //Volume primaire
                 $where .= "OR VID IN ($volumeCondition) ";
                 //Inclure les documents qui ont un volume secondaire
-                $papersWithSecondaryVolume = self::getVolumesQuery()->where("vpt.VID IN ($volumeCondition) ");
+                $papersWithSecondaryVolume = self::getVolumesQuery(['DOCID'], $rvid)->where("vpt.VID IN ($volumeCondition) ");
                 $where .= "OR DOCID IN ($papersWithSecondaryVolume) ";
             }
 

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -182,6 +182,9 @@ class Episciences_PapersManager
     {
         $validFilters = ['rvid', 'repoid', 'uid', 'docid', 'vid', 'sid', 'status'];
         if (array_key_exists('is', $settings)) {
+            $filteredRvid = isset($settings['is']['rvid']) && is_numeric($settings['is']['rvid'])
+                ? (int) $settings['is']['rvid']
+                : null;
             foreach ($settings['is'] as $setting => $value) {
                 if (in_array(strtolower($setting), $validFilters)) {
                     $setting = strtoupper($setting);
@@ -193,7 +196,7 @@ class Episciences_PapersManager
                         }
 
                     } else {
-                        $select = self::volumesFilter($select, $value, $isFilterInfos);
+                        $select = self::volumesFilter($select, $value, $isFilterInfos, $filteredRvid);
                     }
 
                 }
@@ -239,12 +242,13 @@ class Episciences_PapersManager
      * @param Zend_Db_Select $select
      * @param array $value
      * @param bool $includeSecondaryVolume
+     * @param int|null $rvid Journal to scope the volume lookup to; falls back to the global RVID constant when null
      * @return Zend_Db_Select
      */
-    private static function volumesFilter(Zend_Db_Select $select, array $value, bool $includeSecondaryVolume = false): \Zend_Db_Select
+    private static function volumesFilter(Zend_Db_Select $select, array $value, bool $includeSecondaryVolume = false, ?int $rvid = null): \Zend_Db_Select
     {
         // Filtrage par volume secondaire : inclure l'article s'il appartient à un volume primaire(git#72)
-        $select1 = self::getVolumesQuery();
+        $select1 = self::getVolumesQuery(['DOCID'], $rvid);
 
         $select1->where(" st.VID IN (?)", $value);
 
@@ -259,16 +263,17 @@ class Episciences_PapersManager
 
     /**
      * @param array $fields
+     * @param int|null $rvid Journal to scope the query to; falls back to the global RVID constant when null
      * @return Zend_Db_Select
      */
-    public static function getVolumesQuery(array $fields = ['DOCID']): \Zend_Db_Select
+    public static function getVolumesQuery(array $fields = ['DOCID'], ?int $rvid = null): \Zend_Db_Select
     {
         $db = Zend_Db_Table_Abstract::getDefaultAdapter();
         return $db
             ->select()
             ->from(['st' => T_PAPERS], $fields)
             ->joinLeft(['vpt' => T_VOLUME_PAPER], 'st.DOCID = vpt.DOCID', [])
-            ->where('st.RVID = ?', RVID);
+            ->where('st.RVID = ?', $rvid ?? RVID);
     }
 
     /**

--- a/library/Episciences/VolumesManager.php
+++ b/library/Episciences/VolumesManager.php
@@ -480,12 +480,13 @@ class Episciences_VolumesManager
     /**
      * @param int $vid
      * @param array $fields
+     * @param int|null $rvid Journal to scope the lookup to; falls back to the global RVID constant when null
      * @return Zend_Db_Select
      */
-    private static function isPapersInVolumeQuery(int $vid, array $fields = ['COUNT(st.DOCID)']): \Zend_Db_Select
+    private static function isPapersInVolumeQuery(int $vid, array $fields = ['COUNT(st.DOCID)'], ?int $rvid = null): \Zend_Db_Select
     {
         //Prise en compte des volumes secondaires git #169
-        return Episciences_PapersManager::getVolumesQuery($fields)
+        return Episciences_PapersManager::getVolumesQuery($fields, $rvid)
             ->where("st.VID = ? OR vpt.VID = ?", $vid);
     }
 

--- a/tests/unit/library/Episciences/Episciences_PapersManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_PapersManagerTest.php
@@ -688,6 +688,74 @@ final class Episciences_PapersManagerTest extends TestCase
         self::assertStringContainsString('st.RVID = ' . RVID, $sql);
     }
 
+    /**
+     * Reproduces callers using the uppercase 'RVID' filter key convention (e.g. getList()),
+     * combined with a 'vid' filter, to ensure the rvid lookup is not case-sensitive.
+     */
+    public function testApplyFiltersThreadsUppercaseRvidFilterKeyIntoTheVidSubquery(): void
+    {
+        $reflection = new \ReflectionMethod(Episciences_PapersManager::class, 'applyFilters');
+        $reflection->setAccessible(true);
+
+        $otherRvid = RVID + 41;
+
+        /** @var \Zend_Db_Select $select */
+        $select = $reflection->invoke(
+            null,
+            $this->newPapersSelect(),
+            ['is' => ['RVID' => $otherRvid, 'vid' => [5]]]
+        );
+
+        $sql = $select->assemble();
+
+        self::assertStringContainsString(
+            'st.RVID = ' . $otherRvid,
+            $sql,
+            'The VID subquery must be scoped to the requested rvid regardless of the filter key casing'
+        );
+        self::assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    // -----------------------------------------------------------------------
+    // dataTableSearchQuery(): the DataTable "search" box must scope its secondary-volume
+    // subquery to the rvid being filtered on, not to the global RVID constant.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @param array<int, mixed> $args
+     */
+    private function invokePrivateDataTableSearchQuery(array $args): \Zend_Db_Select
+    {
+        $reflection = new \ReflectionMethod(Episciences_PapersManager::class, 'dataTableSearchQuery');
+        $reflection->setAccessible(true);
+
+        /** @var \Zend_Db_Select $result */
+        $result = $reflection->invoke(null, ...$args);
+
+        return $result;
+    }
+
+    public function testDataTableSearchQueryScopesSecondaryVolumeSubqueryToTheProvidedRvid(): void
+    {
+        $otherRvid = RVID + 41;
+
+        $sql = $this->invokePrivateDataTableSearchQuery(
+            [$this->newPapersSelect(), '', [5 => 'Volume A'], [], $otherRvid]
+        )->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . $otherRvid, $sql);
+        self::assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    public function testDataTableSearchQueryFallsBackToGlobalRvidConstantWhenNoneGiven(): void
+    {
+        $sql = $this->invokePrivateDataTableSearchQuery(
+            [$this->newPapersSelect(), '', [5 => 'Volume A'], []]
+        )->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . RVID, $sql);
+    }
+
     // -----------------------------------------------------------------------
     // applySuggestionFilter() / getPapersWithPendingSuggestionQuery()
     // -----------------------------------------------------------------------

--- a/tests/unit/library/Episciences/Episciences_PapersManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_PapersManagerTest.php
@@ -583,7 +583,13 @@ final class Episciences_PapersManagerTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
-    // applySuggestionFilter() / getPapersWithPendingSuggestionQuery()
+    // getVolumesQuery() / volumesFilter() / applyFilters(): the 'vid' filter must scope
+    // its subquery to the rvid being filtered on, not to the global RVID constant.
+    //
+    // RVID is defined once per PHP process. A long-running CLI process that loops over
+    // several journals (e.g. zbjats:zip) defines it for the first journal only, then every
+    // following journal keeps querying under the first journal's rvid and silently gets
+    // zero results.
     // -----------------------------------------------------------------------
 
     private function newPapersSelect(): \Zend_Db_Select
@@ -591,6 +597,100 @@ final class Episciences_PapersManagerTest extends TestCase
         $db = \Zend_Db_Table_Abstract::getDefaultAdapter();
         return $db->select()->from(['papers' => T_PAPERS], ['DOCID']);
     }
+
+    public function testGetVolumesQueryFallsBackToGlobalRvidConstantWhenNoneGiven(): void
+    {
+        $sql = Episciences_PapersManager::getVolumesQuery()->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . RVID, $sql);
+    }
+
+    public function testGetVolumesQueryUsesTheExplicitRvidOverTheGlobalConstant(): void
+    {
+        $otherRvid = RVID + 41;
+
+        $sql = Episciences_PapersManager::getVolumesQuery(['DOCID'], $otherRvid)->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . $otherRvid, $sql);
+        self::assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    /**
+     * @param array<int, mixed> $args
+     */
+    private function invokePrivateVolumesFilter(array $args): \Zend_Db_Select
+    {
+        $reflection = new \ReflectionMethod(Episciences_PapersManager::class, 'volumesFilter');
+        $reflection->setAccessible(true);
+
+        /** @var \Zend_Db_Select $result */
+        $result = $reflection->invoke(null, ...$args);
+
+        return $result;
+    }
+
+    public function testVolumesFilterScopesItsSubqueryToTheProvidedRvid(): void
+    {
+        $otherRvid = RVID + 41;
+
+        $sql = $this->invokePrivateVolumesFilter([$this->newPapersSelect(), [5], false, $otherRvid])->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . $otherRvid, $sql);
+        self::assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    public function testVolumesFilterFallsBackToGlobalRvidConstantWhenNoneGiven(): void
+    {
+        $sql = $this->invokePrivateVolumesFilter([$this->newPapersSelect(), [5]])->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . RVID, $sql);
+    }
+
+    /**
+     * Reproduces Episciences_Volume::getPaperListFromVolume(), which filters papers by
+     * ['is' => ['rvid' => ..., 'vid' => [...]]] for one specific journal.
+     */
+    public function testApplyFiltersThreadsTheRvidFilterIntoTheVidSubquery(): void
+    {
+        $reflection = new \ReflectionMethod(Episciences_PapersManager::class, 'applyFilters');
+        $reflection->setAccessible(true);
+
+        $otherRvid = RVID + 41;
+
+        /** @var \Zend_Db_Select $select */
+        $select = $reflection->invoke(
+            null,
+            $this->newPapersSelect(),
+            ['is' => ['rvid' => $otherRvid, 'vid' => [5]]]
+        );
+
+        $sql = $select->assemble();
+
+        self::assertStringContainsString('RVID = ' . $otherRvid, $sql);
+        self::assertStringContainsString('st.RVID = ' . $otherRvid, $sql, 'The VID subquery must be scoped to the requested rvid, not the global RVID constant');
+        self::assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    public function testApplyFiltersFallsBackToGlobalRvidConstantWhenNoRvidFilterIsGiven(): void
+    {
+        $reflection = new \ReflectionMethod(Episciences_PapersManager::class, 'applyFilters');
+        $reflection->setAccessible(true);
+
+        /** @var \Zend_Db_Select $select */
+        $select = $reflection->invoke(
+            null,
+            $this->newPapersSelect(),
+            ['is' => ['vid' => [5]]]
+        );
+
+        $sql = $select->assemble();
+
+        self::assertStringContainsString('st.RVID = ' . RVID, $sql);
+    }
+
+    // -----------------------------------------------------------------------
+    // applySuggestionFilter() / getPapersWithPendingSuggestionQuery()
+    // -----------------------------------------------------------------------
 
     /**
      * @param array<int, int|string>|string $values

--- a/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
+++ b/tests/unit/library/Episciences/Episciences_VolumesManagerTest.php
@@ -281,4 +281,26 @@ class Episciences_VolumesManagerTest extends TestCase
 
         $this->assertIsInt($uids[0]);
     }
+
+    // =========================================================================
+    // isPapersInVolumeQuery(): must scope its lookup to the rvid being filtered
+    // on, not to the global RVID constant, when one is explicitly provided.
+    // =========================================================================
+
+    public function testIsPapersInVolumeQueryScopesLookupToTheProvidedRvid(): void
+    {
+        $otherRvid = RVID + 41;
+
+        $sql = $this->callPrivate('isPapersInVolumeQuery', [5, ['COUNT(st.DOCID)'], $otherRvid])->assemble();
+
+        $this->assertStringContainsString('st.RVID = ' . $otherRvid, $sql);
+        $this->assertStringNotContainsString('st.RVID = ' . RVID . ' ', $sql . ' ');
+    }
+
+    public function testIsPapersInVolumeQueryFallsBackToGlobalRvidConstantWhenNoneGiven(): void
+    {
+        $sql = $this->callPrivate('isPapersInVolumeQuery', [5])->assemble();
+
+        $this->assertStringContainsString('st.RVID = ' . RVID, $sql);
+    }
 }


### PR DESCRIPTION
## Summary
- `Episciences_PapersManager::getVolumesQuery()` always filtered its subquery by the global `RVID` constant, ignoring any `rvid` already present in the caller's filter settings.
- `RVID` is defined once per PHP process. A long-running CLI process that loops over several journals in the same process (e.g. `zbjats:zip`) defines it for the first journal only; every following journal then queries volumes under the first journal's rvid and silently gets zero papers back — the volume paper list ends up empty, no PDF/XML gets cached, the ZIP creation is skipped, and the command still reports success for that journal.
- Threaded the actually-filtered `rvid` from `applyFilters()` through `volumesFilter()` into `getVolumesQuery()` (new optional `?int $rvid` param, falling back to the `RVID` constant when not given, so every other caller keeps its current behavior unchanged).

## Out of scope
- `Episciences_PapersManager::getList()` still resolves conflicts via `$settings['is']['RVID'] ?? RVID` (uppercase key, never matches the lowercase `'rvid'` settings used everywhere else) — same anti-pattern, but it only affects `Paper::getConflicts()` attribution, not the bug reported here. Flagging separately rather than expanding this PR's scope.
- 3 pre-existing failures in `tests/unit/scripts/ZbjatsZipperCommandTest.php` (`buildPaperUrl()` type mismatch between the method signature and the test fixtures) are unrelated to this change — reproduced identically on `staging` before this branch.

## Test plan
- [x] Added regression tests in `tests/unit/library/Episciences/Episciences_PapersManagerTest.php` covering `getVolumesQuery()`, `volumesFilter()`, and `applyFilters()`, asserting the generated SQL is scoped to the explicit rvid and still falls back to the `RVID` constant when none is given.
- [x] `make phpstan LEVEL=6 TARGET=library/Episciences/PapersManager.php` — same 175 pre-existing errors as on `staging`, no new ones introduced.
- [x] `phpunit` on `Episciences_PapersManagerTest`, `Episciences_PapersManager_CcBccTest`, `paper/Episciences_PapersManagerTest`, `Episciences_VolumeTest`, `Episciences_VolumesManagerTest`, `Episciences_VolumesAndSectionsManagerTest`, `Volume/Episciences_Volume_MetadataTest`, `ZbjatsZipperCommandTest`, `ZbjatsToolsTest` — all green except the 3 pre-existing `ZbjatsZipperCommandTest` failures noted above (reproduced identically on `staging`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Volume filtering now correctly scopes results to the selected review.
  * Review-specific volume lookups use the provided review identifier when available.
  * Existing volume searches continue to work using the default review context when no specific review is selected.

* **Bug Fixes**
  * Improved consistency when applying review and volume filters, ensuring related results are correctly matched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->