### PR TITLE
fix(mail): honor custom mail display code in automatic reminders

### DIFF
--- a/scripts/InboxNotifications.php
+++ b/scripts/InboxNotifications.php
@@ -762,7 +762,7 @@ class InboxNotifications extends AbstractScript
     ): array
     {
         return [
-            Episciences_Mail_Tags::TAG_REVIEW_CODE => $journal->getCode(),
+            Episciences_Mail_Tags::TAG_REVIEW_CODE => $journal->getMailDisplayCode(),
             Episciences_Mail_Tags::TAG_REVIEW_NAME => $journal->getName(),
             Episciences_Mail_Tags::TAG_ARTICLE_ID => $paper->getDocId(),
             Episciences_Mail_Tags::TAG_PERMANENT_ARTICLE_ID => $paper->getPaperid(),

--- a/scripts/reminders.php
+++ b/scripts/reminders.php
@@ -183,7 +183,7 @@ try {
                 $tags = (array_key_exists('tags', $recipient)) ? $recipient['tags'] : [];
                 $paper = null;
 
-                $mail = new Episciences_Mail('UTF-8');
+                $mail = new Episciences_Mail('UTF-8', $rvCode);
                 if (isset($tags['%%ARTICLE_ID%%'])) {
                     $paper = Episciences_PapersManager::get($tags['%%ARTICLE_ID%%']);
                     $mail->setDocid($paper->getDocid());
@@ -192,7 +192,7 @@ try {
 
                 $mail->setFrom($rvCode . '@' . DOMAIN, $rvCode);
                 $mail->setRvid($review->getRvid());
-                $mail->addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $rvCode);
+                $mail->addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $review->getMailDisplayCode());
                 $mail->addTag(Episciences_Mail_Tags::TAG_REVIEW_NAME, $review->getName());
 
                 if (isset($recipient['deadline'])) {

--- a/tests/unit/scripts/RemindersTest.php
+++ b/tests/unit/scripts/RemindersTest.php
@@ -22,4 +22,22 @@ class RemindersTest extends TestCase
         self::assertEquals(9, $interval2);
 
     }
+
+    public function testRemindersScriptUsesMailDisplayCodeForReviewCodeTag(): void
+    {
+        $scriptPath = realpath(__DIR__ . '/../../../scripts/reminders.php');
+        self::assertFileExists($scriptPath);
+
+        $source = file_get_contents($scriptPath);
+        self::assertStringContainsString(
+            'addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $review->getMailDisplayCode())',
+            $source,
+            'reminders.php must use $review->getMailDisplayCode() for TAG_REVIEW_CODE so custom mail display code is respected'
+        );
+        self::assertStringNotContainsString(
+            'addTag(Episciences_Mail_Tags::TAG_REVIEW_CODE, $rvCode)',
+            $source,
+            'reminders.php must not overwrite TAG_REVIEW_CODE with raw $rvCode'
+        );
+    }
 }


### PR DESCRIPTION
## Description

When sending automatic reminder emails via `scripts/reminders.php`, the script explicitly assigned `TAG_REVIEW_CODE` using the raw review code (`$rvCode`), bypassing the review's custom mail display code (`mailDisplayCode`) configured in the journal settings.

This caused automatic reminder subjects and bodies using `%%REVIEW_CODE%%` to display the raw review code instead of the configured custom label.

## Changes
- `scripts/reminders.php`:
  - Pass `$rvCode` to `Episciences_Mail` constructor.
  - Set `TAG_REVIEW_CODE` using `$review->getMailDisplayCode()` instead of `$rvCode`.
- `scripts/InboxNotifications.php`:
  - Update `buildCommonNotificationTags()` to use `$journal->getMailDisplayCode()`.
- `tests/unit/scripts/RemindersTest.php`:
  - Add unit test ensuring that `reminders.php` uses `getMailDisplayCode()` for `TAG_REVIEW_CODE` and does not overwrite it with `$rvCode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email notifications and reminders now display the journal’s correct mail code in review-code placeholders.
  * Reminder emails now use the appropriate journal code when sent.

* **Tests**
  * Added coverage to verify that reminder messages use the display code rather than an internal review code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->