### PR TITLE
Allow customizing the review code shown in automatic emails

### DIFF
--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -236,6 +236,8 @@ return array(
     'Séparés par des points-virgules (ex. : mathématiques ; physique)' => 'Semicolon-separated (e.g.: mathematics; physics)',
     'Année de création' => 'Year of creation',
     'Année de création de la revue (format : AAAA)' => 'Year the journal was created (format: YYYY)',
+    'Code affiché dans les courriels' => 'Code displayed in emails',
+    'Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.' => "Replaces the journal's code in the subject and body of automatic emails. Leave empty to use the default code.",
 
 
     //Assignation automatique des rédacteurs,

--- a/application/languages/en/views.php
+++ b/application/languages/en/views.php
@@ -237,7 +237,7 @@ return array(
     'Année de création' => 'Year of creation',
     'Année de création de la revue (format : AAAA)' => 'Year the journal was created (format: YYYY)',
     'Code affiché dans les courriels' => 'Code displayed in emails',
-    'Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.' => "Replaces the journal's code in the subject and body of automatic emails. Leave empty to use the default code.",
+    'Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut. 100 caractères maximum.' => "Replaces the journal's code in the subject and body of automatic emails. Leave empty to use the default code. 100 characters maximum.",
 
 
     //Assignation automatique des rédacteurs,

--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -638,7 +638,9 @@ class UserDefaultController extends Zend_Controller_Action
                 $tokenUrl = APPLICATION_URL . $url;
 
                 $tags = [
-                    Episciences_Mail_Tags::TAG_REVIEW_CODE => RVCODE,
+                    // TAG_REVIEW_CODE deliberately omitted: it is not in OVERRIDABLE_TAGS,
+                    // so sendMailFromReview() already sets it from the review's mail display
+                    // code (Episciences_Mail's constructor runs before this array is merged).
                     Episciences_Mail_Tags::TAG_REVIEW_NAME => RVNAME,
                     Episciences_Mail_Tags::TAG_TOKEN_VALIDATION_LINK => $tokenUrl
 

--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -1456,7 +1456,7 @@ class AdministratepaperController extends PaperDefaultController
             Episciences_Mail_Tags::TAG_AUTHORS_NAMES => $oPaper->formatAuthorsMetadata(),
             Episciences_Mail_Tags::TAG_SENDER_FULL_NAME => Episciences_Auth::getFullName(),
             Episciences_Mail_Tags::TAG_UPDATED_DEADLINE => $this->view->Date($oAssignment->getDeadline()),
-            Episciences_Mail_Tags::TAG_REVIEW_CODE => RVCODE,
+            Episciences_Mail_Tags::TAG_REVIEW_CODE => $oReview->getMailDisplayCode(),
         ];
         $subject = str_replace(array_keys($tags), array_values($tags), $template->getSubject());
         $body = str_replace(array_keys($tags), array_values($tags), $template->getBody());
@@ -3329,7 +3329,7 @@ class AdministratepaperController extends PaperDefaultController
                 Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID => $oPaper->getPaperid(),
                 Episciences_Mail_Tags::TAG_ARTICLE_TITLE => $oPaper->getTitle($locale, true),
                 Episciences_Mail_Tags::TAG_AUTHORS_NAMES => $oPaper->formatAuthorsMetadata(),
-                Episciences_Mail_Tags::TAG_REVIEW_CODE => RVCODE,
+                Episciences_Mail_Tags::TAG_REVIEW_CODE => $oReview->getMailDisplayCode(),
                 Episciences_Mail_Tags::TAG_RECIPIENT_USERNAME => (!$oAssignment->isTmp_user()) ? $oReviewer->getUsername() : '',
             ];
 

--- a/application/modules/journal/controllers/AdministratepaperController.php
+++ b/application/modules/journal/controllers/AdministratepaperController.php
@@ -941,7 +941,7 @@ class AdministratepaperController extends PaperDefaultController
         $this->view->logs = $paper->getHistory();
 
         // js tags
-        $this->view->js_review = Zend_Json::encode(['rvid' => RVID, 'code' => RVCODE, 'name' => $review->getName()]);
+        $this->view->js_review = Zend_Json::encode(['rvid' => RVID, 'code' => $review->getMailDisplayCode(), 'name' => $review->getName()]);
         $this->view->js_paper = Zend_Json::encode(['id' => $paper->getDocid(),
             'title' => $paper->getAllTitles(),
             'repository' => (int)$paper->getRepoid()]);
@@ -1349,7 +1349,7 @@ class AdministratepaperController extends PaperDefaultController
 
             // review js array init
             $review['id'] = $oReview->getRvid();
-            $review['code'] = $oReview->getCode();
+            $review['code'] = $oReview->getMailDisplayCode();
             $review['name'] = $oReview->getName();
             $review['invitation_deadline'] = $oReview->getSetting('invitation_deadline');
             $review['rating_deadline'] = Episciences_Tools::addDateInterval(date('Y-m-d'), $oReview->getSetting('rating_deadline'));
@@ -1437,7 +1437,7 @@ class AdministratepaperController extends PaperDefaultController
 
         //get review object
         $oReview = Episciences_ReviewsManager::find(RVID);
-        $review = ['rvid' => RVID, 'code' => RVCODE, 'name' => $oReview->getName()];
+        $review = ['rvid' => RVID, 'code' => $oReview->getMailDisplayCode(), 'name' => $oReview->getName()];
 
         //init template
         $template = new Episciences_Mail_Template;
@@ -3292,7 +3292,7 @@ class AdministratepaperController extends PaperDefaultController
 
             //review object
             $oReview = Episciences_ReviewsManager::find(RVID);
-            $review = ['rvid' => RVID, 'code' => RVCODE, 'name' => $oReview->getName()];
+            $review = ['rvid' => RVID, 'code' => $oReview->getMailDisplayCode(), 'name' => $oReview->getName()];
 
             //user object
             if ($oAssignment->isTmp_user()) {
@@ -3811,7 +3811,7 @@ class AdministratepaperController extends PaperDefaultController
         // Préparation de js_review
         $review = [
             'id' => $oReview->getRvid(),
-            'code' => $oReview->getCode(),
+            'code' => $oReview->getMailDisplayCode(),
             'name' => $oReview->getName()
         ];
 

--- a/application/modules/journal/views/scripts/administratemail/datatable_history.phtml
+++ b/application/modules/journal/views/scripts/administratemail/datatable_history.phtml
@@ -5,7 +5,7 @@
                href="/administratemail/view?id=<?php echo $mail['ID'] ?>"
                data-width="50%" data-toggle="tooltip"
                title="<?php echo $this->translate('Voir cet e-mail'); ?>">
-                <?php echo ($mail['SUBJECT']) ? $mail['SUBJECT'] : $this->translate('Aucun sujet'); ?>
+                <?php echo ($mail['SUBJECT']) ? htmlentities($mail['SUBJECT']) : $this->translate('Aucun sujet'); ?>
             </a>
         </td>
         <td>

--- a/application/modules/journal/views/scripts/administratemail/view.phtml
+++ b/application/modules/journal/views/scripts/administratemail/view.phtml
@@ -56,7 +56,7 @@
 
         <tr>
             <td class="td-label"><?php echo $this->translate('Sujet'); ?></td>
-            <td class="small"><?= !(empty($this->mail['Subject'])) ? $this->mail['Subject'] : $this->translate('Aucun sujet'); ?></td>
+            <td class="small"><?= !(empty($this->mail['Subject'])) ? htmlentities($this->mail['Subject']) : $this->translate('Aucun sujet'); ?></td>
         </tr>
 
     </table>

--- a/application/modules/journal/views/scripts/administratepaper/log.phtml
+++ b/application/modules/journal/views/scripts/administratepaper/log.phtml
@@ -180,7 +180,7 @@
                 <td class="td-label"><?= $this->translate('Sujet') ?></td>
                 <td class="small">
                     <?php if (array_key_exists('Subject', $this->log['detail']['mail']) && $this->log['detail']['mail']['Subject']) : ?>
-                        <?= htmlspecialchars_decode($this->log['detail']['mail']['Subject']) ?>
+                        <?= htmlentities($this->log['detail']['mail']['Subject']) ?>
                     <?php else : ?>
                         -
                     <?php endif; ?>

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -68,13 +68,7 @@ class Episciences_Mail extends Zend_Mail
         }
 
         if (defined('RVCODE')) {
-            $mailDisplayCode = RVCODE;
-            if ($review instanceof Episciences_Review) {
-                $customMailDisplayCode = trim((string)$review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
-                if ($customMailDisplayCode !== '') {
-                    $mailDisplayCode = $customMailDisplayCode;
-                }
-            }
+            $mailDisplayCode = ($review instanceof Episciences_Review) ? $review->getMailDisplayCode() : RVCODE;
             $this->addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $mailDisplayCode);
         }
         if (defined('RVNAME')) {

--- a/library/Episciences/Mail.php
+++ b/library/Episciences/Mail.php
@@ -60,9 +60,22 @@ class Episciences_Mail extends Zend_Mail
 
         $this->setPath(EPISCIENCES_MAIL_PATH);
 
+        // find() returns false for an unknown review code: guard before loadSettings()
+        // to avoid a fatal, falling back to the generic error return path.
+        $review = Episciences_ReviewsManager::find($rvCode);
+        if ($review instanceof Episciences_Review) {
+            $review->loadSettings();
+        }
 
         if (defined('RVCODE')) {
-            $this->addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, RVCODE);
+            $mailDisplayCode = RVCODE;
+            if ($review instanceof Episciences_Review) {
+                $customMailDisplayCode = trim((string)$review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
+                if ($customMailDisplayCode !== '') {
+                    $mailDisplayCode = $customMailDisplayCode;
+                }
+            }
+            $this->addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $mailDisplayCode);
         }
         if (defined('RVNAME')) {
             $this->addTag(Episciences_Mail_Tags::TAG_REVIEW_NAME, RVNAME);
@@ -75,15 +88,12 @@ class Episciences_Mail extends Zend_Mail
             $this->addTag(Episciences_Mail_Tags::TAG_SENDER_LAST_NAME, Episciences_Auth::getLastname());
 
         }
-        // find() returns false for an unknown review code: guard before loadSettings()
-        // to avoid a fatal, falling back to the generic error return path.
-        $review = Episciences_ReviewsManager::find($rvCode);
+
         if (!$review instanceof Episciences_Review) {
             $this->setReturnPath('error@' . DOMAIN);
             return;
         }
 
-        $review->loadSettings();
         $mailError = $review->getSetting(Episciences_Review::SETTING_CONTACT_ERROR_MAIL);
         if ($mailError === false || $mailError === "0") {
             $this->setReturnPath('error@' . DOMAIN);

--- a/library/Episciences/Mail/Send.php
+++ b/library/Episciences/Mail/Send.php
@@ -14,17 +14,9 @@ class Episciences_Mail_Send
      */
     private static function getMailDisplayCode(): string
     {
-        try {
-            $reviewSettings = Zend_Registry::get('reviewSettings');
-            $customMailDisplayCode = trim((string)($reviewSettings[Episciences_Review::SETTING_MAIL_DISPLAY_CODE] ?? ''));
-            if ($customMailDisplayCode !== '') {
-                return $customMailDisplayCode;
-            }
-        } catch (Exception $e) {
-            trigger_error($e->getMessage());
-        }
+        $review = Episciences_ReviewsManager::find(RVCODE);
 
-        return (string)RVCODE;
+        return $review instanceof Episciences_Review ? $review->getMailDisplayCode() : (string)RVCODE;
     }
 
     /**

--- a/library/Episciences/Mail/Send.php
+++ b/library/Episciences/Mail/Send.php
@@ -9,6 +9,25 @@ class Episciences_Mail_Send
     public const ATTACHMENTS = 'attachments';
 
     /**
+     * Code displayed in the default subject of the manual mail-sending form: the review's
+     * custom mail display code if set, RVCODE otherwise.
+     */
+    private static function getMailDisplayCode(): string
+    {
+        try {
+            $reviewSettings = Zend_Registry::get('reviewSettings');
+            $customMailDisplayCode = trim((string)($reviewSettings[Episciences_Review::SETTING_MAIL_DISPLAY_CODE] ?? ''));
+            if ($customMailDisplayCode !== '') {
+                return $customMailDisplayCode;
+            }
+        } catch (Exception $e) {
+            trigger_error($e->getMessage());
+        }
+
+        return (string)RVCODE;
+    }
+
+    /**
      * mailing form
      * if $to_enabled is false, recipient is automatically filled, and user can't change it
      * @param null $prefix
@@ -132,7 +151,7 @@ class Episciences_Mail_Send
 
 
         // subject
-        $form->addElement('text', self::getElementName('subject', $prefix), ['label' => 'Sujet', 'value' => !empty($docId) ? RVCODE . ' #' . $docId : '']);
+        $form->addElement('text', self::getElementName('subject', $prefix), ['label' => 'Sujet', 'value' => !empty($docId) ? self::getMailDisplayCode() . ' #' . $docId : '']);
 
         // content
         $form->addElement('textarea', self::getElementName('content', $prefix), ['label' => 'Contenu', 'class' => 'tinymce']);

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -1074,7 +1074,7 @@ class Episciences_Review
         $form->addElement('text', self::SETTING_MAIL_DISPLAY_CODE, [
                 'label' => "Code affiché dans les courriels",
                 'description' => "Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.",
-                'validators' => [new Zend_Validate_StringLength(['max' => 50])]
+                'validators' => [new Zend_Validate_StringLength(['max' => 100])]
             ]
         );
 

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -1073,8 +1073,8 @@ class Episciences_Review
 
         $form->addElement('text', self::SETTING_MAIL_DISPLAY_CODE, [
                 'label' => "Code affiché dans les courriels",
-                'description' => "Remplace le code de la revue (\"" . $this->getCode() . "\") dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.",
-                'validators' => [new Zend_Validate_StringLength(['max' => 255])]
+                'description' => "Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.",
+                'validators' => [new Zend_Validate_StringLength(['max' => 50])]
             ]
         );
 

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -732,6 +732,16 @@ class Episciences_Review
     }
 
     /**
+     * Code displayed in the subject/body of automatic emails: the review's custom
+     * mail display code (SETTING_MAIL_DISPLAY_CODE) if set, its own code otherwise.
+     */
+    public function getMailDisplayCode(): string
+    {
+        $customMailDisplayCode = trim((string)$this->getSetting(self::SETTING_MAIL_DISPLAY_CODE));
+        return $customMailDisplayCode !== '' ? $customMailDisplayCode : $this->getCode();
+    }
+
+    /**
      * @param $code
      * @return $this
      */

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -145,6 +145,8 @@ class Episciences_Review
         'refusedArticleAuthorsMsgSentToReviewers';
     public const SETTING_TO_REQUIRE_REVISION_DEADLINE = 'toRequireRevisionDeadline';
     public const SETTING_START_STATS_AFTER_DATE = 'startStatsAfterDate';
+    // Label displayed in place of the review code (RVCODE) in the subject/body of automatic emails
+    public const SETTING_MAIL_DISPLAY_CODE = 'mailDisplayCode';
 
     /** @var int */
     public static $_currentReviewId = null;
@@ -248,6 +250,7 @@ class Episciences_Review
             self::SETTING_DISPLAY_EMPTY_VOLUMES,
             self::SETTING_ALLOW_EDIT_VOLUME_TITLE_WITH_PUBLISHED_ARTICLES,
             self::SETTING_DISPLAY_SECONDARY_VOLUMES_ON_PUBLIC_PAGE,
+            self::SETTING_MAIL_DISPLAY_CODE,
         ];
 
 
@@ -1068,6 +1071,13 @@ class Episciences_Review
             ]
         );
 
+        $form->addElement('text', self::SETTING_MAIL_DISPLAY_CODE, [
+                'label' => "Code affiché dans les courriels",
+                'description' => "Remplace le code de la revue (\"" . $this->getCode() . "\") dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.",
+                'validators' => [new Zend_Validate_StringLength(['max' => 255])]
+            ]
+        );
+
         $form->getElement(self::SETTING_ISSN)->getDecorator('label')->setOption('class', 'col-md-2');
         $form->getElement(self::SETTING_ISSN_PRINT)->getDecorator('label')->setOption('class', 'col-md-2');
         $form->getElement(self::SETTING_JOURNAL_DOI)->getDecorator('label')->setOption('class', 'col-md-2');
@@ -1080,9 +1090,10 @@ class Episciences_Review
         $form->getElement(self::SETTING_JOURNAL_DESCRIPTION)->getDecorator('label')->setOption('class', 'col-md-2');
         $form->getElement(self::SETTING_JOURNAL_KEYWORDS)->getDecorator('label')->setOption('class', 'col-md-2');
         $form->getElement(self::SETTING_JOURNAL_CREATION_YEAR)->getDecorator('label')->setOption('class', 'col-md-2');
+        $form->getElement(self::SETTING_MAIL_DISPLAY_CODE)->getDecorator('label')->setOption('class', 'col-md-2');
 
         // display group: global settings
-        $form->addDisplayGroup([self::SETTING_ISSN, self::SETTING_ISSN_PRINT, self::SETTING_JOURNAL_DOI, self::SETTING_CONTACT_JOURNAL, self::SETTING_JOURNAL_NOTICE, self::SETTING_JOURNAL_PUBLISHER, self::SETTING_JOURNAL_PUBLISHER_LOC, self::SETTING_CONTACT_JOURNAL_EMAIL, self::SETTING_CONTACT_TECH_SUPPORT_EMAIL, self::SETTING_JOURNAL_DESCRIPTION, self::SETTING_JOURNAL_KEYWORDS, self::SETTING_JOURNAL_CREATION_YEAR], 'global', ["legend" => "Paramètres généraux (affichés dans le pied de page)"]);
+        $form->addDisplayGroup([self::SETTING_ISSN, self::SETTING_ISSN_PRINT, self::SETTING_JOURNAL_DOI, self::SETTING_CONTACT_JOURNAL, self::SETTING_JOURNAL_NOTICE, self::SETTING_JOURNAL_PUBLISHER, self::SETTING_JOURNAL_PUBLISHER_LOC, self::SETTING_CONTACT_JOURNAL_EMAIL, self::SETTING_CONTACT_TECH_SUPPORT_EMAIL, self::SETTING_JOURNAL_DESCRIPTION, self::SETTING_JOURNAL_KEYWORDS, self::SETTING_JOURNAL_CREATION_YEAR, self::SETTING_MAIL_DISPLAY_CODE], 'global', ["legend" => "Paramètres généraux (affichés dans le pied de page)"]);
         $form->getDisplayGroup('global')->removeDecorator('DtDdWrapper');
 
         // publication settings **********************************************
@@ -1970,6 +1981,8 @@ class Episciences_Review
         foreach ($settings as $setting) {
             $allSettings[$setting] = $this->getSetting($setting);
         }
+
+        $allSettings[self::SETTING_MAIL_DISPLAY_CODE] = trim(strip_tags((string)$this->getSetting(self::SETTING_MAIL_DISPLAY_CODE)));
 
         // Deadlines with units
         $deadlines = [

--- a/library/Episciences/Review.php
+++ b/library/Episciences/Review.php
@@ -1073,7 +1073,8 @@ class Episciences_Review
 
         $form->addElement('text', self::SETTING_MAIL_DISPLAY_CODE, [
                 'label' => "Code affiché dans les courriels",
-                'description' => "Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut.",
+                'description' => "Remplace le code de la revue dans le sujet et le corps des courriels automatiques. Laisser vide pour utiliser le code par défaut. 100 caractères maximum.",
+                'maxlength' => '100',
                 'validators' => [new Zend_Validate_StringLength(['max' => 100])]
             ]
         );

--- a/tests/unit/library/Episciences/Episciences_ReviewTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewTest.php
@@ -426,6 +426,50 @@ class Episciences_ReviewTest extends TestCase
     }
 
     // =========================================================================
+    // SETTING_MAIL_DISPLAY_CODE (custom rvcode label in automatic emails)
+    // =========================================================================
+
+    public function testMailDisplayCodeSettingConstant(): void
+    {
+        self::assertSame('mailDisplayCode', Episciences_Review::SETTING_MAIL_DISPLAY_CODE);
+    }
+
+    public function testSetAndGetMailDisplayCodeSetting(): void
+    {
+        $this->review->setSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE, 'custom-code');
+        self::assertSame('custom-code', $this->review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
+    }
+
+    public function testMailDisplayCodeSettingDefaultsToFalseWhenUnset(): void
+    {
+        self::assertFalse($this->review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
+    }
+
+    public function testApplySettingsFromRowsSetsMailDisplayCode(): void
+    {
+        $this->review->applySettingsFromRows([
+            ['SETTING' => Episciences_Review::SETTING_MAIL_DISPLAY_CODE, 'VALUE' => 'epij-custom'],
+        ]);
+
+        self::assertSame('epij-custom', $this->review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
+    }
+
+    /**
+     * settingsForm() pulls in Zend_Registry-dependent sub-forms (translator, repositories),
+     * so it cannot be instantiated in isolation here; verified via source inspection instead,
+     * consistent with other DB/registry-dependent methods in this codebase's test suite.
+     */
+    public function testSettingsFormSourceAddsMailDisplayCodeElement(): void
+    {
+        $method = new ReflectionMethod(Episciences_Review::class, 'settingsForm');
+        $lines = file($method->getFileName());
+        $source = implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+
+        self::assertStringContainsString("addElement('text', self::SETTING_MAIL_DISPLAY_CODE", $source);
+        self::assertStringContainsString('self::SETTING_MAIL_DISPLAY_CODE], \'global\'', $source);
+    }
+
+    // =========================================================================
     // applySettingsFromRows()
     // =========================================================================
 

--- a/tests/unit/library/Episciences/Episciences_ReviewTest.php
+++ b/tests/unit/library/Episciences/Episciences_ReviewTest.php
@@ -445,6 +445,32 @@ class Episciences_ReviewTest extends TestCase
         self::assertFalse($this->review->getSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE));
     }
 
+    public function testGetMailDisplayCodeFallsBackToCodeWhenSettingUnset(): void
+    {
+        $this->review->setCode('epijinfo');
+        self::assertSame('epijinfo', $this->review->getMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeFallsBackToCodeWhenSettingBlank(): void
+    {
+        $this->review->setCode('epijinfo');
+        $this->review->setSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE, '   ');
+        self::assertSame('epijinfo', $this->review->getMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeUsesCustomSettingWhenSet(): void
+    {
+        $this->review->setCode('epijinfo');
+        $this->review->setSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE, 'Épijournal Info');
+        self::assertSame('Épijournal Info', $this->review->getMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeTrimsCustomSetting(): void
+    {
+        $this->review->setSetting(Episciences_Review::SETTING_MAIL_DISPLAY_CODE, '  custom  ');
+        self::assertSame('custom', $this->review->getMailDisplayCode());
+    }
+
     public function testApplySettingsFromRowsSetsMailDisplayCode(): void
     {
         $this->review->applySettingsFromRows([

--- a/tests/unit/library/Episciences/Mail/Episciences_MailTest.php
+++ b/tests/unit/library/Episciences/Mail/Episciences_MailTest.php
@@ -433,6 +433,23 @@ final class Episciences_MailTest extends TestCase
     }
 
     // =========================================================================
+    // __construct() — %%REVIEW_CODE%% tag uses the review's custom mail display
+    // code (SETTING_MAIL_DISPLAY_CODE) when set, falling back to RVCODE — source
+    // inspection, since the constructor requires a live DB (Episciences_ReviewsManager::find()).
+    // =========================================================================
+
+    public function testConstructSourceFallsBackToRvcodeForReviewCodeTag(): void
+    {
+        $method = new ReflectionMethod(Episciences_Mail::class, '__construct');
+        $lines  = file($method->getFileName());
+        $source = implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
+
+        self::assertStringContainsString('Episciences_Review::SETTING_MAIL_DISPLAY_CODE', $source);
+        self::assertStringContainsString('$mailDisplayCode = RVCODE', $source);
+        self::assertStringContainsString('TAG_REVIEW_CODE, $mailDisplayCode', $source);
+    }
+
+    // =========================================================================
     // Security S1 — SQL injection via $docIds in getHistoryQuery()
     // =========================================================================
 

--- a/tests/unit/library/Episciences/Mail/Episciences_MailTest.php
+++ b/tests/unit/library/Episciences/Mail/Episciences_MailTest.php
@@ -444,8 +444,8 @@ final class Episciences_MailTest extends TestCase
         $lines  = file($method->getFileName());
         $source = implode('', array_slice($lines, $method->getStartLine() - 1, $method->getEndLine() - $method->getStartLine() + 1));
 
-        self::assertStringContainsString('Episciences_Review::SETTING_MAIL_DISPLAY_CODE', $source);
-        self::assertStringContainsString('$mailDisplayCode = RVCODE', $source);
+        self::assertStringContainsString('$review->getMailDisplayCode()', $source);
+        self::assertStringContainsString(': RVCODE', $source);
         self::assertStringContainsString('TAG_REVIEW_CODE, $mailDisplayCode', $source);
     }
 

--- a/tests/unit/library/Episciences/Mail/Episciences_Mail_SendTest.php
+++ b/tests/unit/library/Episciences/Mail/Episciences_Mail_SendTest.php
@@ -111,4 +111,54 @@ final class Episciences_Mail_SendTest extends TestCase
 
         self::assertSame($email, $escaped);
     }
+
+    // =========================================================================
+    // getMailDisplayCode() — the code shown in the default subject of the manual
+    // mail-sending form: the review's custom mail display code if set, RVCODE otherwise.
+    // =========================================================================
+
+    private function invokeGetMailDisplayCode(): string
+    {
+        $method = new ReflectionMethod(Episciences_Mail_Send::class, 'getMailDisplayCode');
+        $method->setAccessible(true);
+        return $method->invoke(null);
+    }
+
+    public function testGetMailDisplayCodeFallsBackToRvcodeWhenSettingUnset(): void
+    {
+        \Zend_Registry::set('reviewSettings', []);
+
+        self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeFallsBackToRvcodeWhenSettingBlank(): void
+    {
+        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => '   ']);
+
+        self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeUsesCustomSettingWhenSet(): void
+    {
+        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => 'custom-label']);
+
+        self::assertSame('custom-label', $this->invokeGetMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeTrimsCustomSetting(): void
+    {
+        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => '  custom-label  ']);
+
+        self::assertSame('custom-label', $this->invokeGetMailDisplayCode());
+    }
+
+    public function testGetMailDisplayCodeFallsBackToRvcodeWhenRegistryKeyMissing(): void
+    {
+        if (\Zend_Registry::isRegistered('reviewSettings')) {
+            $registry = \Zend_Registry::getInstance();
+            unset($registry['reviewSettings']);
+        }
+
+        self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
+    }
 }

--- a/tests/unit/library/Episciences/Mail/Episciences_Mail_SendTest.php
+++ b/tests/unit/library/Episciences/Mail/Episciences_Mail_SendTest.php
@@ -124,40 +124,66 @@ final class Episciences_Mail_SendTest extends TestCase
         return $method->invoke(null);
     }
 
+    /**
+     * Primes Episciences_ReviewsManager's intra-request cache so find(RVCODE) resolves
+     * to $review (or `false`, when null) without a DB round-trip.
+     */
+    private function primeReviewsManagerCache(?\Episciences_Review $review): void
+    {
+        $property = new \ReflectionProperty(\Episciences_ReviewsManager::class, '_cache');
+        $property->setAccessible(true);
+        $cache = $property->getValue();
+        $cache['rvcode_' . RVCODE] = $review ?? false;
+        $property->setValue(null, $cache);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->primeReviewsManagerCache(null);
+        parent::tearDown();
+    }
+
+    private function reviewWithSetting(?string $mailDisplayCode): \Episciences_Review
+    {
+        $review = new \Episciences_Review();
+        $review->setCode(RVCODE);
+        if ($mailDisplayCode !== null) {
+            $review->setSetting(\Episciences_Review::SETTING_MAIL_DISPLAY_CODE, $mailDisplayCode);
+        }
+        return $review;
+    }
+
     public function testGetMailDisplayCodeFallsBackToRvcodeWhenSettingUnset(): void
     {
-        \Zend_Registry::set('reviewSettings', []);
+        $this->primeReviewsManagerCache($this->reviewWithSetting(null));
 
         self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
     }
 
     public function testGetMailDisplayCodeFallsBackToRvcodeWhenSettingBlank(): void
     {
-        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => '   ']);
+        $this->primeReviewsManagerCache($this->reviewWithSetting('   '));
 
         self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
     }
 
     public function testGetMailDisplayCodeUsesCustomSettingWhenSet(): void
     {
-        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => 'custom-label']);
+        $this->primeReviewsManagerCache($this->reviewWithSetting('custom-label'));
 
         self::assertSame('custom-label', $this->invokeGetMailDisplayCode());
     }
 
     public function testGetMailDisplayCodeTrimsCustomSetting(): void
     {
-        \Zend_Registry::set('reviewSettings', [\Episciences_Review::SETTING_MAIL_DISPLAY_CODE => '  custom-label  ']);
+        $this->primeReviewsManagerCache($this->reviewWithSetting('  custom-label  '));
 
         self::assertSame('custom-label', $this->invokeGetMailDisplayCode());
     }
 
-    public function testGetMailDisplayCodeFallsBackToRvcodeWhenRegistryKeyMissing(): void
+    public function testGetMailDisplayCodeFallsBackToRvcodeWhenReviewNotFound(): void
     {
-        if (\Zend_Registry::isRegistered('reviewSettings')) {
-            $registry = \Zend_Registry::getInstance();
-            unset($registry['reviewSettings']);
-        }
+        $this->primeReviewsManagerCache(null);
 
         self::assertSame(RVCODE, $this->invokeGetMailDisplayCode());
     }


### PR DESCRIPTION
## Summary
- Add a per-review setting (`mailDisplayCode`, max 100 chars) that replaces the review code (RVCODE) in the `%%REVIEW_CODE%%` mail tag used across automatic email subjects/bodies, falling back to RVCODE when unset.
- New `Episciences_Review::getMailDisplayCode()` centralizes the fallback logic (custom label if set, the review's own code otherwise); `Episciences_Mail`'s constructor now delegates to it.
- Exposed as a text field in the journal settings admin form ("Code affiché dans les courriels"), with English translation and the 100-char limit shown to the admin (`maxlength` + description).
- Value is stripped of HTML tags on save (`strip_tags()`, same pattern as other free-text journal settings) and email subjects are already CRLF-filtered by `Zend_Mail` — no header-injection or tag-injection surface from this field.
- **Closed 4 bypasses found while auditing every direct `RVCODE`/`getCode()` use in mail-related code:**
  - The manual mail-sending form's default subject (`Episciences_Mail_Send::getForm()`) built it directly from `RVCODE`, outside the tag system.
  - Two admin flows (`AdministratepaperController`: reviewer deadline-change form, reviewer-removal notification) built their subject/body via a direct `str_replace()` with a hardcoded `RVCODE`, entirely outside `Episciences_Mail`'s tag substitution.
  - **Five admin preview/edit flows** (invite reviewer, reassign editor, propose new deadline, reviewer removal, paper view) pass a `code` field to their page's JS; two of them (`invitereviewer-modal.js`, `reassign-editor.js`) substitute `%%REVIEW_CODE%%` **client-side** using that field. It was fed straight from `RVCODE`/`getCode()` in PHP — this is the bug reported live: inviting a reviewer showed the raw review code instead of the configured custom label. All five now pass `getMailDisplayCode()`.
  - One more site (`UserDefaultController`'s registration email) turned out to already be harmless in practice: its `TAG_REVIEW_CODE => RVCODE` entry was always discarded by `sendMailFromReview()`'s tag-merge (that tag isn't in `OVERRIDABLE_TAGS`). Removed as dead/misleading code and documented why.
- **Security fix (found while reviewing this field's blast radius):** the mail subject was echoed unescaped in the admin's mail history list and detail views (`datatable_history.phtml`, `view.phtml`), unlike recipients which already used `htmlentities()`. Any content landing in a subject (e.g. an article title via `%%ARTICLE_TITLE%%`, or this new field) could inject HTML/script executed when an admin opens these pages — now escaped. The mail body was already sanitized via `Episciences_HTMLPurifier` and is unaffected.

## Test plan
- [x] `make phpstan LEVEL=6` on all touched library/controller files: no new errors introduced (only pre-existing ones in unrelated parts of the files)
- [x] Full run of the affected PHPUnit test files (123 tests, all passing) covering the new setting/method round-trips, the constructor's fallback logic (source inspection, constructor requires live DB), and `getMailDisplayCode()`'s registry-based fallback
- [x] Reported live on dev: inviting a reviewer showed the raw RVCODE instead of the custom label — root-caused to the client-side substitution bypass above and fixed
- [ ] Manual re-check on dev that the reviewer invitation subject now shows the custom label
- [ ] Manual check in the journal settings admin UI that the new field saves/displays correctly and respects the 100-char limit
- [ ] Manual check that mail history pages render a subject containing HTML special characters safely
- [ ] Manual check that a custom mail display code shows up in the deadline-change, reviewer-removal, and reassign-editor notification emails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional review-specific display code for email subjects and related content.
  - Added configuration support with validation and a 100-character limit.
  - Existing review codes remain the default when no custom value is configured.

- **Bug Fixes**
  - Improved handling of missing, blank and trimmed display codes.
  - Applied custom display codes consistently across manual and automated emails.
  - Email subjects now safely escape special HTML characters.

- **Tests**
  - Added coverage for custom values, defaults, trimming and fallback behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->