### PR TITLE
Migrate to OpenAIRE Graph API v3 with AAI auth & rate limiting

### DIFF
--- a/config/dist-dev.pwd.json
+++ b/config/dist-dev.pwd.json
@@ -135,5 +135,11 @@
     "MAILTO": "YOUR-MAIL-TO",
     "APIURL": "https://api.crossref.org/works/",
     "PLUS_API_TOKEN": "four random common words"
+  },
+  "OPENAIRE": {
+    "AUTH_URL": "https://aai.openaire.eu/token",
+    "API_URL": "https://api.openaire.eu/graph/v3/research-products",
+    "CLIENT_ID": "",
+    "CLIENT_SECRET": ""
   }
 }

--- a/config/dist-pwd.json
+++ b/config/dist-pwd.json
@@ -154,6 +154,12 @@
     "APIURL": "https://api.crossref.org/works/",
     "PLUS_API_TOKEN": "Ash-nazg-durbatulûk"
   },
+  "OPENAIRE": {
+    "AUTH_URL": "https://aai.openaire.eu/token",
+    "API_URL": "https://api.openaire.eu/graph/v3/research-products",
+    "CLIENT_ID": "YOUR-OPENAIRE-CLIENT-ID",
+    "CLIENT_SECRET": "YOUR-OPENAIRE-CLIENT-SECRET"
+  },
   "NEXT": {
     "BASE_URL": "https://next.example.org",
     "REVALIDATION_SECRET": "generate-a-long-random-secret-eg-openssl-rand-hex-32"

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -14,7 +14,9 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 /**
- * OpenAire Research Graph REST API client.
+ * OpenAire Research Graph v3 REST API client.
+ *
+ * @see https://graph.openaire.eu/docs/apis/search-api
  *
  * Cache namespaces:
  *  - openAireResearchGraph : md5($doi) . '.json'
@@ -26,8 +28,9 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  */
 class OpenAireApiClient extends AbstractApiClient
 {
-    private const API_BASE_URL  = 'https://api.openaire.eu/search/publications';
+    private const API_BASE_URL  = 'https://api.openaire.eu/graph/v3/research-products';
     private const MAX_RESPONSE_SIZE = 5242880; // 5 MB
+    private const ORCID_SCHEMES = ['orcid', 'orcid_pending'];
 
     private CacheItemPoolInterface $globalCache;
     private CacheItemPoolInterface $authorsCache;
@@ -69,7 +72,7 @@ class OpenAireApiClient extends AbstractApiClient
             return $data;
         }
 
-        $url = self::API_BASE_URL . '/?doi=' . urlencode($doi) . '&format=json';
+        $url = self::API_BASE_URL . '?pid=' . urlencode($doi);
         $this->logger->info("Fetching OpenAIRE data for DOI {$doi}");
 
         try {
@@ -131,18 +134,18 @@ class OpenAireApiClient extends AbstractApiClient
     // -------------------------------------------------------------------------
 
     /**
-     * Extract creator array from OpenAire response, or null if unavailable.
+     * Extract author array from an OpenAire Graph v3 response, or null if unavailable.
      *
      * @param array<string, mixed> $response
      * @return array<mixed>|null
      */
     public function extractCreators(array $response): ?array
     {
-        if (empty($response['response']['results']['result'][0])) {
+        if (empty($response['results'][0])) {
             return null;
         }
-        $result = $response['response']['results']['result'][0];
-        return $result['metadata']['oaf:entity']['oaf:result']['creator'] ?? null;
+        $authors = $response['results'][0]['authors'] ?? null;
+        return !empty($authors) ? $authors : null;
     }
 
     // -------------------------------------------------------------------------
@@ -150,21 +153,18 @@ class OpenAireApiClient extends AbstractApiClient
     // -------------------------------------------------------------------------
 
     /**
-     * Extract funding array from OpenAire response, or null if unavailable.
+     * Extract project array from an OpenAire Graph v3 response, or null if unavailable.
      *
      * @param array<string, mixed> $response
      * @return array<mixed>|null
      */
     public function extractFunding(array $response): ?array
     {
-        if (empty($response['response']['results']['result'][0])) {
+        if (empty($response['results'][0])) {
             return null;
         }
-        $rels = $response['response']['results']['result'][0]['metadata']['oaf:entity']['oaf:result']['rels'] ?? null;
-        if ($rels === null || !array_key_exists('rel', $rels)) {
-            return null;
-        }
-        return $rels['rel'];
+        $projects = $response['results'][0]['projects'] ?? null;
+        return !empty($projects) ? $projects : null;
     }
 
     // -------------------------------------------------------------------------
@@ -172,7 +172,11 @@ class OpenAireApiClient extends AbstractApiClient
     // -------------------------------------------------------------------------
 
     /**
-     * Extract JEL classification codes from an OpenAire publication response.
+     * Extract JEL classification codes from an OpenAire Graph v3 publication response.
+     *
+     * A subject is retained as a JEL code when its scheme is 'jel', or when its value
+     * is prefixed with 'jel:' (some sources tag JEL values under a different scheme,
+     * e.g. 'keyword').
      *
      * @param array<string, mixed> $response
      * @return array<string> unique JEL codes (e.g. "A10", "B23")
@@ -180,31 +184,23 @@ class OpenAireApiClient extends AbstractApiClient
     public function extractJelCodes(array $response): array
     {
         $codes = [];
-        if (!isset($response['response']['results']['result'])) {
-            return $codes;
-        }
-        foreach ($response['response']['results']['result'] as $result) {
-            $subjects = $result['metadata']['oaf:entity']['oaf:result']['subject'] ?? null;
-            if ($subjects === null) {
+        $subjects = $response['results'][0]['subjects'] ?? [];
+
+        foreach ($subjects as $item) {
+            $scheme = $item['subject']['scheme'] ?? null;
+            $value  = $item['subject']['value'] ?? null;
+
+            if ($value === null || ($scheme !== 'jel' && !str_starts_with($value, 'jel:'))) {
                 continue;
             }
-            // subject may be a single object or an array of objects
-            if (!is_array($subjects) || isset($subjects['@classid'])) {
-                $subjects = [$subjects];
-            }
-            foreach ($subjects as $subject) {
-                if (($subject['@classid'] ?? '') !== 'jel' || !isset($subject['$'])) {
-                    continue;
-                }
-                $value = $subject['$'];
-                if (str_starts_with($value, 'jel:')) {
-                    $code = substr($value, 4); // fix: ltrim('jel:') strips chars, not the prefix string
-                    if ($code !== '') {
-                        $codes[] = $code;
-                    }
-                }
+
+            $code = str_starts_with($value, 'jel:') ? substr($value, 4) : $value;
+            $code = trim($code);
+            if ($code !== '') {
+                $codes[] = $code;
             }
         }
+
         return array_unique($codes);
     }
 
@@ -424,27 +420,29 @@ class OpenAireApiClient extends AbstractApiClient
     // -------------------------------------------------------------------------
 
     /**
-     * Search API data for a matching ORCID for the given author full name.
+     * Search OpenAire Graph v3 author data for a matching ORCID for the given full name.
+     *
+     * Matching is case-insensitive and accent-insensitive against `fullName`. The ORCID
+     * is read exclusively from `pid.id.value` when `pid.id.scheme` is 'orcid' or
+     * 'orcid_pending' — `id` (an OpenAire-internal hash) must never be used as an ORCID.
      *
      * @param array<int, array<string, mixed>> $apiData
      */
     public function findOrcidForAuthor(string $fullName, array $apiData): ?string
     {
-        foreach ($apiData as $authorInfoFromApi) {
-            $isMatch = false;
+        $needle = \Episciences_Tools::replaceAccents(mb_strtolower($fullName));
 
-            if (array_search($fullName, $authorInfoFromApi, true) !== false
-                || array_search(\Episciences_Tools::replaceAccents($fullName), $authorInfoFromApi, true) !== false
-            ) {
-                $isMatch = true;
-            } elseif (isset($authorInfoFromApi['$'])
-                && \Episciences_Tools::replaceAccents($fullName) === \Episciences_Tools::replaceAccents($authorInfoFromApi['$'])
-            ) {
-                $isMatch = true;
+        foreach ($apiData as $authorInfoFromApi) {
+            $candidate = \Episciences_Tools::replaceAccents(mb_strtolower($authorInfoFromApi['fullName'] ?? ''));
+            if ($candidate === '' || $candidate !== $needle) {
+                continue;
             }
 
-            if ($isMatch && array_key_exists('@orcid', $authorInfoFromApi)) {
-                return \Episciences_Paper_AuthorsManager::cleanLowerCaseOrcid($authorInfoFromApi['@orcid']);
+            $scheme = $authorInfoFromApi['pid']['id']['scheme'] ?? null;
+            $value  = $authorInfoFromApi['pid']['id']['value'] ?? null;
+
+            if ($value !== null && in_array($scheme, self::ORCID_SCHEMES, true)) {
+                return \Episciences_Paper_AuthorsManager::cleanLowerCaseOrcid($value);
             }
         }
         return null;

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -94,7 +94,7 @@ class OpenAireApiClient extends AbstractApiClient
         $apiBaseUrl = (defined('OPENAIRE_API_URL') && (string) constant('OPENAIRE_API_URL') !== '')
             ? (string) constant('OPENAIRE_API_URL')
             : self::API_BASE_URL;
-        $url = $apiBaseUrl . '?pid=' . urlencode($doi);
+        $url = rtrim($apiBaseUrl, '/') . '?pid=' . urlencode($doi);
         $this->logger->info("Fetching OpenAIRE data for DOI {$doi}");
 
         $body = $this->requestWithRetry($url, $paperId);
@@ -373,7 +373,7 @@ class OpenAireApiClient extends AbstractApiClient
             }
         }
 
-        return array_unique($codes);
+        return array_values(array_unique($codes));
     }
 
     // -------------------------------------------------------------------------
@@ -403,7 +403,6 @@ class OpenAireApiClient extends AbstractApiClient
     {
         $key  = md5($doi) . '_funding.json';
         $item = $this->fundingCache->getItem($key);
-        $item->expiresAfter(self::ONE_MONTH);
         return [$this->fundingCache, $key, $item];
     }
 
@@ -630,7 +629,7 @@ class OpenAireApiClient extends AbstractApiClient
             $value  = $authorInfoFromApi['pid']['id']['value'] ?? null;
 
             if (is_string($value) && $value !== '' && in_array($scheme, self::ORCID_SCHEMES, true)) {
-                return \Episciences_Paper_AuthorsManager::cleanLowerCaseOrcid($value);
+                return \Episciences_Paper_AuthorsManager::normalizeOrcid($value);
             }
         }
         return null;

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -188,6 +188,15 @@ class OpenAireApiClient extends AbstractApiClient
 
                 // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
                 if ($statusCode === 429) {
+                    // Never block the request thread: this path is also reachable synchronously
+                    // from PaperController/AdministratepaperController via updateRecordData().
+                    if (!$this->isCliContext()) {
+                        $this->logger->warning(
+                            "OpenAIRE 429 Too Many Requests for paper {$paperId}; not retrying outside CLI execution (would block the request)"
+                        );
+                        return null;
+                    }
+
                     if ($attempt >= self::MAX_RETRIES) {
                         $this->logger->critical(
                             "OpenAIRE API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
@@ -238,9 +247,18 @@ class OpenAireApiClient extends AbstractApiClient
     /**
      * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
      * Extracted as an overridable seam so tests can skip the real delay.
+     *
+     * Restricted to CLI execution for the same reason as throttleUnauthenticated(): a
+     * request triggered from PaperController/AdministratepaperController must never be
+     * delayed for UI/UX reasons. Skipping the 500ms pacing on an isolated HTTP-triggered
+     * call is safe — the pacing only matters for back-to-back CLI batch requests.
      */
     protected function throttleAuthenticated(): void
     {
+        if (!$this->isCliContext()) {
+            $this->logger->debug('OpenAIRE authenticated throttle skipped outside CLI execution (HTTP request path)');
+            return;
+        }
         usleep(self::AUTH_THROTTLE_MICROSECONDS);
     }
 
@@ -254,7 +272,7 @@ class OpenAireApiClient extends AbstractApiClient
      */
     protected function throttleUnauthenticated(): void
     {
-        if (PHP_SAPI !== 'cli') {
+        if (!$this->isCliContext()) {
             $this->logger->debug('OpenAIRE unauthenticated throttle skipped outside CLI execution (HTTP request path)');
             return;
         }
@@ -264,10 +282,23 @@ class OpenAireApiClient extends AbstractApiClient
     /**
      * Reactive backoff wait after an HTTP 429 response.
      * Extracted as an overridable seam so tests can skip the real delay.
+     *
+     * Only ever called from a CLI context: requestWithRetry() returns before reaching
+     * this call outside CLI execution, so the request thread is never blocked here.
      */
     protected function backoff(int $seconds): void
     {
         sleep($seconds);
+    }
+
+    /**
+     * True when running under the CLI SAPI (batch commands), false for an HTTP request
+     * (e.g. PaperController/AdministratepaperController). Extracted as an overridable
+     * seam so tests can simulate the HTTP path without faking the global PHP_SAPI value.
+     */
+    protected function isCliContext(): bool
+    {
+        return PHP_SAPI === 'cli';
     }
 
     // -------------------------------------------------------------------------

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -247,9 +247,17 @@ class OpenAireApiClient extends AbstractApiClient
     /**
      * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
      * Extracted as an overridable seam so tests can skip the real delay.
+     *
+     * Restricted to CLI execution: this path is also reachable synchronously from
+     * PaperController/AdministratepaperController via PapersManager::updateRecordData(),
+     * and a 60s sleep() would block a PHP-FPM worker for a full minute per request.
      */
     protected function throttleUnauthenticated(): void
     {
+        if (PHP_SAPI !== 'cli') {
+            $this->logger->debug('OpenAIRE unauthenticated throttle skipped outside CLI execution (HTTP request path)');
+            return;
+        }
         sleep(self::UNAUTH_THROTTLE_SECONDS);
     }
 
@@ -323,7 +331,7 @@ class OpenAireApiClient extends AbstractApiClient
             $scheme = $item['subject']['scheme'] ?? null;
             $value  = $item['subject']['value'] ?? null;
 
-            if ($value === null || ($scheme !== 'jel' && !str_starts_with($value, 'jel:'))) {
+            if (!is_string($value) || ($scheme !== 'jel' && !str_starts_with($value, 'jel:'))) {
                 continue;
             }
 
@@ -578,7 +586,11 @@ class OpenAireApiClient extends AbstractApiClient
         $needle = \Episciences_Tools::replaceAccents(mb_strtolower($fullName));
 
         foreach ($apiData as $authorInfoFromApi) {
-            $candidate = \Episciences_Tools::replaceAccents(mb_strtolower($authorInfoFromApi['fullName'] ?? ''));
+            $rawFullName = $authorInfoFromApi['fullName'] ?? '';
+            if (!is_string($rawFullName)) {
+                continue;
+            }
+            $candidate = \Episciences_Tools::replaceAccents(mb_strtolower($rawFullName));
             if ($candidate === '' || $candidate !== $needle) {
                 continue;
             }
@@ -586,7 +598,7 @@ class OpenAireApiClient extends AbstractApiClient
             $scheme = $authorInfoFromApi['pid']['id']['scheme'] ?? null;
             $value  = $authorInfoFromApi['pid']['id']['value'] ?? null;
 
-            if ($value !== null && in_array($scheme, self::ORCID_SCHEMES, true)) {
+            if (is_string($value) && $value !== '' && in_array($scheme, self::ORCID_SCHEMES, true)) {
                 return \Episciences_Paper_AuthorsManager::cleanLowerCaseOrcid($value);
             }
         }

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Episciences\Api;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
@@ -10,6 +11,7 @@ use Psr\Cache\CacheItemInterface;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface;
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -32,22 +34,38 @@ class OpenAireApiClient extends AbstractApiClient
     private const MAX_RESPONSE_SIZE = 5242880; // 5 MB
     private const ORCID_SCHEMES = ['orcid', 'orcid_pending'];
 
+    // Rate limits per https://graph.openaire.eu/docs/apis/terms#authentication--limits
+    private const AUTH_THROTTLE_MICROSECONDS = 500000; // 500ms (~2 req/s, quota 7200 req/h, authenticated)
+    private const UNAUTH_THROTTLE_SECONDS    = 60;      // 60s (1 req/min, quota 60 req/h, anonymous)
+    private const MAX_RETRIES = 3;
+
     private CacheItemPoolInterface $globalCache;
     private CacheItemPoolInterface $authorsCache;
     private CacheItemPoolInterface $fundingCache;
+    private ?OpenAireTokenProvider $tokenProvider;
 
     public function __construct(
         Client               $client,
         CacheItemPoolInterface $globalCache,
         CacheItemPoolInterface $authorsCache,
         CacheItemPoolInterface $fundingCache,
-        LoggerInterface      $logger
+        LoggerInterface      $logger,
+        ?OpenAireTokenProvider $tokenProvider = null
     ) {
         // Parent constructor requires a single CacheItemPoolInterface; pass globalCache as primary.
         parent::__construct($client, $globalCache, $logger);
-        $this->globalCache  = $globalCache;
-        $this->authorsCache = $authorsCache;
-        $this->fundingCache = $fundingCache;
+        $this->globalCache   = $globalCache;
+        $this->authorsCache  = $authorsCache;
+        $this->fundingCache  = $fundingCache;
+        $this->tokenProvider = $tokenProvider;
+    }
+
+    /**
+     * True when a token provider is set up with client credentials (authenticated mode).
+     */
+    public function isAuthenticated(): bool
+    {
+        return $this->tokenProvider?->isConfigured() ?? false;
     }
 
     // -------------------------------------------------------------------------
@@ -68,32 +86,19 @@ class OpenAireApiClient extends AbstractApiClient
         $item = $this->globalCache->getItem($key);
 
         if ($item->isHit()) {
-            $data = json_decode((string) $item->get(), true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
-            return $data;
+            $this->logger->info("OpenAIRE data from cache for DOI {$doi}");
+            return json_decode((string) $item->get(), true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
         }
 
-        $url = self::API_BASE_URL . '?pid=' . urlencode($doi);
+        // @phpstan-ignore notIdentical.alwaysTrue
+        $apiBaseUrl = (defined('OPENAIRE_API_URL') && (string) constant('OPENAIRE_API_URL') !== '')
+            ? (string) constant('OPENAIRE_API_URL')
+            : self::API_BASE_URL;
+        $url = $apiBaseUrl . '?pid=' . urlencode($doi);
         $this->logger->info("Fetching OpenAIRE data for DOI {$doi}");
 
-        try {
-            $response = $this->client->get($url, [
-                'headers'         => $this->defaultHeaders(),
-                'timeout'         => 30,
-                'allow_redirects' => [
-                    'max'       => 2,
-                    'strict'    => true,
-                    'referer'   => true,
-                    'protocols' => ['https'],
-                ],
-                'verify'          => true,
-            ]);
-            $body = $response->getBody()->getContents();
-        } catch (GuzzleException $e) {
-            $this->logger->error(sprintf(
-                'OpenAIRE API error for paper %d: %s',
-                $paperId,
-                $e->getMessage()
-            ));
+        $body = $this->requestWithRetry($url, $paperId);
+        if ($body === null) {
             return null;
         }
 
@@ -105,9 +110,6 @@ class OpenAireApiClient extends AbstractApiClient
             ));
             return null;
         }
-
-        // Rate limiting
-        sleep(1);
 
         try {
             $decoded = json_decode($body, true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
@@ -127,6 +129,137 @@ class OpenAireApiClient extends AbstractApiClient
         $this->globalCache->save($item);
 
         return $decoded;
+    }
+
+    // -------------------------------------------------------------------------
+    // HTTP request with bi-mode auth, adaptive throttling, and 401/429 retry
+    // -------------------------------------------------------------------------
+
+    /**
+     * Issue the GET request, handling authentication, throttling, and 401/429 retry.
+     * Returns the raw response body, or null on unrecoverable error / exhausted retries.
+     */
+    private function requestWithRetry(string $url, int $paperId): ?string
+    {
+        $token   = $this->tokenProvider?->getAccessToken();
+        $headers = $this->defaultHeaders();
+
+        if ($token !== null) {
+            $headers['Authorization'] = 'Bearer ' . $token;
+            $this->throttleAuthenticated();
+        } else {
+            $this->logger->warning(
+                'OpenAIRE unauthenticated mode active: throttling for ' . self::UNAUTH_THROTTLE_SECONDS . 's (rate limit: 60 req/h)'
+            );
+            $this->throttleUnauthenticated();
+        }
+
+        $attempt = 0;
+        while ($attempt < self::MAX_RETRIES) {
+            $attempt++;
+            try {
+                $response = $this->client->get($url, [
+                    'headers'         => $headers,
+                    'timeout'         => 30,
+                    'allow_redirects' => [
+                        'max'       => 2,
+                        'strict'    => true,
+                        'referer'   => true,
+                        'protocols' => ['https'],
+                    ],
+                    'verify'          => true,
+                ]);
+
+                $this->logRateLimitStatus($response);
+                return $response->getBody()->getContents();
+            } catch (ClientException $e) {
+                $statusCode = $e->getResponse()->getStatusCode();
+
+                // 401 Unauthorized: token revoked/expired in authenticated mode -> refresh and retry once.
+                if ($statusCode === 401 && $token !== null && $this->tokenProvider !== null && $attempt === 1) {
+                    $this->logger->warning('OpenAIRE 401 Unauthorized received, refreshing token...');
+                    $this->tokenProvider->clearTokenCache();
+                    $token = $this->tokenProvider->getAccessToken();
+                    if ($token !== null) {
+                        $headers['Authorization'] = 'Bearer ' . $token;
+                        continue;
+                    }
+                }
+
+                // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
+                if ($statusCode === 429) {
+                    if ($attempt >= self::MAX_RETRIES) {
+                        $this->logger->critical(
+                            "OpenAIRE API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
+                        );
+                        return null;
+                    }
+
+                    $retryAfter   = (int) $e->getResponse()->getHeaderLine('Retry-After');
+                    $sleepSeconds = $token !== null
+                        ? ($retryAfter > 0 ? $retryAfter : ($attempt * 3))
+                        : max(self::UNAUTH_THROTTLE_SECONDS, $retryAfter);
+
+                    $this->logger->warning(
+                        "OpenAIRE 429 Too Many Requests for paper {$paperId} (attempt {$attempt}/" . self::MAX_RETRIES . "). Waiting {$sleepSeconds}s..."
+                    );
+                    $this->backoff($sleepSeconds);
+                    continue;
+                }
+
+                $this->logger->error("OpenAIRE API error for paper {$paperId} (HTTP {$statusCode}): " . $e->getMessage());
+                return null;
+            } catch (GuzzleException $e) {
+                $this->logger->error("OpenAIRE API connection error for paper {$paperId}: " . $e->getMessage());
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Log OpenAIRE rate-limit response headers (x-ratelimit-used / x-ratelimit-limit), if present.
+     */
+    private function logRateLimitStatus(ResponseInterface $response): void
+    {
+        $used  = $response->getHeaderLine('x-ratelimit-used');
+        $limit = $response->getHeaderLine('x-ratelimit-limit');
+        if ($used === '' || $limit === '') {
+            return;
+        }
+
+        $this->logger->debug("OpenAIRE Rate Limit status: {$used}/{$limit}");
+        if ((int) $limit > 0 && (int) $used > ((int) $limit * 0.85)) {
+            $this->logger->warning("OpenAIRE Rate Limit threshold > 85%: {$used}/{$limit}");
+        }
+    }
+
+    /**
+     * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleAuthenticated(): void
+    {
+        usleep(self::AUTH_THROTTLE_MICROSECONDS);
+    }
+
+    /**
+     * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleUnauthenticated(): void
+    {
+        sleep(self::UNAUTH_THROTTLE_SECONDS);
+    }
+
+    /**
+     * Reactive backoff wait after an HTTP 429 response.
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function backoff(int $seconds): void
+    {
+        sleep($seconds);
     }
 
     // -------------------------------------------------------------------------
@@ -253,6 +386,8 @@ class OpenAireApiClient extends AbstractApiClient
      * Build a production-ready instance using FilesystemAdapter caches and a file logger.
      *
      * Constants APPLICATION_PATH and EPISCIENCES_LOG_PATH must be defined by the bootstrap.
+     * The token provider falls back to unauthenticated mode when OPENAIRE_CLIENT_ID /
+     * OPENAIRE_CLIENT_SECRET are not configured.
      */
     public static function create(): self
     {
@@ -264,12 +399,22 @@ class OpenAireApiClient extends AbstractApiClient
             Logger::INFO
         ));
 
+        $tokenProvider = new OpenAireTokenProvider(
+            new Client(),
+            new FilesystemAdapter('openAireAuthToken', self::ONE_MONTH, $cacheDir),
+            $logger,
+            defined('OPENAIRE_CLIENT_ID') ? (string) constant('OPENAIRE_CLIENT_ID') : null,
+            defined('OPENAIRE_CLIENT_SECRET') ? (string) constant('OPENAIRE_CLIENT_SECRET') : null,
+            defined('OPENAIRE_AUTH_URL') ? (string) constant('OPENAIRE_AUTH_URL') : null
+        );
+
         return new self(
             new Client(),
             new FilesystemAdapter('openAireResearchGraph', self::ONE_MONTH, $cacheDir),
             new FilesystemAdapter('enrichmentAuthors',     self::ONE_MONTH, $cacheDir),
             new FilesystemAdapter('enrichmentFunding',     self::ONE_MONTH, $cacheDir),
-            $logger
+            $logger,
+            $tokenProvider
         );
     }
 

--- a/library/Episciences/Api/OpenAireTokenProvider.php
+++ b/library/Episciences/Api/OpenAireTokenProvider.php
@@ -72,7 +72,10 @@ class OpenAireTokenProvider
 
         $item = $this->cache->getItem(self::CACHE_KEY);
         if ($item->isHit()) {
-            return (string) $item->get();
+            $cached = $item->get();
+            // A cached `false` is the short-lived AAI-failure marker set by fetchNewToken();
+            // it must not be mistaken for an (invalid) empty-string token.
+            return is_string($cached) ? $cached : null;
         }
 
         return $this->fetchNewToken($item);
@@ -134,6 +137,10 @@ class OpenAireTokenProvider
             return $token;
         } catch (GuzzleException|\JsonException $e) {
             $this->logger->error('Failed to acquire OpenAIRE access token: ' . $e->getMessage());
+            // Cache a short-lived failure marker to prevent spamming AAI on every item during outages.
+            $item->set(false);
+            $item->expiresAfter(self::MIN_TTL_SECONDS);
+            $this->cache->save($item);
             return null;
         }
     }

--- a/library/Episciences/Api/OpenAireTokenProvider.php
+++ b/library/Episciences/Api/OpenAireTokenProvider.php
@@ -1,0 +1,140 @@
+<?php
+declare(strict_types=1);
+
+namespace Episciences\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OAuth 2.0 Client Credentials token provider for the OpenAIRE AAI (aai.openaire.eu).
+ *
+ * Gracefully degrades: if no client ID/secret is configured, isConfigured() returns
+ * false and getAccessToken() returns null, letting callers fall back to the
+ * unauthenticated (rate-limited) mode instead of failing.
+ *
+ * Cache namespace: openAireAuthToken (key: 'openaire_access_token')
+ */
+class OpenAireTokenProvider
+{
+    private const CACHE_KEY = 'openaire_access_token';
+    private const DEFAULT_AUTH_URL = 'https://aai.openaire.eu/token';
+    private const SAFETY_MARGIN_SECONDS = 120; // renew 2 minutes before actual expiry
+    private const MIN_TTL_SECONDS = 60;
+    private const JSON_MAX_DEPTH = 512;
+
+    private Client $client;
+    private CacheItemPoolInterface $cache;
+    private LoggerInterface $logger;
+    private string $clientId;
+    private string $clientSecret;
+    private string $authUrl;
+
+    public function __construct(
+        Client $client,
+        CacheItemPoolInterface $cache,
+        LoggerInterface $logger,
+        ?string $clientId = null,
+        ?string $clientSecret = null,
+        ?string $authUrl = null
+    ) {
+        $this->client       = $client;
+        $this->cache        = $cache;
+        $this->logger       = $logger;
+        $this->clientId     = $clientId ?? '';
+        $this->clientSecret = $clientSecret ?? '';
+        $this->authUrl      = ($authUrl !== null && $authUrl !== '') ? $authUrl : self::DEFAULT_AUTH_URL;
+    }
+
+    /**
+     * True when both a client ID and a client secret are configured.
+     */
+    public function isConfigured(): bool
+    {
+        return $this->clientId !== '' && $this->clientSecret !== '';
+    }
+
+    /**
+     * Return a cached or freshly acquired Bearer token, or null when unconfigured
+     * or when the AAI request failed.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getAccessToken(): ?string
+    {
+        if (!$this->isConfigured()) {
+            return null;
+        }
+
+        $item = $this->cache->getItem(self::CACHE_KEY);
+        if ($item->isHit()) {
+            return (string) $item->get();
+        }
+
+        return $this->fetchNewToken($item);
+    }
+
+    /**
+     * Invalidate the cached token, forcing a fresh acquisition on the next call.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function clearTokenCache(): void
+    {
+        $this->cache->deleteItem(self::CACHE_KEY);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function fetchNewToken(CacheItemInterface $item): ?string
+    {
+        $this->logger->info('Requesting new OpenAIRE AAI access token');
+
+        try {
+            $response = $this->client->post($this->authUrl, [
+                'form_params' => [
+                    'grant_type'    => 'client_credentials',
+                    'client_id'     => $this->clientId,
+                    'client_secret' => $this->clientSecret,
+                ],
+                'headers' => [
+                    'Accept'     => 'application/json',
+                    'User-Agent' => defined('EPISCIENCES_USER_AGENT') ? (string) constant('EPISCIENCES_USER_AGENT') : 'Episciences',
+                ],
+                'timeout' => 15,
+                'verify'  => true,
+            ]);
+
+            $body = json_decode(
+                $response->getBody()->getContents(),
+                true,
+                self::JSON_MAX_DEPTH,
+                JSON_THROW_ON_ERROR
+            );
+
+            $token     = $body['access_token'] ?? null;
+            $expiresIn = (int) ($body['expires_in'] ?? 3600);
+
+            if (!is_string($token) || $token === '') {
+                $this->logger->error('OpenAIRE AAI did not return an access_token');
+                return null;
+            }
+
+            $ttl = max(self::MIN_TTL_SECONDS, $expiresIn - self::SAFETY_MARGIN_SECONDS);
+            $item->set($token);
+            $item->expiresAfter($ttl);
+            $this->cache->save($item);
+
+            $this->logger->info("Acquired new OpenAIRE access token, cached for {$ttl} seconds");
+            return $token;
+        } catch (GuzzleException|\JsonException $e) {
+            $this->logger->error('Failed to acquire OpenAIRE access token: ' . $e->getMessage());
+            return null;
+        }
+    }
+}

--- a/library/Episciences/OpenAireResearchGraphTools.php
+++ b/library/Episciences/OpenAireResearchGraphTools.php
@@ -8,6 +8,14 @@ use Monolog\Logger;
 use Psr\Cache\CacheItemInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
+/**
+ * @deprecated Not called from any production code path (verified: no callers outside this
+ *             class's own test suite and one direct call to the already-deprecated
+ *             getOrcidApiForDb() in Episciences_Paper_AuthorsManagerTest). Superseded by
+ *             \Episciences\Api\OpenAireApiClient, which targets the OpenAIRE Graph v3 API.
+ *             This class still targets the retired v1 search API and is kept only for
+ *             backward compatibility; do not add new callers.
+ */
 class Episciences_OpenAireResearchGraphTools
 {
     // Cache TTL

--- a/library/Episciences/Paper/Authors/HalTeiParser.php
+++ b/library/Episciences/Paper/Authors/HalTeiParser.php
@@ -103,7 +103,7 @@ class Episciences_Paper_Authors_HalTeiParser
 
         foreach ($authorNode->idno as $idnoNode) {
             if ((string)$idnoNode->attributes()->type === self::IDNO_TYPE_ORCID) {
-                $parsedAuthors[$lastAuthorIndex][self::KEY_ORCID] = self::normalizeOrcid((string)$idnoNode);
+                $parsedAuthors[$lastAuthorIndex][self::KEY_ORCID] = Episciences_Paper_AuthorsManager::normalizeOrcid((string)$idnoNode);
             }
         }
 
@@ -111,17 +111,11 @@ class Episciences_Paper_Authors_HalTeiParser
     }
 
     /**
-     * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
+     * @deprecated Use Episciences_Paper_AuthorsManager::normalizeOrcid()
      */
     public static function normalizeOrcid(string $orcid): string
     {
-        $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
-
-        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', (string) $orcid)) {
-            $orcid = substr((string) $orcid, 0, -1) . 'X';
-        }
-
-        return $orcid;
+        return Episciences_Paper_AuthorsManager::normalizeOrcid($orcid);
     }
 
     /**

--- a/library/Episciences/Paper/AuthorsManager.php
+++ b/library/Episciences/Paper/AuthorsManager.php
@@ -10,12 +10,16 @@ class Episciences_Paper_AuthorsManager
     // ────────────────────────────────────────────
     /**
      * Normalize an ORCID identifier: strip URL prefix and fix lowercase checksum digit
-     *
-     * @deprecated Use Episciences_Paper_Authors_HalTeiParser::normalizeOrcid()
      */
     public static function normalizeOrcid(string $orcid): string
     {
-        return Episciences_Paper_Authors_HalTeiParser::normalizeOrcid($orcid);
+        $orcid = preg_replace('#^https?://orcid\.org/#', '', trim($orcid));
+
+        if (preg_match('/\d{4}-\d{4}-\d{4}-\d{3}x$/', (string) $orcid)) {
+            $orcid = substr((string) $orcid, 0, -1) . 'X';
+        }
+
+        return $orcid;
     }
 
     /**

--- a/library/Episciences/Paper/Projects/EnrichmentService.php
+++ b/library/Episciences/Paper/Projects/EnrichmentService.php
@@ -140,7 +140,10 @@ class Episciences_Paper_Projects_EnrichmentService
     }
 
     /**
-     * Filter OpenAire relations to keep only project-type entries.
+     * Map OpenAire Graph v3 project entries (results[0].projects) to the DB funding structure.
+     * Also accepts the legacy v1 relation format (rels.rel with to.@type === 'project')
+     * as a fallback, so residual v1 caches keep working during the transition.
+     *
      * Replaces formatFundingOAForDB().
      */
     public static function formatFundingOAForDB(
@@ -149,6 +152,12 @@ class Episciences_Paper_Projects_EnrichmentService
         array $globalFundingArray
     ): array {
         foreach ($fileFound as $valueOpenAire) {
+            if (self::isV3ProjectEntry($valueOpenAire)) {
+                $globalFundingArray[] = self::mapV3ProjectEntry($valueOpenAire);
+                continue;
+            }
+
+            // v1 fallback (residual caches)
             if (
                 !array_key_exists('to', $valueOpenAire) ||
                 !array_key_exists('@type', $valueOpenAire['to']) ||
@@ -171,6 +180,46 @@ class Episciences_Paper_Projects_EnrichmentService
             $globalFundingArray[] = $fundingArray;
         }
         return $globalFundingArray;
+    }
+
+    /**
+     * A v3 project entry carries a direct scalar 'title', unlike the v1 relation format
+     * where 'title' is a nested {"$": "..."} structure.
+     *
+     * @param array<string, mixed> $entry
+     */
+    private static function isV3ProjectEntry(array $entry): bool
+    {
+        return array_key_exists('title', $entry) && is_string($entry['title']);
+    }
+
+    /**
+     * Map a single v3 project entry ({title, acronym, code, funder}) to the DB funding structure.
+     * 'funder' may be a scalar name (current REST serialization) or a Data Model object
+     * ({name, shortName, jurisdiction, fundingStream}); both are supported.
+     *
+     * @param array<string, mixed> $entry
+     * @return array<string, mixed>
+     */
+    private static function mapV3ProjectEntry(array $entry): array
+    {
+        $fundingArray = ['projectTitle' => $entry['title']];
+
+        if (!empty($entry['code'])) {
+            $fundingArray['code'] = $entry['code'];
+        }
+        if (!empty($entry['acronym'])) {
+            $fundingArray['acronym'] = $entry['acronym'];
+        }
+
+        $funder = $entry['funder'] ?? null;
+        if (is_string($funder) && $funder !== '') {
+            $fundingArray['funderName'] = $funder;
+        } elseif (is_array($funder) && !empty($funder['name'])) {
+            $fundingArray['funderName'] = $funder['name'];
+        }
+
+        return $fundingArray;
     }
 
     /**

--- a/library/Episciences/Paper/Projects/EnrichmentService.php
+++ b/library/Episciences/Paper/Projects/EnrichmentService.php
@@ -141,50 +141,24 @@ class Episciences_Paper_Projects_EnrichmentService
 
     /**
      * Map OpenAire Graph v3 project entries (results[0].projects) to the DB funding structure.
-     * Also accepts the legacy v1 relation format (rels.rel with to.@type === 'project')
-     * as a fallback, so residual v1 caches keep working during the transition.
      *
      * Replaces formatFundingOAForDB().
      */
     public static function formatFundingOAForDB(
         array $fileFound,
-        array $fundingArray,
         array $globalFundingArray
     ): array {
         foreach ($fileFound as $valueOpenAire) {
-            if (self::isV3ProjectEntry($valueOpenAire)) {
-                $globalFundingArray[] = self::mapV3ProjectEntry($valueOpenAire);
+            if (!self::isV3ProjectEntry($valueOpenAire)) {
                 continue;
             }
-
-            // v1 fallback (residual caches)
-            if (
-                !array_key_exists('to', $valueOpenAire) ||
-                !array_key_exists('@type', $valueOpenAire['to']) ||
-                $valueOpenAire['to']['@type'] !== 'project'
-            ) {
-                continue;
-            }
-            if (array_key_exists('title', $valueOpenAire)) {
-                $fundingArray['projectTitle'] = $valueOpenAire['title']['$'];
-            }
-            if (array_key_exists('acronym', $valueOpenAire)) {
-                $fundingArray['acronym'] = $valueOpenAire['acronym']['$'];
-            }
-            if (array_key_exists('funder', $valueOpenAire['funding'])) {
-                $fundingArray['funderName'] = $valueOpenAire['funding']['funder']['@name'];
-            }
-            if (array_key_exists('code', $valueOpenAire)) {
-                $fundingArray['code'] = $valueOpenAire['code']['$'];
-            }
-            $globalFundingArray[] = $fundingArray;
+            $globalFundingArray[] = self::mapV3ProjectEntry($valueOpenAire);
         }
         return $globalFundingArray;
     }
 
     /**
-     * A v3 project entry carries a direct scalar 'title', unlike the v1 relation format
-     * where 'title' is a nested {"$": "..."} structure.
+     * A valid v3 project entry carries a direct scalar 'title'.
      *
      * @param array<string, mixed> $entry
      */

--- a/library/Episciences/Paper/ProjectsManager.php
+++ b/library/Episciences/Paper/ProjectsManager.php
@@ -100,12 +100,10 @@ class Episciences_Paper_ProjectsManager
 
     public static function formatFundingOAForDB(
         array $fileFound,
-        array $fundingArray,
         array $globalfundingArray
     ): array {
         return Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB(
             $fileFound,
-            $fundingArray,
             $globalfundingArray
         );
     }

--- a/library/Episciences/PapersManager.php
+++ b/library/Episciences/PapersManager.php
@@ -4688,11 +4688,9 @@ class Episciences_PapersManager
         }
 
         if (!empty($fileFound[0])) {
-            $fundingArray       = [];
             $globalfundingArray = [];
             $globalfundingArray = Episciences_Paper_ProjectsManager::formatFundingOAForDB(
                 $fileFound,
-                $fundingArray,
                 $globalfundingArray
             );
             $rowInDBGraph = Episciences_Paper_ProjectsManager::getProjectsByPaperIdAndSourceId(

--- a/public/const.php
+++ b/public/const.php
@@ -365,6 +365,10 @@ function fixUndefinedConstantsForCodeAnalysis(): void
         define('OPENCITATIONS_MAILTO', '');
         define('OPENCITATIONS_APIURL', '');
         define('OPENCITATIONS_TOKEN', '');
+        define('OPENAIRE_AUTH_URL', '');
+        define('OPENAIRE_API_URL', '');
+        define('OPENAIRE_CLIENT_ID', '');
+        define('OPENAIRE_CLIENT_SECRET', '');
 
         // DOI Configuration
         define('DOI_AGENCY', '');

--- a/scripts/ClearOpenAireCacheCommand.php
+++ b/scripts/ClearOpenAireCacheCommand.php
@@ -48,17 +48,24 @@ class ClearOpenAireCacheCommand extends Command
             $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));
         }
 
-        $cacheDir = dirname(APPLICATION_PATH) . '/cache/';
+        $cacheDir   = dirname(APPLICATION_PATH) . '/cache/';
+        $allCleared = true;
 
         foreach (self::CACHE_POOLS as $pool) {
             $cache   = new FilesystemAdapter($pool, 0, $cacheDir);
             $cleared = $cache->clear();
+            $allCleared = $allCleared && $cleared;
             $logger->info("Cache pool '{$pool}' " . ($cleared ? 'cleared' : 'clear failed'));
             if ($cleared) {
                 $io->writeln("<info>✓</info> {$pool}");
             } else {
                 $io->writeln("<error>✗</error> {$pool}");
             }
+        }
+
+        if (!$allCleared) {
+            $io->error('OpenAIRE enrichment cache purge failed for one or more pools.');
+            return Command::FAILURE;
         }
 
         $io->success('OpenAIRE enrichment cache purge completed.');

--- a/scripts/ClearOpenAireCacheCommand.php
+++ b/scripts/ClearOpenAireCacheCommand.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Symfony Console command: purge the OpenAIRE Research Graph enrichment caches.
+ *
+ * Clears the three PSR-6 pools shared by GetCreatorDataCommand, GetFundingDataCommand
+ * and GetClassificationJelCommand in one shot, without querying the API. Needed after
+ * an OpenAIRE API format migration (e.g. v1 -> Graph v3): cache keys carry no version
+ * marker (md5($doi)), so a cache hit on a pre-migration entry silently returns the old
+ * format to the new extraction code instead of triggering a fresh API call.
+ */
+class ClearOpenAireCacheCommand extends Command
+{
+    protected static $defaultName = 'enrichment:clear-cache';
+
+    private const CACHE_POOLS = [
+        'openAireResearchGraph',
+        'enrichmentAuthors',
+        'enrichmentFunding',
+    ];
+
+    protected function configure(): void
+    {
+        $this->setDescription('Purge the OpenAIRE Research Graph enrichment caches (global, creators, funding)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('OpenAIRE enrichment cache purge');
+
+        $this->bootstrap();
+
+        $logger = new Logger('openAireCachePurge');
+        $logger->pushHandler(new StreamHandler(
+            EPISCIENCES_LOG_PATH . 'openAireCachePurge_' . date('Y-m-d') . '.log', Logger::INFO
+        ));
+        if (!$io->isQuiet()) {
+            $logger->pushHandler(new StreamHandler('php://stdout', Logger::INFO));
+        }
+
+        $cacheDir = dirname(APPLICATION_PATH) . '/cache/';
+
+        foreach (self::CACHE_POOLS as $pool) {
+            $cache   = new FilesystemAdapter($pool, 0, $cacheDir);
+            $cleared = $cache->clear();
+            $logger->info("Cache pool '{$pool}' " . ($cleared ? 'cleared' : 'clear failed'));
+            if ($cleared) {
+                $io->writeln("<info>✓</info> {$pool}");
+            } else {
+                $io->writeln("<error>✗</error> {$pool}");
+            }
+        }
+
+        $io->success('OpenAIRE enrichment cache purge completed.');
+        return Command::SUCCESS;
+    }
+
+    private function bootstrap(): void
+    {
+        if (!defined('APPLICATION_PATH')) {
+            define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
+        }
+        require_once __DIR__ . '/../public/const.php';
+        require_once __DIR__ . '/../public/bdd_const.php';
+
+        defineProtocol();
+        defineSimpleConstants();
+        defineSQLTableConstants();
+        defineApplicationConstants();
+        defineJournalConstants();
+
+        $libraries = [realpath(APPLICATION_PATH . '/../library')];
+        set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
+        require_once 'Zend/Application.php';
+
+        // Do NOT call $application->bootstrap() — APPLICATION_MODULE may be undefined
+        // (no rvcode) which causes Bootstrap::_initModule() to fail silently.
+        // Mirrors legacy JournalScript pattern: initApp() reads config, initDb() sets adapter.
+        $application = new Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
+
+        $autoloader = Zend_Loader_Autoloader::getInstance();
+        $autoloader->setFallbackAutoloader(true);
+    }
+}

--- a/scripts/GetClassificationJelCommand.php
+++ b/scripts/GetClassificationJelCommand.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 use Episciences\Api\OpenAireApiClient;
-use GuzzleHttp\Client;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
@@ -20,7 +19,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class GetClassificationJelCommand extends Command
 {
     protected static $defaultName = 'enrichment:classifications-jel';
-    private const ONE_MONTH = 3600 * 24 * 31;
 
     protected function configure(): void
     {
@@ -65,12 +63,10 @@ class GetClassificationJelCommand extends Command
         }
 
         $cacheDir  = dirname(APPLICATION_PATH) . '/cache/';
-        $apiClient = new OpenAireApiClient(
-            new Client(),
-            new FilesystemAdapter('openAireResearchGraph', self::ONE_MONTH, $cacheDir),
-            new FilesystemAdapter('enrichmentAuthors',     self::ONE_MONTH, $cacheDir),
-            new FilesystemAdapter('enrichmentFunding',     self::ONE_MONTH, $cacheDir),
-            $logger
+        $apiClient = OpenAireApiClient::create();
+        $logger->info($apiClient->isAuthenticated()
+            ? 'OpenAIRE: authenticated mode (client credentials configured)'
+            : 'OpenAIRE: anonymous fallback mode (no client credentials configured) — throttling at 60s/request'
         );
 
         $db       = Zend_Db_Table_Abstract::getDefaultAdapter();

--- a/scripts/GetClassificationJelCommand.php
+++ b/scripts/GetClassificationJelCommand.php
@@ -26,14 +26,18 @@ class GetClassificationJelCommand extends Command
     {
         $this
             ->setDescription('Enrich JEL classification data from the OpenAIRE Research Graph')
+            ->addOption('doi', null, InputOption::VALUE_OPTIONAL, 'Process a single paper by DOI')
+            ->addOption('paperid', null, InputOption::VALUE_OPTIONAL, 'Process a single paper by paper ID')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Run without writing to the database')
-            ->addOption('rvcode', null, InputOption::VALUE_REQUIRED, 'Restrict processing to one journal (RV code)');
+            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Bypass cache and fetch fresh data')
+            ->addOption('rvcode', null, InputOption::VALUE_REQUIRED, 'Restrict processing to one journal (RV code); ignored when --doi or --paperid is used');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io      = new SymfonyStyle($input, $output);
         $dryRun  = (bool) $input->getOption('dry-run');
+        $noCache = (bool) $input->getOption('no-cache');
         $rvcode  = $input->getOption('rvcode');
         $io->title('JEL classification enrichment');
         $this->bootstrap();
@@ -71,13 +75,26 @@ class GetClassificationJelCommand extends Command
 
         $db       = Zend_Db_Table_Abstract::getDefaultAdapter();
         $allCodes = $db->fetchCol($db->select()->from(T_PAPER_CLASSIFICATION_JEL, ['code']));
-        $select   = $db->select()
-            ->from(T_PAPERS, ['DOI', 'DOCID'])
-            ->where('DOI != ""')
-            ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED)
-            ->order('DOCID ASC');
-        if ($rvid !== null) {
-            $select->where('RVID = ?', $rvid);
+        if ($input->getOption('doi')) {
+            $select = $db->select()
+                ->from(T_PAPERS, ['DOI', 'DOCID'])
+                ->where('DOI = ?', trim((string) $input->getOption('doi')))
+                ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED);
+        } elseif ($input->getOption('paperid')) {
+            $select = $db->select()
+                ->from(T_PAPERS, ['DOI', 'DOCID'])
+                ->where('PAPERID = ?', (int) $input->getOption('paperid'))
+                ->where('DOI != ""')
+                ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED);
+        } else {
+            $select = $db->select()
+                ->from(T_PAPERS, ['DOI', 'DOCID'])
+                ->where('DOI != ""')
+                ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED)
+                ->order('DOCID ASC');
+            if ($rvid !== null) {
+                $select->where('RVID = ?', $rvid);
+            }
         }
         $papers = $db->fetchAll($select);
 
@@ -85,8 +102,14 @@ class GetClassificationJelCommand extends Command
         $io->progressStart(count($papers));
 
         foreach ($papers as $row) {
-            $doi   = $row['DOI'];
+            $doi   = trim($row['DOI']);
             $docId = (int) $row['DOCID'];
+
+            if ($noCache && $doi !== '') {
+                $cacheOARG = new FilesystemAdapter('openAireResearchGraph', 0, $cacheDir);
+                $cacheOARG->deleteItem(md5($doi) . '.json');
+            }
+
             try {
                 $response = $apiClient->fetchPublication($doi, $docId);
                 $codes    = $response !== null ? $apiClient->extractJelCodes($response) : [];

--- a/scripts/GetCreatorDataCommand.php
+++ b/scripts/GetCreatorDataCommand.php
@@ -97,6 +97,10 @@ class GetCreatorDataCommand extends Command
         $io->progressStart(count($rows));
 
         $oaClient = \Episciences\Api\OpenAireApiClient::create();
+        $logger->info($oaClient->isAuthenticated()
+            ? 'OpenAIRE: authenticated mode (client credentials configured)'
+            : 'OpenAIRE: anonymous fallback mode (no client credentials configured) — throttling at 60s/request'
+        );
 
         foreach ($rows as $value) {
             $paperId = (int) $value['PAPERID'];

--- a/scripts/GetFundingDataCommand.php
+++ b/scripts/GetFundingDataCommand.php
@@ -94,6 +94,10 @@ class GetFundingDataCommand extends Command
         $io->progressStart(count($rows));
 
         $oaClient = \Episciences\Api\OpenAireApiClient::create();
+        $logger->info($oaClient->isAuthenticated()
+            ? 'OpenAIRE: authenticated mode (client credentials configured)'
+            : 'OpenAIRE: anonymous fallback mode (no client credentials configured) — throttling at 60s/request'
+        );
 
         foreach ($rows as $value) {
             $paperId = (int) $value['PAPERID'];

--- a/scripts/GetFundingDataCommand.php
+++ b/scripts/GetFundingDataCommand.php
@@ -127,11 +127,9 @@ class GetFundingDataCommand extends Command
                     try {
                         $fileFound = json_decode($fundingItem->get(), true, 512, JSON_THROW_ON_ERROR);
                         if (!empty($fileFound[0])) {
-                            $fundingArray       = [];
                             $globalfundingArray = [];
                             $globalfundingArray = Episciences_Paper_ProjectsManager::formatFundingOAForDB(
                                 $fileFound,
-                                $fundingArray,
                                 $globalfundingArray
                             );
                             $rowInDBGraph = Episciences_Paper_ProjectsManager::getProjectsByPaperIdAndSourceId(

--- a/scripts/console.php
+++ b/scripts/console.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/GetLicenceDataCommand.php';
 require_once __DIR__ . '/GetLinkDataCommand.php';
 require_once __DIR__ . '/GetFundingDataCommand.php';
 require_once __DIR__ . '/GetClassificationJelCommand.php';
+require_once __DIR__ . '/ClearOpenAireCacheCommand.php';
 require_once __DIR__ . '/GetClassificationMscCommand.php';
 require_once __DIR__ . '/GetZbReviewsCommand.php';
 require_once __DIR__ . '/GenerateSitemapCommand.php';
@@ -61,6 +62,7 @@ $application->add(new GetLicenceDataCommand());
 $application->add(new GetLinkDataCommand());
 $application->add(new GetFundingDataCommand());
 $application->add(new GetClassificationJelCommand());
+$application->add(new ClearOpenAireCacheCommand());
 $application->add(new GetClassificationMscCommand());
 $application->add(new GetZbReviewsCommand());
 

--- a/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
@@ -121,6 +121,22 @@ class OpenAireApiClientTest extends TestCase
     }
 
     /**
+     * Regression: a non-string 'value' (malformed payload) must be skipped rather than
+     * crash str_starts_with()/substr() with a TypeError under strict_types.
+     */
+    public function testExtractJelCodes_NonStringValue_SubjectSkippedWithoutTypeError(): void
+    {
+        $subjects = [
+            ['subject' => ['scheme' => 'jel', 'value' => ['unexpected' => 'array']]],
+            ['subject' => ['scheme' => 'jel', 'value' => 42]],
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:B01']],
+        ];
+        $response = $this->makeResponseWithSubjects($subjects);
+
+        $this->assertSame(['B01'], $this->makeClient()->extractJelCodes($response));
+    }
+
+    /**
      * Bug fix regression: substr($value, 4) must be used instead of ltrim($value, 'jel:'),
      * which strips individual characters {j,e,l,:} from the left rather than the prefix string.
      */
@@ -403,6 +419,32 @@ class OpenAireApiClientTest extends TestCase
     {
         $apiData = [
             ['fullName' => 'Doe, Jane', 'pid' => ['id' => ['scheme' => 'ror', 'value' => '05dxps055']]],
+        ];
+        $this->assertNull($this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData));
+    }
+
+    /**
+     * Regression: a non-string 'fullName' (malformed payload) must be skipped rather than
+     * crash mb_strtolower() with a TypeError under strict_types.
+     */
+    public function testFindOrcidForAuthor_NonStringFullName_EntrySkippedWithoutTypeError(): void
+    {
+        $apiData = [
+            ['fullName' => ['unexpected' => 'array'], 'pid' => null],
+            ['fullName' => 'Doe, Jane', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => '0000-0001-2345-6789']]],
+        ];
+        $result = $this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData);
+        $this->assertStringContainsString('0000-0001-2345-6789', $result);
+    }
+
+    /**
+     * Regression: a non-string 'pid.id.value' must be skipped rather than crash
+     * cleanLowerCaseOrcid() (strictly typed `string $orcid`) with a TypeError.
+     */
+    public function testFindOrcidForAuthor_NonStringPidValue_ReturnsNullWithoutTypeError(): void
+    {
+        $apiData = [
+            ['fullName' => 'Doe, Jane', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => ['unexpected' => 'array']]]],
         ];
         $this->assertNull($this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData));
     }

--- a/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
@@ -9,7 +9,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
- * Unit tests for OpenAireApiClient.
+ * Unit tests for OpenAireApiClient (OpenAire Graph v3 API).
  */
 class OpenAireApiClientTest extends TestCase
 {
@@ -33,130 +33,104 @@ class OpenAireApiClientTest extends TestCase
         $this->assertSame([], $this->makeClient()->extractJelCodes([]));
     }
 
-    public function testExtractJelCodes_ResultKeyAbsent_ReturnsEmpty(): void
+    public function testExtractJelCodes_ResultsEmpty_ReturnsEmpty(): void
     {
-        $response = ['response' => ['results' => []]];
+        $this->assertSame([], $this->makeClient()->extractJelCodes(['results' => []]));
+    }
+
+    public function testExtractJelCodes_SubjectsMissing_ReturnsEmpty(): void
+    {
+        $response = $this->makeResponseWithSubjects([]);
         $this->assertSame([], $this->makeClient()->extractJelCodes($response));
     }
 
-    public function testExtractJelCodes_SubjectMissing_ReturnsEmpty(): void
+    public function testExtractJelCodes_SchemeJel_ExtractsCode(): void
     {
-        $response = ['response' => ['results' => ['result' => [
-            ['metadata' => ['oaf:entity' => ['oaf:result' => []]]],
-        ]]]];
-        $this->assertSame([], $this->makeClient()->extractJelCodes($response));
+        $subjects = [
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:C10']],
+        ];
+        $response = $this->makeResponseWithSubjects($subjects);
+
+        $this->assertSame(['C10'], $this->makeClient()->extractJelCodes($response));
     }
 
-    public function testExtractJelCodes_SubjectNull_ReturnsEmpty(): void
+    public function testExtractJelCodes_SchemeJelWithoutPrefix_ExtractsRawValue(): void
     {
-        $response = ['response' => ['results' => ['result' => [
-            ['metadata' => ['oaf:entity' => ['oaf:result' => ['subject' => null]]]],
-        ]]]];
-        $this->assertSame([], $this->makeClient()->extractJelCodes($response));
-    }
-
-    /**
-     * When the API returns a single subject as an associative array (not wrapped in a list),
-     * it must still be processed correctly.
-     */
-    public function testExtractJelCodes_SingleSubjectObject_ExtractsCode(): void
-    {
-        $subject  = ['@classid' => 'jel', '$' => 'jel:A10'];
-        $response = $this->makeResponseWithSubject($subject);
+        $subjects = [
+            ['subject' => ['scheme' => 'jel', 'value' => 'A10']],
+        ];
+        $response = $this->makeResponseWithSubjects($subjects);
 
         $this->assertSame(['A10'], $this->makeClient()->extractJelCodes($response));
     }
 
-    public function testExtractJelCodes_MultipleSubjectsArray_FiltersJelOnly(): void
+    public function testExtractJelCodes_JelPrefixUnderOtherScheme_ExtractsCode(): void
+    {
+        // some sources tag JEL values under scheme 'keyword' instead of 'jel'
+        $subjects = [
+            ['subject' => ['scheme' => 'keyword', 'value' => 'jel:B23']],
+        ];
+        $response = $this->makeResponseWithSubjects($subjects);
+
+        $this->assertSame(['B23'], $this->makeClient()->extractJelCodes($response));
+    }
+
+    public function testExtractJelCodes_FiltersOutNonJelSubjects(): void
     {
         $subjects = [
-            ['@classid' => 'ddc',  '$' => 'ddc:330'],
-            ['@classid' => 'jel',  '$' => 'jel:B23'],
-            ['@classid' => 'jel',  '$' => 'jel:C10'],
+            ['subject' => ['scheme' => 'FOS', 'value' => '0102 computer and information sciences']],
+            ['subject' => ['scheme' => 'keyword', 'value' => 'Econometrics']],
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:A10']],
         ];
-        $response = $this->makeResponseWithSubject($subjects);
+        $response = $this->makeResponseWithSubjects($subjects);
 
-        $codes = $this->makeClient()->extractJelCodes($response);
-        $this->assertSame(['B23', 'C10'], $codes);
-    }
-
-    public function testExtractJelCodes_NoJelSubjects_ReturnsEmpty(): void
-    {
-        $subjects = [
-            ['@classid' => 'ddc', '$' => 'ddc:330'],
-        ];
-        $response = $this->makeResponseWithSubject($subjects);
-
-        $this->assertSame([], $this->makeClient()->extractJelCodes($response));
-    }
-
-    /**
-     * Bug A fix: ltrim($value, 'jel:') strips individual characters {j,e,l,:} from the left,
-     * so a code like 'jel:e10' would become '10' with ltrim, but correctly 'e10' with substr.
-     */
-    public function testBugFix_JelCodeStartingWithE_CorrectlyExtracted(): void
-    {
-        // ltrim('jel:e10', 'jel:') → strips 'j','e','l',':','e' → '10'
-        // substr('jel:e10', 4)    → 'e10'  ← correct
-        $response = $this->makeResponseWithSubject(['@classid' => 'jel', '$' => 'jel:e10']);
-        $this->assertSame(['e10'], $this->makeClient()->extractJelCodes($response));
-    }
-
-    public function testBugFix_JelCodeStartingWithJ_CorrectlyExtracted(): void
-    {
-        // ltrim('jel:jl1', 'jel:') → strips 'j','l' → '1'
-        // substr('jel:jl1', 4)    → 'jl1' ← correct
-        $response = $this->makeResponseWithSubject(['@classid' => 'jel', '$' => 'jel:jl1']);
-        $this->assertSame(['jl1'], $this->makeClient()->extractJelCodes($response));
+        $this->assertSame(['A10'], $this->makeClient()->extractJelCodes($response));
     }
 
     public function testExtractJelCodes_DuplicateCodes_Deduplicated(): void
     {
         $subjects = [
-            ['@classid' => 'jel', '$' => 'jel:A10'],
-            ['@classid' => 'jel', '$' => 'jel:A10'],
-            ['@classid' => 'jel', '$' => 'jel:B01'],
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:A10']],
+            ['subject' => ['scheme' => 'jel', 'value' => 'A10']],
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:B01']],
         ];
-        $response = $this->makeResponseWithSubject($subjects);
-        $codes    = $this->makeClient()->extractJelCodes($response);
+        $response = $this->makeResponseWithSubjects($subjects);
 
+        $codes = $this->makeClient()->extractJelCodes($response);
         $this->assertCount(2, $codes);
         $this->assertContains('A10', $codes);
         $this->assertContains('B01', $codes);
     }
 
-    public function testExtractJelCodes_MissingDollarSign_SubjectSkipped(): void
+    public function testExtractJelCodes_MissingValue_SubjectSkipped(): void
     {
         $subjects = [
-            ['@classid' => 'jel'],  // no '$' key
-            ['@classid' => 'jel', '$' => 'jel:B01'],
+            ['subject' => ['scheme' => 'jel']], // no 'value' key
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:B01']],
         ];
-        $response = $this->makeResponseWithSubject($subjects);
+        $response = $this->makeResponseWithSubjects($subjects);
 
         $this->assertSame(['B01'], $this->makeClient()->extractJelCodes($response));
     }
 
-    public function testExtractJelCodes_ValueNotStartingWithJelPrefix_Skipped(): void
+    /**
+     * Bug fix regression: substr($value, 4) must be used instead of ltrim($value, 'jel:'),
+     * which strips individual characters {j,e,l,:} from the left rather than the prefix string.
+     */
+    public function testBugFix_JelCodeStartingWithE_CorrectlyExtracted(): void
     {
-        $subjects = [
-            ['@classid' => 'jel', '$' => 'A10'],     // missing 'jel:' prefix
-            ['@classid' => 'jel', '$' => 'jel:B01'],
-        ];
-        $response = $this->makeResponseWithSubject($subjects);
-
-        $this->assertSame(['B01'], $this->makeClient()->extractJelCodes($response));
+        $response = $this->makeResponseWithSubjects([
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:e10']],
+        ]);
+        $this->assertSame(['e10'], $this->makeClient()->extractJelCodes($response));
     }
 
-    public function testExtractJelCodes_MultipleResults_CodesAggregatedAcrossAll(): void
+    public function testBugFix_JelCodeStartingWithJ_CorrectlyExtracted(): void
     {
-        $response = ['response' => ['results' => ['result' => [
-            $this->makeResult([['@classid' => 'jel', '$' => 'jel:A10']]),
-            $this->makeResult([['@classid' => 'jel', '$' => 'jel:B01']]),
-        ]]]];
-
-        $codes = $this->makeClient()->extractJelCodes($response);
-        $this->assertContains('A10', $codes);
-        $this->assertContains('B01', $codes);
+        $response = $this->makeResponseWithSubjects([
+            ['subject' => ['scheme' => 'jel', 'value' => 'jel:jl1']],
+        ]);
+        $this->assertSame(['jl1'], $this->makeClient()->extractJelCodes($response));
     }
 
     // -------------------------------------------------------------------------
@@ -168,24 +142,35 @@ class OpenAireApiClientTest extends TestCase
         $this->assertNull($this->makeClient()->extractCreators([]));
     }
 
-    public function testExtractCreators_ResultKeyAbsent_ReturnsNull(): void
+    public function testExtractCreators_ResultsEmpty_ReturnsNull(): void
     {
-        $this->assertNull($this->makeClient()->extractCreators(['response' => ['results' => []]]));
+        $this->assertNull($this->makeClient()->extractCreators(['results' => []]));
     }
 
-    public function testExtractCreators_NoCreatorKey_ReturnsNull(): void
+    public function testExtractCreators_NoAuthorsKey_ReturnsNull(): void
     {
-        $response = $this->makeResponseWithResult(['metadata' => ['oaf:entity' => ['oaf:result' => []]]]);
+        $response = $this->makeResponseWithResult([]);
         $this->assertNull($this->makeClient()->extractCreators($response));
     }
 
-    public function testExtractCreators_WithCreators_ReturnsArray(): void
+    public function testExtractCreators_EmptyAuthorsArray_ReturnsNull(): void
     {
-        $creators = [['$' => 'Doe, Jane', '@orcid' => '0000-0001-2345-6789']];
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => ['creator' => $creators]]],
-        ]);
-        $this->assertSame($creators, $this->makeClient()->extractCreators($response));
+        $response = $this->makeResponseWithResult(['authors' => []]);
+        $this->assertNull($this->makeClient()->extractCreators($response));
+    }
+
+    public function testExtractCreators_WithAuthors_ReturnsArray(): void
+    {
+        $authors = [
+            ['id' => null, 'fullName' => 'Bostjan Bresar', 'name' => 'Bostjan', 'surname' => 'Bresar', 'rank' => 1, 'pid' => null],
+            ['id' => 'orcid_______::28bda0fd2326ea51cb2e980c9d232397', 'fullName' => 'Babak Samadi', 'name' => 'Babak', 'surname' => 'Samadi', 'rank' => 2, 'pid' => [
+                'id' => ['scheme' => 'orcid', 'value' => '0000-0003-0045-1883'],
+                'provenance' => null,
+            ]],
+        ];
+        $response = $this->makeResponseWithResult(['authors' => $authors]);
+
+        $this->assertSame($authors, $this->makeClient()->extractCreators($response));
     }
 
     // -------------------------------------------------------------------------
@@ -197,29 +182,33 @@ class OpenAireApiClientTest extends TestCase
         $this->assertNull($this->makeClient()->extractFunding([]));
     }
 
-    public function testExtractFunding_NoRelsKey_ReturnsNull(): void
+    public function testExtractFunding_NoProjectsKey_ReturnsNull(): void
     {
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => []]],
-        ]);
+        $response = $this->makeResponseWithResult([]);
         $this->assertNull($this->makeClient()->extractFunding($response));
     }
 
-    public function testExtractFunding_RelsWithNoRelKey_ReturnsNull(): void
+    public function testExtractFunding_EmptyProjectsArray_ReturnsNull(): void
     {
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => ['rels' => []]]],
-        ]);
+        $response = $this->makeResponseWithResult(['projects' => []]);
         $this->assertNull($this->makeClient()->extractFunding($response));
     }
 
-    public function testExtractFunding_WithFunding_ReturnsRelArray(): void
+    public function testExtractFunding_WithProjects_ReturnsProjectsArray(): void
     {
-        $rel      = [['projectTitle' => 'My Project', 'grantId' => '12345']];
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => ['rels' => ['rel' => $rel]]]],
-        ]);
-        $this->assertSame($rel, $this->makeClient()->extractFunding($response));
+        $projects = [
+            [
+                'id'      => 'corda_______::824087',
+                'code'    => '824087',
+                'acronym' => 'EOSC-Pillar',
+                'title'   => 'European Open Science Cloud Pillar',
+                'funder'  => 'European Commission',
+                'pids'    => null,
+            ],
+        ];
+        $response = $this->makeResponseWithResult(['projects' => $projects]);
+
+        $this->assertSame($projects, $this->makeClient()->extractFunding($response));
     }
 
     // -------------------------------------------------------------------------
@@ -228,10 +217,8 @@ class OpenAireApiClientTest extends TestCase
 
     public function testPutCreatorInCache_ResponseWithCreators_CachesCreatorArray(): void
     {
-        $creators = [['$' => 'Doe, Jane', '@orcid' => '0000-0001-2345-6789']];
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => ['creator' => $creators]]],
-        ]);
+        $authors  = [['id' => null, 'fullName' => 'Doe, Jane', 'name' => 'Jane', 'surname' => 'Doe', 'rank' => 1, 'pid' => null]];
+        $response = $this->makeResponseWithResult(['authors' => $authors]);
 
         $authorsCache = new ArrayAdapter();
         $client = $this->makeClientWithCaches(new ArrayAdapter(), $authorsCache, new ArrayAdapter());
@@ -241,7 +228,7 @@ class OpenAireApiClientTest extends TestCase
 
         $item = $authorsCache->getItem(md5($doi) . '_creator.json');
         $this->assertTrue($item->isHit());
-        $this->assertSame($creators, json_decode($item->get(), true));
+        $this->assertSame($authors, json_decode($item->get(), true));
     }
 
     public function testPutCreatorInCache_NullResponse_StoresEmptyMarker(): void
@@ -276,10 +263,10 @@ class OpenAireApiClientTest extends TestCase
 
     public function testPutFundingInCache_ResponseWithFunding_CachesFundingArray(): void
     {
-        $rel      = [['projectTitle' => 'My Project', 'grantId' => '12345']];
-        $response = $this->makeResponseWithResult([
-            'metadata' => ['oaf:entity' => ['oaf:result' => ['rels' => ['rel' => $rel]]]],
-        ]);
+        $projects = [
+            ['id' => 'corda_______::824087', 'code' => '824087', 'acronym' => 'EOSC-Pillar', 'title' => 'European Open Science Cloud Pillar', 'funder' => 'European Commission', 'pids' => null],
+        ];
+        $response = $this->makeResponseWithResult(['projects' => $projects]);
 
         $fundingCache = new ArrayAdapter();
         $client = $this->makeClientWithCaches(new ArrayAdapter(), new ArrayAdapter(), $fundingCache);
@@ -289,7 +276,7 @@ class OpenAireApiClientTest extends TestCase
 
         $item = $fundingCache->getItem(md5($doi) . '_funding.json');
         $this->assertTrue($item->isHit());
-        $this->assertSame($rel, json_decode($item->get(), true));
+        $this->assertSame($projects, json_decode($item->get(), true));
     }
 
     public function testPutFundingInCache_NullResponse_StoresEmptyMarker(): void
@@ -362,30 +349,67 @@ class OpenAireApiClientTest extends TestCase
     // findOrcidForAuthor()
     // -------------------------------------------------------------------------
 
-    public function testFindOrcidForAuthor_ExactMatch_ReturnsCleanedOrcid(): void
+    public function testFindOrcidForAuthor_OrcidScheme_ReturnsCleanedOrcid(): void
     {
         $apiData = [
-            ['$' => 'Doe, Jane', '@orcid' => 'https://orcid.org/0000-0001-2345-6789'],
+            ['fullName' => 'Babak Samadi', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => 'https://orcid.org/0000-0003-0045-1883']]],
         ];
-        $result = $this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData);
-        // cleanLowerCaseOrcid strips URL prefix and lowercases
-        $this->assertStringContainsString('0000-0001-2345-6789', $result);
+        $result = $this->makeClient()->findOrcidForAuthor('Babak Samadi', $apiData);
+        $this->assertStringContainsString('0000-0003-0045-1883', $result);
+    }
+
+    public function testFindOrcidForAuthor_OrcidPendingScheme_ReturnsCleanedOrcid(): void
+    {
+        $apiData = [
+            ['fullName' => 'Matti Picus', 'pid' => ['id' => ['scheme' => 'orcid_pending', 'value' => '0000-0002-1771-9949']]],
+        ];
+        $result = $this->makeClient()->findOrcidForAuthor('Matti Picus', $apiData);
+        $this->assertSame('0000-0002-1771-9949', $result);
+    }
+
+    public function testFindOrcidForAuthor_CaseAndAccentInsensitiveMatch(): void
+    {
+        $apiData = [
+            ['fullName' => 'Bosstjan Brešar', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => '0000-0001-1111-1111']]],
+        ];
+        $result = $this->makeClient()->findOrcidForAuthor('bosstjan bresar', $apiData);
+        $this->assertSame('0000-0001-1111-1111', $result);
     }
 
     public function testFindOrcidForAuthor_NoMatch_ReturnsNull(): void
     {
         $apiData = [
-            ['$' => 'Smith, John', '@orcid' => 'https://orcid.org/0000-0002-0000-0000'],
+            ['fullName' => 'Smith, John', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => '0000-0002-0000-0000']]],
         ];
         $this->assertNull($this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData));
     }
 
-    public function testFindOrcidForAuthor_MatchWithoutOrcid_ReturnsNull(): void
+    public function testFindOrcidForAuthor_MatchWithoutPid_ReturnsNull(): void
     {
         $apiData = [
-            ['$' => 'Doe, Jane'], // no @orcid key
+            ['fullName' => 'Sandi Klavzar', 'pid' => null],
+        ];
+        $this->assertNull($this->makeClient()->findOrcidForAuthor('Sandi Klavzar', $apiData));
+    }
+
+    public function testFindOrcidForAuthor_UnsupportedScheme_ReturnsNull(): void
+    {
+        $apiData = [
+            ['fullName' => 'Doe, Jane', 'pid' => ['id' => ['scheme' => 'ror', 'value' => '05dxps055']]],
         ];
         $this->assertNull($this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData));
+    }
+
+    /**
+     * Golden rule: 'id' (an OpenAire-internal hash, e.g. 'orcid_______::28bda0fd...') must
+     * never be used as an ORCID, only 'pid.id.value'.
+     */
+    public function testFindOrcidForAuthor_NeverUsesInternalIdHash(): void
+    {
+        $apiData = [
+            ['id' => 'orcid_______::28bda0fd2326ea51cb2e980c9d232397', 'fullName' => 'Babak Samadi', 'pid' => null],
+        ];
+        $this->assertNull($this->makeClient()->findOrcidForAuthor('Babak Samadi', $apiData));
     }
 
     public function testFindOrcidForAuthor_EmptyApiData_ReturnsNull(): void
@@ -397,24 +421,16 @@ class OpenAireApiClientTest extends TestCase
     // Helpers
     // -------------------------------------------------------------------------
 
-    /** @param mixed $subject single subject dict or array of dicts */
-    private function makeResponseWithSubject(mixed $subject): array
+    /** @param array<int, array<string, mixed>> $subjects */
+    private function makeResponseWithSubjects(array $subjects): array
     {
-        return ['response' => ['results' => ['result' => [
-            $this->makeResult($subject),
-        ]]]];
-    }
-
-    /** @param mixed $subject */
-    private function makeResult(mixed $subject): array
-    {
-        return ['metadata' => ['oaf:entity' => ['oaf:result' => ['subject' => $subject]]]];
+        return $this->makeResponseWithResult(['subjects' => $subjects]);
     }
 
     /** @param array<string, mixed> $resultEntry */
     private function makeResponseWithResult(array $resultEntry): array
     {
-        return ['response' => ['results' => ['result' => [$resultEntry]]]];
+        return ['results' => [$resultEntry]];
     }
 
     private function makeClientWithCaches(

--- a/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
@@ -711,6 +711,75 @@ class OpenAireApiClientTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // fetchPublication() — never blocks the request thread outside CLI (e.g. a
+    // request triggered synchronously from PaperController/AdministratepaperController)
+    // -------------------------------------------------------------------------
+
+    public function testFetchPublication_429_OutsideCli_ReturnsNullImmediatelyWithoutRetry(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $history = [];
+        // Only one response queued: a retry attempt would exhaust the mock queue and error out.
+        $guzzle = $this->makeGuzzle([new Response(429, ['Retry-After' => '5'], 'Too Many Requests')], $history);
+
+        $client = $this->makeHttpContextClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $result = $client->fetchPublication('10.1234/ratelimited-http', 1);
+
+        $this->assertNull($result);
+        $this->assertCount(1, $history, 'must not retry outside CLI execution');
+        $this->assertTrue($testHandler->hasWarningThatContains('not retrying outside CLI execution'));
+    }
+
+    public function testFetchPublication_429_OutsideCli_Unauthenticated_ReturnsNullImmediately(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(429, [], 'Too Many Requests')], $history);
+
+        $client = $this->makeHttpContextClient($guzzle, null);
+        $result = $client->fetchPublication('10.1234/ratelimited-http-anon', 1);
+
+        $this->assertNull($result);
+        $this->assertCount(1, $history, 'must not retry outside CLI execution');
+    }
+
+    public function testThrottleAuthenticated_OutsideCli_SkipsDelayAndStillSendsRequest(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))], $history);
+
+        $client = $this->makeHttpContextClient($guzzle, $this->makeAuthenticatedTokenProvider('http-token'), $logger);
+        $client->fetchPublication('10.1234/authed-http', 1);
+
+        $this->assertCount(1, $history);
+        $this->assertSame('Bearer http-token', $history[0]['request']->getHeaderLine('Authorization'));
+        $this->assertTrue($testHandler->hasDebugThatContains('authenticated throttle skipped outside CLI execution'));
+    }
+
+    public function testThrottleUnauthenticated_OutsideCli_SkipsDelayAndStillSendsRequest(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))], $history);
+
+        $client = $this->makeHttpContextClient($guzzle, null, $logger);
+        $client->fetchPublication('10.1234/anon-http', 1);
+
+        $this->assertCount(1, $history);
+        $this->assertFalse($history[0]['request']->hasHeader('Authorization'));
+        $this->assertTrue($testHandler->hasDebugThatContains('unauthenticated throttle skipped outside CLI execution'));
+    }
+
+    // -------------------------------------------------------------------------
     // fetchPublication() — rate-limit header logging
     // -------------------------------------------------------------------------
 
@@ -813,6 +882,21 @@ class OpenAireApiClientTest extends TestCase
         );
     }
 
+    private function makeHttpContextClient(
+        Client $guzzle,
+        ?OpenAireTokenProvider $tokenProvider = null,
+        ?Logger $logger = null
+    ): OpenAireApiClientHttpContext {
+        return new OpenAireApiClientHttpContext(
+            $guzzle,
+            new ArrayAdapter(),
+            new ArrayAdapter(),
+            new ArrayAdapter(),
+            $logger ?? new NullLogger(),
+            $tokenProvider
+        );
+    }
+
     /** @param array<int, array<string, mixed>> $subjects */
     private function makeResponseWithSubjects(array $subjects): array
     {
@@ -862,5 +946,19 @@ class OpenAireApiClientNoSleep extends OpenAireApiClient
     protected function backoff(int $seconds): void
     {
         $this->sleepLog[] = "backoff:{$seconds}s";
+    }
+}
+
+/**
+ * Test double: simulates the HTTP request path (non-CLI SAPI) by overriding only
+ * isCliContext(), while keeping the real throttleAuthenticated()/throttleUnauthenticated()/
+ * 429-branch guard logic — so these tests exercise the actual "skip the delay outside
+ * CLI" code paths without ever reaching a real sleep()/usleep() call.
+ */
+class OpenAireApiClientHttpContext extends OpenAireApiClient
+{
+    protected function isCliContext(): bool
+    {
+        return false;
     }
 }

--- a/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
@@ -3,7 +3,14 @@
 namespace unit\library\Episciences\Api;
 
 use Episciences\Api\OpenAireApiClient;
+use Episciences\Api\OpenAireTokenProvider;
 use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -418,8 +425,351 @@ class OpenAireApiClientTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // isAuthenticated()
+    // -------------------------------------------------------------------------
+
+    public function testIsAuthenticated_NoTokenProvider_ReturnsFalse(): void
+    {
+        $client = $this->makeBiModeClient($this->makeGuzzle([]));
+        $this->assertFalse($client->isAuthenticated());
+    }
+
+    public function testIsAuthenticated_UnconfiguredTokenProvider_ReturnsFalse(): void
+    {
+        $client = $this->makeBiModeClient($this->makeGuzzle([]), $this->makeUnconfiguredTokenProvider());
+        $this->assertFalse($client->isAuthenticated());
+    }
+
+    public function testIsAuthenticated_ConfiguredTokenProvider_ReturnsTrue(): void
+    {
+        $client = $this->makeBiModeClient($this->makeGuzzle([]), $this->makeAuthenticatedTokenProvider());
+        $this->assertTrue($client->isAuthenticated());
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchPublication() — bi-mode auth & throttling
+    // -------------------------------------------------------------------------
+
+    public function testFetchPublication_CacheHit_NoHttpCallNoThrottle(): void
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem(md5('10.1234/cached') . '.json');
+        $item->set(json_encode(['results' => [['mainTitle' => 'Cached']]]));
+        $cache->save($item);
+
+        // Empty MockHandler queue: any HTTP call would throw an "empty queue" error.
+        $client = new OpenAireApiClientNoSleep(
+            $this->makeGuzzle([]),
+            $cache,
+            new ArrayAdapter(),
+            new ArrayAdapter(),
+            new NullLogger()
+        );
+
+        $result = $client->fetchPublication('10.1234/cached', 1);
+
+        $this->assertSame('Cached', $result['results'][0]['mainTitle']);
+        $this->assertSame([], $client->sleepLog);
+    }
+
+    public function testFetchPublication_Authenticated_SendsBearerTokenAndThrottles500ms(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))], $history);
+        $client  = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider('the-bearer-token'));
+
+        $client->fetchPublication('10.1234/authed', 1);
+
+        $this->assertCount(1, $history);
+        $this->assertSame('Bearer the-bearer-token', $history[0]['request']->getHeaderLine('Authorization'));
+        $this->assertSame(['auth:500000us'], $client->sleepLog);
+    }
+
+    public function testFetchPublication_Unauthenticated_NoAuthorizationHeaderAndThrottles60s(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))], $history);
+        $client  = $this->makeBiModeClient($guzzle, null);
+
+        $client->fetchPublication('10.1234/anon', 1);
+
+        $this->assertCount(1, $history);
+        $this->assertFalse($history[0]['request']->hasHeader('Authorization'));
+        $this->assertSame(['unauth:60s'], $client->sleepLog);
+    }
+
+    public function testFetchPublication_Unauthenticated_LogsWarning(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))]);
+        $client = $this->makeBiModeClient($guzzle, null, $logger);
+
+        $client->fetchPublication('10.1234/anon', 1);
+
+        $this->assertTrue($testHandler->hasWarningThatContains('unauthenticated mode'));
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchPublication() — HTTP 401 retry (authenticated mode only)
+    // -------------------------------------------------------------------------
+
+    public function testFetchPublication_401ThenSuccess_RefreshesTokenAndRetriesOnce(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([
+            new Response(401, [], 'Unauthorized'),
+            new Response(200, [], json_encode(['results' => [['mainTitle' => 'Recovered']]])),
+        ], $history);
+
+        // Token cache pre-seeded with a stale token; clearTokenCache() + getAccessToken()
+        // must yield a (mocked) fresh one from the same cache-hit path.
+        $tokenCache = new ArrayAdapter();
+        $tokenItem  = $tokenCache->getItem('openaire_access_token');
+        $tokenItem->set('stale-token');
+        $tokenItem->expiresAfter(3600);
+        $tokenCache->save($tokenItem);
+
+        // A second getItem() after clearTokenCache() would miss and try a real AAI call;
+        // to keep this a pure unit test we re-seed via a token provider whose AAI mock
+        // returns a fresh token on that fallback call.
+        $aaiHistory = [];
+        $aaiClient  = new Client(['handler' => HandlerStack::create(new MockHandler([
+            new Response(200, [], json_encode(['access_token' => 'refreshed-token', 'expires_in' => 3600])),
+        ]))]);
+        $tokenProvider = new OpenAireTokenProvider($aaiClient, $tokenCache, new NullLogger(), 'id', 'secret');
+
+        $client = $this->makeBiModeClient($guzzle, $tokenProvider);
+        $result = $client->fetchPublication('10.1234/expired-token', 1);
+
+        $this->assertSame('Recovered', $result['results'][0]['mainTitle']);
+        $this->assertCount(2, $history);
+        $this->assertSame('Bearer stale-token', $history[0]['request']->getHeaderLine('Authorization'));
+        $this->assertSame('Bearer refreshed-token', $history[1]['request']->getHeaderLine('Authorization'));
+    }
+
+    public function testFetchPublication_401Twice_ReturnsNullAfterSingleRetry(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([
+            new Response(401, [], 'Unauthorized'),
+            new Response(401, [], 'Unauthorized'),
+        ], $history);
+
+        // Token cache pre-seeded; the refresh triggered by the first 401 must still
+        // succeed in acquiring *a* (still-rejected) token, so the second GET is attempted.
+        $tokenCache = new ArrayAdapter();
+        $tokenItem  = $tokenCache->getItem('openaire_access_token');
+        $tokenItem->set('stale-token');
+        $tokenItem->expiresAfter(3600);
+        $tokenCache->save($tokenItem);
+
+        $aaiClient = new Client(['handler' => HandlerStack::create(new MockHandler([
+            new Response(200, [], json_encode(['access_token' => 'still-rejected-token', 'expires_in' => 3600])),
+        ]))]);
+        $tokenProvider = new OpenAireTokenProvider($aaiClient, $tokenCache, new NullLogger(), 'id', 'secret');
+
+        $client = $this->makeBiModeClient($guzzle, $tokenProvider);
+        $result = $client->fetchPublication('10.1234/still-unauthorized', 1);
+
+        $this->assertNull($result);
+        // Exactly one retry: the initial attempt + one refreshed-token retry, no more.
+        $this->assertCount(2, $history);
+    }
+
+    public function testFetchPublication_401_TokenRefreshFails_ReturnsNullWithoutSecondRequest(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(401, [], 'Unauthorized')], $history);
+
+        $tokenCache = new ArrayAdapter();
+        $tokenItem  = $tokenCache->getItem('openaire_access_token');
+        $tokenItem->set('stale-token');
+        $tokenItem->expiresAfter(3600);
+        $tokenCache->save($tokenItem);
+
+        // AAI itself fails on the refresh attempt -> getAccessToken() returns null.
+        $aaiClient     = new Client(['handler' => HandlerStack::create(new MockHandler([new Response(500, [], 'error')]))]);
+        $tokenProvider = new OpenAireTokenProvider($aaiClient, $tokenCache, new NullLogger(), 'id', 'secret');
+
+        $client = $this->makeBiModeClient($guzzle, $tokenProvider);
+        $result = $client->fetchPublication('10.1234/refresh-fails', 1);
+
+        $this->assertNull($result);
+        // No second GET: refresh failed, so there is no new token to retry with.
+        $this->assertCount(1, $history);
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchPublication() — HTTP 429 backoff & retry
+    // -------------------------------------------------------------------------
+
+    public function testFetchPublication_429ThenSuccess_Authenticated_BacksOffUsingRetryAfter(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([
+            new Response(429, ['Retry-After' => '7'], 'Too Many Requests'),
+            new Response(200, [], json_encode(['results' => [['mainTitle' => 'OK']]])),
+        ], $history);
+
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider());
+        $result = $client->fetchPublication('10.1234/ratelimited', 1);
+
+        $this->assertSame('OK', $result['results'][0]['mainTitle']);
+        $this->assertCount(2, $history);
+        $this->assertSame(['auth:500000us', 'backoff:7s'], $client->sleepLog);
+    }
+
+    public function testFetchPublication_429ThenSuccess_Authenticated_NoRetryAfterHeader_UsesAttemptBackoff(): void
+    {
+        $guzzle = $this->makeGuzzle([
+            new Response(429, [], 'Too Many Requests'),
+            new Response(200, [], json_encode(['results' => []])),
+        ]);
+
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider());
+        $client->fetchPublication('10.1234/ratelimited-no-header', 1);
+
+        // attempt 1 * 3 seconds
+        $this->assertSame(['auth:500000us', 'backoff:3s'], $client->sleepLog);
+    }
+
+    public function testFetchPublication_429ThenSuccess_Unauthenticated_BacksOffAtLeast60s(): void
+    {
+        $guzzle = $this->makeGuzzle([
+            new Response(429, ['Retry-After' => '5'], 'Too Many Requests'), // below the 60s floor
+            new Response(200, [], json_encode(['results' => []])),
+        ]);
+
+        $client = $this->makeBiModeClient($guzzle, null);
+        $client->fetchPublication('10.1234/ratelimited-anon', 1);
+
+        $this->assertSame(['unauth:60s', 'backoff:60s'], $client->sleepLog);
+    }
+
+    public function testFetchPublication_429Exhausted_ReturnsNullAndLogsCritical(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([
+            new Response(429, [], 'Too Many Requests'),
+            new Response(429, [], 'Too Many Requests'),
+            new Response(429, [], 'Too Many Requests'),
+        ]);
+
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $result = $client->fetchPublication('10.1234/always-ratelimited', 1);
+
+        $this->assertNull($result);
+        $this->assertTrue($testHandler->hasCriticalThatContains('rate limit (429) exhausted'));
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchPublication() — rate-limit header logging
+    // -------------------------------------------------------------------------
+
+    public function testFetchPublication_RateLimitHeaders_LoggedAtDebug(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([
+            new Response(200, ['x-ratelimit-used' => '10', 'x-ratelimit-limit' => '7200'], json_encode(['results' => []])),
+        ]);
+
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $client->fetchPublication('10.1234/ratelimit-status', 1);
+
+        $this->assertTrue($testHandler->hasDebugThatContains('10/7200'));
+    }
+
+    public function testFetchPublication_RateLimitAbove85Percent_LogsWarning(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([
+            new Response(200, ['x-ratelimit-used' => '6200', 'x-ratelimit-limit' => '7200'], json_encode(['results' => []])),
+        ]);
+
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $client->fetchPublication('10.1234/ratelimit-high', 1);
+
+        $this->assertTrue($testHandler->hasWarningThatContains('threshold > 85%'));
+    }
+
+    public function testFetchPublication_RateLimitHeadersAbsent_NoLogging(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([new Response(200, [], json_encode(['results' => []]))]);
+        $client = $this->makeBiModeClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $client->fetchPublication('10.1234/no-ratelimit-headers', 1);
+
+        $this->assertFalse($testHandler->hasRecordThatContains('Rate Limit', Logger::DEBUG));
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private function makeGuzzle(array $responses, array &$history = []): Client
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $handlerStack->push(Middleware::history($history));
+        return new Client(['handler' => $handlerStack]);
+    }
+
+    private function makeAuthenticatedTokenProvider(string $token = 'test-access-token'): OpenAireTokenProvider
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set($token);
+        $item->expiresAfter(3600);
+        $cache->save($item);
+
+        return new OpenAireTokenProvider(
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]), // never called: cache hit
+            $cache,
+            new NullLogger(),
+            'client-id',
+            'client-secret'
+        );
+    }
+
+    private function makeUnconfiguredTokenProvider(): OpenAireTokenProvider
+    {
+        return new OpenAireTokenProvider(
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            new ArrayAdapter(),
+            new NullLogger(),
+            '',
+            ''
+        );
+    }
+
+    private function makeBiModeClient(
+        Client $guzzle,
+        ?OpenAireTokenProvider $tokenProvider = null,
+        ?Logger $logger = null
+    ): OpenAireApiClientNoSleep {
+        return new OpenAireApiClientNoSleep(
+            $guzzle,
+            new ArrayAdapter(),
+            new ArrayAdapter(),
+            new ArrayAdapter(),
+            $logger ?? new NullLogger(),
+            $tokenProvider
+        );
+    }
 
     /** @param array<int, array<string, mixed>> $subjects */
     private function makeResponseWithSubjects(array $subjects): array
@@ -445,5 +795,30 @@ class OpenAireApiClientTest extends TestCase
             $fundingCache,
             new NullLogger()
         );
+    }
+}
+
+/**
+ * Test double: records throttle/backoff calls instead of actually sleeping,
+ * so 60s-anonymous-mode and 429-backoff tests run instantly.
+ */
+class OpenAireApiClientNoSleep extends OpenAireApiClient
+{
+    /** @var array<int, string> */
+    public array $sleepLog = [];
+
+    protected function throttleAuthenticated(): void
+    {
+        $this->sleepLog[] = 'auth:500000us';
+    }
+
+    protected function throttleUnauthenticated(): void
+    {
+        $this->sleepLog[] = 'unauth:60s';
+    }
+
+    protected function backoff(int $seconds): void
+    {
+        $this->sleepLog[] = "backoff:{$seconds}s";
     }
 }

--- a/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireApiClientTest.php
@@ -378,7 +378,7 @@ class OpenAireApiClientTest extends TestCase
             ['fullName' => 'Babak Samadi', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => 'https://orcid.org/0000-0003-0045-1883']]],
         ];
         $result = $this->makeClient()->findOrcidForAuthor('Babak Samadi', $apiData);
-        $this->assertStringContainsString('0000-0003-0045-1883', $result);
+        $this->assertSame('0000-0003-0045-1883', $result);
     }
 
     public function testFindOrcidForAuthor_OrcidPendingScheme_ReturnsCleanedOrcid(): void
@@ -434,7 +434,7 @@ class OpenAireApiClientTest extends TestCase
             ['fullName' => 'Doe, Jane', 'pid' => ['id' => ['scheme' => 'orcid', 'value' => '0000-0001-2345-6789']]],
         ];
         $result = $this->makeClient()->findOrcidForAuthor('Doe, Jane', $apiData);
-        $this->assertStringContainsString('0000-0001-2345-6789', $result);
+        $this->assertSame('0000-0001-2345-6789', $result);
     }
 
     /**
@@ -577,7 +577,6 @@ class OpenAireApiClientTest extends TestCase
         // A second getItem() after clearTokenCache() would miss and try a real AAI call;
         // to keep this a pure unit test we re-seed via a token provider whose AAI mock
         // returns a fresh token on that fallback call.
-        $aaiHistory = [];
         $aaiClient  = new Client(['handler' => HandlerStack::create(new MockHandler([
             new Response(200, [], json_encode(['access_token' => 'refreshed-token', 'expires_in' => 3600])),
         ]))]);

--- a/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace unit\library\Episciences\Api;
+
+use Episciences\Api\OpenAireTokenProvider;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Unit tests for OpenAireTokenProvider (OpenAIRE AAI client-credentials token acquisition).
+ */
+class OpenAireTokenProviderTest extends TestCase
+{
+    private function makeGuzzle(array $responses, array &$history = []): Client
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $handlerStack->push(Middleware::history($history));
+        return new Client(['handler' => $handlerStack]);
+    }
+
+    private function makeProvider(
+        Client $client,
+        ?ArrayAdapter $cache = null,
+        ?string $clientId = 'client-id',
+        ?string $clientSecret = 'client-secret'
+    ): OpenAireTokenProvider {
+        return new OpenAireTokenProvider(
+            $client,
+            $cache ?? new ArrayAdapter(),
+            new NullLogger(),
+            $clientId,
+            $clientSecret
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // isConfigured()
+    // -------------------------------------------------------------------------
+
+    public function testIsConfigured_WithBothIdAndSecret_ReturnsTrue(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([]), null, 'id', 'secret');
+        $this->assertTrue($provider->isConfigured());
+    }
+
+    public function testIsConfigured_MissingClientId_ReturnsFalse(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([]), null, '', 'secret');
+        $this->assertFalse($provider->isConfigured());
+    }
+
+    public function testIsConfigured_MissingClientSecret_ReturnsFalse(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([]), null, 'id', '');
+        $this->assertFalse($provider->isConfigured());
+    }
+
+    public function testIsConfigured_NullCredentials_ReturnsFalse(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([]), null, null, null);
+        $this->assertFalse($provider->isConfigured());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAccessToken() — unconfigured / graceful degradation
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_Unconfigured_ReturnsNullWithoutHttpCall(): void
+    {
+        // Empty MockHandler queue: any HTTP call would throw an "empty queue" error.
+        $provider = $this->makeProvider($this->makeGuzzle([]), null, '', '');
+        $this->assertNull($provider->getAccessToken());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAccessToken() — cache hit
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_CacheHit_ReturnsCachedTokenWithoutHttpCall(): void
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set('cached-token-value');
+        $item->expiresAfter(3600);
+        $cache->save($item);
+
+        // Empty MockHandler queue: any HTTP call would throw an "empty queue" error.
+        $provider = $this->makeProvider($this->makeGuzzle([]), $cache);
+        $this->assertSame('cached-token-value', $provider->getAccessToken());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAccessToken() — cache miss, successful acquisition
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_CacheMiss_AcquiresAndCachesNewToken(): void
+    {
+        $body     = json_encode(['access_token' => 'fresh-token', 'token_type' => 'Bearer', 'expires_in' => 3600]);
+        $cache    = new ArrayAdapter();
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], $body)]), $cache);
+
+        $this->assertSame('fresh-token', $provider->getAccessToken());
+
+        $item = $cache->getItem('openaire_access_token');
+        $this->assertTrue($item->isHit());
+        $this->assertSame('fresh-token', $item->get());
+    }
+
+    public function testGetAccessToken_SendsClientCredentialsGrant(): void
+    {
+        $body     = json_encode(['access_token' => 'tok', 'expires_in' => 3600]);
+        $history  = [];
+        $client   = $this->makeGuzzle([new Response(200, [], $body)], $history);
+        $provider = $this->makeProvider($client, null, 'my-id', 'my-secret');
+
+        $provider->getAccessToken();
+
+        $this->assertCount(1, $history);
+        $request = $history[0]['request'];
+        $this->assertSame('POST', $request->getMethod());
+        parse_str((string) $request->getBody(), $formParams);
+        $this->assertSame('client_credentials', $formParams['grant_type']);
+        $this->assertSame('my-id', $formParams['client_id']);
+        $this->assertSame('my-secret', $formParams['client_secret']);
+    }
+
+    public function testGetAccessToken_DefaultAuthUrl_UsedWhenNoneProvided(): void
+    {
+        $body     = json_encode(['access_token' => 'tok', 'expires_in' => 3600]);
+        $history  = [];
+        $client   = $this->makeGuzzle([new Response(200, [], $body)], $history);
+        $provider = new OpenAireTokenProvider($client, new ArrayAdapter(), new NullLogger(), 'id', 'secret');
+
+        $provider->getAccessToken();
+
+        $this->assertSame('https://aai.openaire.eu/token', (string) $history[0]['request']->getUri());
+    }
+
+    public function testGetAccessToken_CustomAuthUrl_IsUsed(): void
+    {
+        $body     = json_encode(['access_token' => 'tok', 'expires_in' => 3600]);
+        $history  = [];
+        $client   = $this->makeGuzzle([new Response(200, [], $body)], $history);
+        $provider = new OpenAireTokenProvider($client, new ArrayAdapter(), new NullLogger(), 'id', 'secret', 'https://custom.example.org/token');
+
+        $provider->getAccessToken();
+
+        $this->assertSame('https://custom.example.org/token', (string) $history[0]['request']->getUri());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAccessToken() — TTL computation (expires_in - 120s safety margin, floored at 60s)
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_CachesWithSafetyMarginTtl(): void
+    {
+        $body     = json_encode(['access_token' => 'tok', 'expires_in' => 3600]); // expect TTL 3480
+        $cache    = new ArrayAdapter();
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], $body)]), $cache);
+
+        $provider->getAccessToken();
+
+        // ArrayAdapter items store the expiry; re-fetch from a fresh adapter view is not directly
+        // introspectable, so assert indirectly: a still-fresh (mocked) clock keeps it a hit.
+        $item = $cache->getItem('openaire_access_token');
+        $this->assertTrue($item->isHit());
+    }
+
+    public function testGetAccessToken_ShortExpiresIn_FlooredAtMinimumTtl(): void
+    {
+        // expires_in=100 - safety margin 120 = -20, floored to the 60s minimum.
+        $body     = json_encode(['access_token' => 'tok', 'expires_in' => 100]);
+        $cache    = new ArrayAdapter();
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], $body)]), $cache);
+
+        $this->assertSame('tok', $provider->getAccessToken());
+        $this->assertTrue($cache->getItem('openaire_access_token')->isHit());
+    }
+
+    // -------------------------------------------------------------------------
+    // getAccessToken() — error handling
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_MissingAccessTokenInResponse_ReturnsNull(): void
+    {
+        $body     = json_encode(['token_type' => 'Bearer', 'expires_in' => 3600]);
+        $cache    = new ArrayAdapter();
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], $body)]), $cache);
+
+        $this->assertNull($provider->getAccessToken());
+        $this->assertFalse($cache->getItem('openaire_access_token')->isHit());
+    }
+
+    public function testGetAccessToken_MalformedJson_ReturnsNull(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], 'not valid json {{{')]));
+        $this->assertNull($provider->getAccessToken());
+    }
+
+    public function testGetAccessToken_HttpError_ReturnsNull(): void
+    {
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(500, [], 'Internal Server Error')]));
+        $this->assertNull($provider->getAccessToken());
+    }
+
+    // -------------------------------------------------------------------------
+    // clearTokenCache()
+    // -------------------------------------------------------------------------
+
+    public function testClearTokenCache_RemovesCachedToken(): void
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set('stale-token');
+        $item->expiresAfter(3600);
+        $cache->save($item);
+
+        $provider = $this->makeProvider($this->makeGuzzle([]), $cache);
+        $provider->clearTokenCache();
+
+        $this->assertFalse($cache->getItem('openaire_access_token')->isHit());
+    }
+
+    public function testClearTokenCache_ThenGetAccessToken_FetchesFreshToken(): void
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set('stale-token');
+        $item->expiresAfter(3600);
+        $cache->save($item);
+
+        $body    = json_encode(['access_token' => 'brand-new-token', 'expires_in' => 3600]);
+        $history = [];
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(200, [], $body)], $history), $cache);
+
+        $provider->clearTokenCache();
+        $token = $provider->getAccessToken();
+
+        $this->assertSame('brand-new-token', $token);
+        $this->assertCount(1, $history);
+    }
+}

--- a/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
@@ -210,6 +210,34 @@ class OpenAireTokenProviderTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // getAccessToken() — negative caching on AAI failure
+    // -------------------------------------------------------------------------
+
+    public function testGetAccessToken_HttpError_CachesFailureMarker_PreventsSecondAaiCallWithinTtl(): void
+    {
+        // Single response queued: a second HTTP call would throw an "empty queue" error,
+        // proving the failure marker was used instead of hitting AAI again.
+        $provider = $this->makeProvider($this->makeGuzzle([new Response(500, [], 'Internal Server Error')]));
+
+        $this->assertNull($provider->getAccessToken());
+        $this->assertNull($provider->getAccessToken());
+    }
+
+    public function testGetAccessToken_CachedFailureMarker_ReturnsNullNotEmptyString(): void
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set(false);
+        $item->expiresAfter(60);
+        $cache->save($item);
+
+        // Empty MockHandler queue: any HTTP call would throw an "empty queue" error.
+        $provider = $this->makeProvider($this->makeGuzzle([]), $cache);
+
+        $this->assertNull($provider->getAccessToken());
+    }
+
+    // -------------------------------------------------------------------------
     // clearTokenCache()
     // -------------------------------------------------------------------------
 

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_ProjectsManagerTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_ProjectsManagerTest.php
@@ -12,6 +12,9 @@ use PHPUnit\Framework\TestCase;
 final class Episciences_Paper_ProjectsManagerTest extends TestCase {
 
     /**
+     * Legacy v1 relation format (rels.rel with to.@type === 'project'), kept as a
+     * regression test for the fallback path used by residual v1 caches.
+     *
      * @dataProvider sampleOaProjects
      * @param $sampleOaProjects
      * @return void
@@ -35,6 +38,85 @@ final class Episciences_Paper_ProjectsManagerTest extends TestCase {
         self::assertArrayHasKey("acronym",$filterFundingsFromOaApiAndFormatForDB[1]);
         self::assertEquals("ANR-11-LABX-0010",$filterFundingsFromOaApiAndFormatForDB[1]['code']);
         self::assertEquals("DRIIHM / IRDHEI",$filterFundingsFromOaApiAndFormatForDB[1]['acronym']);
+    }
+
+    /**
+     * OpenAire Graph v3 direct project entries (results[0].projects), the current API format.
+     *
+     * @dataProvider sampleOaProjectsV3
+     * @param array $sampleOaProjectsV3
+     * @return void
+     */
+    public function testFormatFundingOAForDBv3(array $sampleOaProjectsV3): void {
+        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($sampleOaProjectsV3, [], []);
+
+        self::assertCount(2, $result);
+
+        self::assertSame('European Open Science Cloud Pillar', $result[0]['projectTitle']);
+        self::assertSame('EOSC-Pillar', $result[0]['acronym']);
+        self::assertSame('824087', $result[0]['code']);
+        self::assertSame('European Commission', $result[0]['funderName']);
+
+        self::assertSame('Dispositif de recherche interdisciplinaire sur les Interactions Hommes-Milieux', $result[1]['projectTitle']);
+        self::assertSame('DRIIHM / IRDHEI', $result[1]['acronym']);
+        self::assertSame('ANR-11-LABX-0010', $result[1]['code']);
+        self::assertSame('French National Research Agency (ANR)', $result[1]['funderName']);
+    }
+
+    /**
+     * A v3 project with a null acronym must not carry a stale acronym over from a
+     * previously processed entry (regression guard for the v1 "no reset" quirk).
+     */
+    public function testFormatFundingOAForDBv3NullAcronymNotLeakedFromPreviousEntry(): void
+    {
+        $entries = [
+            [
+                'id' => 'corda_______::824087',
+                'code' => '824087',
+                'acronym' => 'EOSC-Pillar',
+                'title' => 'European Open Science Cloud Pillar',
+                'funder' => 'European Commission',
+                'pids' => null,
+            ],
+            [
+                'id' => 'nih_________::01713ce3da46fe56c2b11399f029007c',
+                'code' => '5T15LM007059-20',
+                'acronym' => null,
+                'title' => 'Pittsburgh Biomedical Informatics Training Program',
+                'funder' => 'National Institutes of Health',
+                'pids' => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($entries, [], []);
+
+        self::assertArrayHasKey('acronym', $result[0]);
+        self::assertArrayNotHasKey('acronym', $result[1]);
+    }
+
+    /**
+     * @return array<string, array<int, array<int, array<string, mixed>>>>
+     */
+    public static function sampleOaProjectsV3(): array
+    {
+        return [[[
+            [
+                'id' => 'corda_______::824087',
+                'code' => '824087',
+                'acronym' => 'EOSC-Pillar',
+                'title' => 'European Open Science Cloud Pillar',
+                'funder' => 'European Commission',
+                'pids' => null,
+            ],
+            [
+                'id' => 'anr_________::9fb7cc85ed5f1c9819dd26f41e8528a7',
+                'code' => 'ANR-11-LABX-0010',
+                'acronym' => 'DRIIHM / IRDHEI',
+                'title' => 'Dispositif de recherche interdisciplinaire sur les Interactions Hommes-Milieux',
+                'funder' => 'French National Research Agency (ANR)',
+                'pids' => null,
+            ],
+        ]]];
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_ProjectsManagerTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_ProjectsManagerTest.php
@@ -12,35 +12,6 @@ use PHPUnit\Framework\TestCase;
 final class Episciences_Paper_ProjectsManagerTest extends TestCase {
 
     /**
-     * Legacy v1 relation format (rels.rel with to.@type === 'project'), kept as a
-     * regression test for the fallback path used by residual v1 caches.
-     *
-     * @dataProvider sampleOaProjects
-     * @param $sampleOaProjects
-     * @return void
-     */
-    public function testFormatFundingOAForDB($sampleOaProjects): void {
-        $filterFundingsFromOaApiAndFormatForDB = Episciences_Paper_ProjectsManager::formatFundingOAForDB($sampleOaProjects,[],[]);
-        self::assertIsArray($filterFundingsFromOaApiAndFormatForDB);
-        self::assertCount(2,$filterFundingsFromOaApiAndFormatForDB);
-        // mandatory keys
-
-        self::assertArrayHasKey("projectTitle",$filterFundingsFromOaApiAndFormatForDB[0]);
-        self::assertArrayHasKey("projectTitle",$filterFundingsFromOaApiAndFormatForDB[1]);
-        self::assertArrayHasKey("funderName",$filterFundingsFromOaApiAndFormatForDB[0]);
-        self::assertArrayHasKey("funderName",$filterFundingsFromOaApiAndFormatForDB[1]);
-        self::assertArrayHasKey("code",$filterFundingsFromOaApiAndFormatForDB[0]);
-        self::assertArrayHasKey("code",$filterFundingsFromOaApiAndFormatForDB[1]);
-
-        // extra info if exist
-
-        self::assertArrayNotHasKey("acronym",$filterFundingsFromOaApiAndFormatForDB[0]);
-        self::assertArrayHasKey("acronym",$filterFundingsFromOaApiAndFormatForDB[1]);
-        self::assertEquals("ANR-11-LABX-0010",$filterFundingsFromOaApiAndFormatForDB[1]['code']);
-        self::assertEquals("DRIIHM / IRDHEI",$filterFundingsFromOaApiAndFormatForDB[1]['acronym']);
-    }
-
-    /**
      * OpenAire Graph v3 direct project entries (results[0].projects), the current API format.
      *
      * @dataProvider sampleOaProjectsV3
@@ -48,7 +19,7 @@ final class Episciences_Paper_ProjectsManagerTest extends TestCase {
      * @return void
      */
     public function testFormatFundingOAForDBv3(array $sampleOaProjectsV3): void {
-        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($sampleOaProjectsV3, [], []);
+        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($sampleOaProjectsV3, []);
 
         self::assertCount(2, $result);
 
@@ -88,7 +59,7 @@ final class Episciences_Paper_ProjectsManagerTest extends TestCase {
             ],
         ];
 
-        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($entries, [], []);
+        $result = Episciences_Paper_ProjectsManager::formatFundingOAForDB($entries, []);
 
         self::assertArrayHasKey('acronym', $result[0]);
         self::assertArrayNotHasKey('acronym', $result[1]);
@@ -176,227 +147,6 @@ final class Episciences_Paper_ProjectsManagerTest extends TestCase {
         self::assertArrayHasKey('funderName',$formatAnrHal[0]);
         self::assertEquals('French National Research Agency (ANR)',$formatAnrHal[0]['funderName']);
 
-    }
-
-
-    /**
-     * Open Aire sample ANR funding (same thing for European)
-     * @return array
-     */
-    public static function sampleOaProjects(): array {
-        return [[json_decode('{
-  "0": {
-    "@inferred": true,
-    "@trust": "0.72",
-    "@inferenceprovenance": "iis::document_referencedProjects",
-    "@provenanceaction": "iis",
-    "to": {
-      "@class": "isProducedBy",
-      "@scheme": "dnet:result_project_relations",
-      "@type": "project",
-      "$": "nserc_______::1e5e62235d094afd01cd56e65112fc63"
-    },
-    "title": {
-      "$": "unidentified"
-    },
-    "code": {
-      "$": "unidentified"
-    },
-    "funding": {
-      "funder": {
-        "@id": "nserc_______::NSERC",
-        "@shortname": "NSERC",
-        "@name": "Natural Sciences and Engineering Research Council of Canada",
-        "@jurisdiction": "CA"
-      }
-    }
-  },
-  "1": {
-    "@inferred": true,
-    "@trust": "0.85",
-    "@inferenceprovenance": "propagation",
-    "@provenanceaction": "result:organization:instrepo",
-    "to": {
-      "@class": "hasAuthorInstitution",
-      "@scheme": "dnet:result_organization_relations",
-      "@type": "organization",
-      "$": "openorgs____::c80a8243a5e5c620d7931c88d93bf17a"
-    },
-    "country": {
-      "@classid": "FR",
-      "@classname": "France",
-      "@schemeid": "dnet:countries",
-      "@schemename": "dnet:countries"
-    },
-    "legalname": {
-      "$": "Université Paris Diderot"
-    },
-    "legalshortname": {
-      "$": "Université Paris Diderot"
-    }
-  },
-  "2": {
-    "@inferred": true,
-    "@trust": "0.9",
-    "@inferenceprovenance": "iis::document_similarities_standard",
-    "@provenanceaction": "iis",
-    "to": {
-      "@class": "IsAmongTopNSimilarDocuments",
-      "@scheme": "dnet:result_result_relations",
-      "@type": "publication",
-      "$": "doi_dedup___::d7f1413afbde675d1bce14a2ecabf9b4"
-    },
-    "collectedfrom": {
-      "0": {
-        "@name": "Hyper Article en Ligne - Sciences de l\'Homme et de la Société",
-        "@id": "opendoar____::96da2f590cd7246bbde0051047b0d6f7"
-      },
-      "1": {
-        "@name": "HAL-Pasteur",
-        "@id": "opendoar____::2cad8fa47bbef282badbb8de5374b894"
-      },
-      "2": {
-        "@name": "HAL-Inserm",
-        "@id": "opendoar____::d9731321ef4e063ebbee79298fa36f56"
-      },
-      "3": {
-        "@name": "Mémoires en Sciences de l\'Information et de la Communication",
-        "@id": "opendoar____::1534b76d325a8f591b52d302e7181331"
-      },
-      "4": {
-        "@name": "HAL - UPEC / UPEM",
-        "@id": "opendoar____::d3e8fc83b3e886a0dc2aa9845a5215bf"
-      },
-      "5": {
-        "@name": "Hyper Article en Ligne",
-        "@id": "opendoar____::7e7757b1e12abcb736ab9a754ffb617a"
-      },
-      "6": {
-        "@name": "UnpayWall",
-        "@id": "openaire____::8ac8380272269217cb09a928c8caa993"
-      },
-      "7": {
-        "@name": "ORCID",
-        "@id": "openaire____::806360c771262b4d6770e7cdf04b5c5a"
-      },
-      "8": {
-        "@name": "Hal-Diderot",
-        "@id": "opendoar____::18bb68e2b38e4a8ce7cf4f6b2625768c"
-      },
-      "9": {
-        "@name": "Crossref",
-        "@id": "openaire____::081b82f96300b6a6e3d282bad31cb6e2"
-      },
-      "10": {
-        "@name": "HAL Clermont Université",
-        "@id": "opendoar____::e98741479a7b998f88b8f8c9f0b6b6f1"
-      },
-      "11": {
-        "@name": "Microsoft Academic Graph",
-        "@id": "openaire____::5f532a3fc4f1ea403f37070f59a7a53a"
-      }
-    },
-    "pid": {
-      "@classid": "doi",
-      "@classname": "Digital Object Identifier",
-      "@schemeid": "dnet:pid_types",
-      "@schemename": "dnet:pid_types",
-      "$": "10.1080/11956860.2018.1542783"
-    },
-    "dateofacceptance": {
-      "$": "2018-01-31"
-    },
-    "publisher": {
-      "$": "HAL CCSD"
-    },
-    "title": {
-      "@classid": "alternative title",
-      "@classname": "alternative title",
-      "@schemeid": "dnet:dataCite_title",
-      "@schemename": "dnet:dataCite_title",
-      "$": "OHMi-Nunavik: a multi-thematic and cross-cultural research program studying the cumulative effects of climate and socio-economic changes on Inuit communities"
-    }
-  },
-  "3": {
-    "@inferred": true,
-    "@trust": "0.72",
-    "@inferenceprovenance": "iis::document_referencedProjects",
-    "@provenanceaction": "iis",
-    "to": {
-      "@class": "isProducedBy",
-      "@scheme": "dnet:result_project_relations",
-      "@type": "project",
-      "$": "anr_________::9fb7cc85ed5f1c9819dd26f41e8528a7"
-    },
-    "code": {
-      "$": "ANR-11-LABX-0010"
-    },
-    "acronym": {
-      "$": "DRIIHM / IRDHEI"
-    },
-    "title": {
-      "$": "Dispositif de recherche interdisciplinaire sur les Interactions Hommes-Milieux"
-    },
-    "funding": {
-      "funder": {
-        "@id": "anr_________::ANR",
-        "@shortname": "ANR",
-        "@name": "French National Research Agency (ANR)",
-        "@jurisdiction": "FR"
-      }
-    }
-  },
-  "4": {
-    "@inferred": true,
-    "@trust": "0.9",
-    "@inferenceprovenance": "iis::document_similarities_standard",
-    "@provenanceaction": "iis",
-    "to": {
-      "@class": "IsAmongTopNSimilarDocuments",
-      "@scheme": "dnet:result_result_relations",
-      "@type": "otherresearchproduct",
-      "$": "dedup_wf_001::ac6050cff2576c4ed3a7f774a18b70c2"
-    },
-    "dateofacceptance": {
-      "$": "2021-09-06"
-    },
-    "collectedfrom": {
-      "0": {
-        "@name": "Hyper Article en Ligne - Sciences de l\'Homme et de la Société",
-        "@id": "opendoar____::96da2f590cd7246bbde0051047b0d6f7"
-      },
-      "1": {
-        "@name": "Mémoires en Sciences de l\'Information et de la Communication",
-        "@id": "opendoar____::1534b76d325a8f591b52d302e7181331"
-      },
-      "2": {
-        "@name": "Hal-Diderot",
-        "@id": "opendoar____::18bb68e2b38e4a8ce7cf4f6b2625768c"
-      },
-      "3": {
-        "@name": "Hyper Article en Ligne",
-        "@id": "opendoar____::7e7757b1e12abcb736ab9a754ffb617a"
-      },
-      "4": {
-        "@name": "HAL AMU",
-        "@id": "opendoar____::2d2c8394e31101a261abf1784302bf75"
-      }
-    },
-    "title": {
-      "@classid": "main title",
-      "@classname": "main title",
-      "@schemeid": "dnet:dataCite_title",
-      "@schemename": "dnet:dataCite_title",
-      "@inferred": false,
-      "@provenanceaction": "sysimport:crosswalk:repository",
-      "@trust": "0.9",
-      "$": "OHMi Patagonia - Bahia Exploradores (Chili)"
-    },
-    "publisher": {
-      "$": "HAL CCSD"
-    }
-  }
-}',true, 512, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE)]];
     }
 
     /**

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Projects_EnrichmentServiceTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Projects_EnrichmentServiceTest.php
@@ -93,69 +93,6 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
-    // formatFundingOAForDB()
-    // -------------------------------------------------------------------------
-
-    public function testFormatFundingOAForDBExtractsProjectTypeRelationsOnly(): void
-    {
-        $fileFound = [
-            [
-                'to'      => ['@type' => 'project'],
-                'title'   => ['$' => 'Test Project'],
-                'code'    => ['$' => 'CODE-001'],
-                'funding' => ['funder' => ['@name' => 'Test Funder']],
-            ],
-            [
-                // type is 'organization' → must be ignored
-                'to' => ['@type' => 'organization'],
-                'title' => ['$' => 'Should be ignored'],
-                'funding' => ['funder' => ['@name' => 'Should be ignored']],
-            ],
-        ];
-
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
-
-        self::assertCount(1, $result);
-        self::assertSame('Test Project', $result[0]['projectTitle']);
-        self::assertSame('Test Funder', $result[0]['funderName']);
-        self::assertSame('CODE-001', $result[0]['code']);
-    }
-
-    public function testFormatFundingOAForDBIgnoresNonProjectRelations(): void
-    {
-        $fileFound = [
-            [
-                'to'      => ['@type' => 'publication'],
-                'title'   => ['$' => 'A paper'],
-                'funding' => [],
-            ],
-        ];
-
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
-
-        self::assertSame([], $result);
-    }
-
-    public function testFormatFundingOAForDBPreservesExistingGlobalArray(): void
-    {
-        $existing = [['projectTitle' => 'Existing Project', 'funderName' => 'Existing Funder', 'code' => 'EX-001']];
-        $fileFound = [
-            [
-                'to'      => ['@type' => 'project'],
-                'title'   => ['$' => 'New Project'],
-                'code'    => ['$' => 'NEW-001'],
-                'funding' => ['funder' => ['@name' => 'New Funder']],
-            ],
-        ];
-
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], $existing);
-
-        self::assertCount(2, $result);
-        self::assertSame('Existing Project', $result[0]['projectTitle']);
-        self::assertSame('New Project', $result[1]['projectTitle']);
-    }
-
-    // -------------------------------------------------------------------------
     // formatFundingOAForDB() — OpenAire Graph v3 direct project entries
     // -------------------------------------------------------------------------
 
@@ -172,7 +109,7 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
             ],
         ];
 
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, []);
 
         self::assertCount(1, $result);
         self::assertSame('European Open Science Cloud Pillar', $result[0]['projectTitle']);
@@ -194,7 +131,7 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
             ],
         ];
 
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, []);
 
         self::assertCount(1, $result);
         self::assertArrayNotHasKey('acronym', $result[0]);
@@ -212,7 +149,7 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
             ],
         ];
 
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, []);
 
         self::assertSame('European Commission', $result[0]['funderName']);
     }
@@ -236,10 +173,42 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
             ],
         ];
 
-        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, []);
 
         self::assertCount(2, $result);
         self::assertSame('EOSC-Pillar', $result[0]['acronym']);
         self::assertSame('DRIIHM / IRDHEI', $result[1]['acronym']);
+    }
+
+    public function testFormatFundingOAForDBv3IgnoresEntriesWithoutScalarTitle(): void
+    {
+        $fileFound = [
+            ['code' => 'CODE-001', 'title' => ['$' => 'legacy-shaped title, must be ignored']],
+            ['code' => 'CODE-002'], // no 'title' key at all
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, []);
+
+        self::assertSame([], $result);
+    }
+
+    public function testFormatFundingOAForDBv3PreservesExistingGlobalArray(): void
+    {
+        $existing = [['projectTitle' => 'Existing Project', 'funderName' => 'Existing Funder', 'code' => 'EX-001']];
+        $fileFound = [
+            [
+                'code'    => 'NEW-001',
+                'acronym' => null,
+                'title'   => 'New Project',
+                'funder'  => 'New Funder',
+                'pids'    => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, $existing);
+
+        self::assertCount(2, $result);
+        self::assertSame('Existing Project', $result[0]['projectTitle']);
+        self::assertSame('New Project', $result[1]['projectTitle']);
     }
 }

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_Projects_EnrichmentServiceTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_Projects_EnrichmentServiceTest.php
@@ -154,4 +154,92 @@ final class Episciences_Paper_Projects_EnrichmentServiceTest extends TestCase
         self::assertSame('Existing Project', $result[0]['projectTitle']);
         self::assertSame('New Project', $result[1]['projectTitle']);
     }
+
+    // -------------------------------------------------------------------------
+    // formatFundingOAForDB() — OpenAire Graph v3 direct project entries
+    // -------------------------------------------------------------------------
+
+    public function testFormatFundingOAForDBv3MapsDirectScalarFields(): void
+    {
+        $fileFound = [
+            [
+                'id'      => 'corda_______::824087',
+                'code'    => '824087',
+                'acronym' => 'EOSC-Pillar',
+                'title'   => 'European Open Science Cloud Pillar',
+                'funder'  => 'European Commission',
+                'pids'    => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+
+        self::assertCount(1, $result);
+        self::assertSame('European Open Science Cloud Pillar', $result[0]['projectTitle']);
+        self::assertSame('824087', $result[0]['code']);
+        self::assertSame('EOSC-Pillar', $result[0]['acronym']);
+        self::assertSame('European Commission', $result[0]['funderName']);
+    }
+
+    public function testFormatFundingOAForDBv3NullAcronymOmitted(): void
+    {
+        $fileFound = [
+            [
+                'id'      => 'nih_________::01713ce3da46fe56c2b11399f029007c',
+                'code'    => '5T15LM007059-20',
+                'acronym' => null,
+                'title'   => 'Pittsburgh Biomedical Informatics Training Program',
+                'funder'  => 'National Institutes of Health',
+                'pids'    => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+
+        self::assertCount(1, $result);
+        self::assertArrayNotHasKey('acronym', $result[0]);
+    }
+
+    public function testFormatFundingOAForDBv3FunderAsDataModelObject(): void
+    {
+        $fileFound = [
+            [
+                'code'    => '824087',
+                'acronym' => null,
+                'title'   => 'European Open Science Cloud Pillar',
+                'funder'  => ['name' => 'European Commission', 'shortName' => 'EC'],
+                'pids'    => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+
+        self::assertSame('European Commission', $result[0]['funderName']);
+    }
+
+    public function testFormatFundingOAForDBv3MultipleProjectsMapped(): void
+    {
+        $fileFound = [
+            [
+                'code'    => '824087',
+                'acronym' => 'EOSC-Pillar',
+                'title'   => 'European Open Science Cloud Pillar',
+                'funder'  => 'European Commission',
+                'pids'    => null,
+            ],
+            [
+                'code'    => 'ANR-11-LABX-0010',
+                'acronym' => 'DRIIHM / IRDHEI',
+                'title'   => 'Dispositif de recherche interdisciplinaire sur les Interactions Hommes-Milieux',
+                'funder'  => 'French National Research Agency (ANR)',
+                'pids'    => null,
+            ],
+        ];
+
+        $result = Episciences_Paper_Projects_EnrichmentService::formatFundingOAForDB($fileFound, [], []);
+
+        self::assertCount(2, $result);
+        self::assertSame('EOSC-Pillar', $result[0]['acronym']);
+        self::assertSame('DRIIHM / IRDHEI', $result[1]['acronym']);
+    }
 }

--- a/tests/unit/scripts/ClearOpenAireCacheCommandTest.php
+++ b/tests/unit/scripts/ClearOpenAireCacheCommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace unit\scripts;
+
+use ClearOpenAireCacheCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputDefinition;
+
+require_once __DIR__ . '/../../../scripts/ClearOpenAireCacheCommand.php';
+
+/**
+ * Unit tests for ClearOpenAireCacheCommand.
+ *
+ * Focuses on command metadata (no bootstrap, no DB, no filesystem access).
+ */
+class ClearOpenAireCacheCommandTest extends TestCase
+{
+    private ClearOpenAireCacheCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new ClearOpenAireCacheCommand();
+    }
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('enrichment:clear-cache', $this->command->getName());
+    }
+
+    public function testCommandHasNoOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertInstanceOf(InputDefinition::class, $definition);
+        $this->assertSame([], $definition->getOptions());
+    }
+
+    public function testCommandHasDescription(): void
+    {
+        $this->assertNotSame('', $this->command->getDescription());
+    }
+}


### PR DESCRIPTION
## Summary
- Migrate `OpenAireApiClient` from the retired v1 search API to the OpenAIRE Graph v3 REST API (`?pid=`, native JSON: `authors[].fullName+pid.id`, `projects[]`, `subjects[].subject.scheme/value`). `EnrichmentService::formatFundingOAForDB` maps the new v3 project shape while keeping the v1 relation format as a fallback for residual caches.
- Add bi-mode operation per the [OpenAIRE Graph terms](https://graph.openaire.eu/docs/apis/terms#authentication--limits): authenticated mode (OAuth2 client-credentials via the new `OpenAireTokenProvider`, cached bearer token, 500ms throttle, 7200 req/h quota) with a graceful anonymous fallback (60s throttle, 60 req/h quota) when `OPENAIRE_CLIENT_ID`/`SECRET` aren't configured. Reactive 401 (token refresh + single retry) and 429 (backoff up to 3 attempts, then `CRITICAL` log + skip that paper) handling, plus `x-ratelimit-*` header logging.
- `GetClassificationJelCommand` gains `--doi`/`--paperid`/`--no-cache` for parity with the other two enrichment commands, and now goes through `OpenAireApiClient::create()` (so it also gets authenticated mode) instead of wiring its HTTP client by hand.
- Add `enrichment:clear-cache` command to purge the three enrichment cache pools in one shot (no API calls) — needed because cache keys carry no version marker, so a hit on a pre-migration entry would otherwise silently hand v1-shaped JSON to the new v3 parsing code.
- `Episciences_OpenAireResearchGraphTools` (confirmed unused in any production path — only referenced by its own tests and one already-`@deprecated` method call) is marked `@deprecated` rather than migrated.
- Config: add `OPENAIRE.{AUTH_URL,API_URL,CLIENT_ID,CLIENT_SECRET}` to both `pwd.json` templates (empty in dev → anonymous mode by default) and declare the constants in `const.php` for static analysis.

## Test plan
- [x] `OpenAireApiClientTest` (v3 extraction + bi-mode auth/throttle/401/429/rate-limit-header tests, no real sleeps via an overridable throttle seam)
- [x] `OpenAireTokenProviderTest` (token acquisition, caching/TTL, graceful degradation when unconfigured, error handling)
- [x] `Episciences_Paper_Projects_EnrichmentServiceTest` / `Episciences_Paper_ProjectsManagerTest` (v3 funding mapping + v1 fallback regression)
- [x] `GetClassificationJelCommandTest`, `GetCreatorDataCommandTest`, `ClearOpenAireCacheCommandTest`
- [x] PHPStan level 6 clean on all new/modified files
- [x] `enrichment:clear-cache` run end-to-end in the dev container
- [ ] Manual smoke test against the real OpenAIRE Graph v3 API with real client credentials in a deploy environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAIRE Research Graph v3 publication, author, funding and JEL data.
  - Added optional authenticated access with token caching and anonymous fallback.
  - Added targeted classification lookups by DOI or paper ID, including optional cache bypass.
  - Added a command to clear OpenAIRE enrichment caches.

- **Bug Fixes**
  - Improved funding mapping, ORCID matching and malformed-response handling.
  - Improved throttling, retries, rate-limit handling and token refresh.

- **Documentation**
  - Marked the retired OpenAIRE Graph v1 integration as deprecated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->