### PR TITLE
fix(notify): fix COAR Notify inbox processing bugs

### DIFF
--- a/library/Episciences/Notify/Notification.php
+++ b/library/Episciences/Notify/Notification.php
@@ -9,8 +9,15 @@ class Notification
     public const DIRECTION_INBOUND  = 'INBOUND';
     public const DIRECTION_OUTBOUND = 'OUTBOUND';
 
-    public const STATUS_PENDING = 0;
-    public const STATUS_FAILED  = -1;
+    public const STATUS_PENDING  = 0;
+    public const STATUS_FAILED   = -1;
+
+    /**
+     * The notification is moot, not erroneous: the state it describes has
+     * already been superseded (e.g. this paper version was already applied
+     * or a newer one already exists). Excluded from future inbound fetches.
+     */
+    public const STATUS_OUTDATED = -2;
 
     private string $id;
     private string $fromId;

--- a/library/Episciences/Notify/NotificationsRepository.php
+++ b/library/Episciences/Notify/NotificationsRepository.php
@@ -37,14 +37,17 @@ class NotificationsRepository
      */
     public function findInbound(int $limit = self::MAX_INBOUND_FETCH): array
     {
+        // Outdated notifications are permanently moot (the state they describe was
+        // already superseded) and are excluded so they are not refetched forever.
         $sql = 'SELECT id, fromId, toId, inReplyToId, type, status, timestamp, original, direction
                 FROM notifications
-                WHERE direction = :direction
+                WHERE direction = :direction AND status != :statusOutdated
                 ORDER BY timestamp DESC
                 LIMIT :limit';
 
         $stmt = $this->pdo->prepare($sql);
         $stmt->bindValue(':direction', Notification::DIRECTION_INBOUND, \PDO::PARAM_STR);
+        $stmt->bindValue(':statusOutdated', Notification::STATUS_OUTDATED, \PDO::PARAM_INT);
         $stmt->bindValue(':limit', $limit, \PDO::PARAM_INT);
         $stmt->execute();
 
@@ -78,6 +81,15 @@ class NotificationsRepository
     {
         $sql = 'DELETE FROM notifications WHERE id = :id';
         $stmt = $this->pdo->prepare($sql);
+        $stmt->bindValue(':id', $id, \PDO::PARAM_STR);
+        $stmt->execute();
+    }
+
+    public function updateStatus(string $id, int $status): void
+    {
+        $sql = 'UPDATE notifications SET status = :status WHERE id = :id';
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->bindValue(':status', $status, \PDO::PARAM_INT);
         $stmt->bindValue(':id', $id, \PDO::PARAM_STR);
         $stmt->execute();
     }

--- a/library/Episciences/Notify/NotifySourceConfig.php
+++ b/library/Episciences/Notify/NotifySourceConfig.php
@@ -13,18 +13,20 @@ namespace Episciences\Notify;
 final class NotifySourceConfig
 {
     /**
-     * @param int      $repoId        Internal Episciences repository ID.
-     * @param string   $label         Human-readable label (e.g. 'HAL', 'Zenodo').
-     * @param string   $originId      Repository home URL (e.g. 'https://hal.science/').
-     * @param string   $originInbox   Inbox URL used to identify this source in payloads.
-     * @param string[] $acceptedTypes COAR Notify types this source may send.
+     * @param int        $repoId        Internal Episciences repository ID.
+     * @param string     $label         Human-readable label (e.g. 'HAL', 'Zenodo').
+     * @param string     $originId      Repository home URL (e.g. 'https://hal.science/').
+     * @param string     $originInbox   Inbox URL used to identify this source in payloads.
+     * @param string[][] $acceptedTypes List of accepted COAR Notify type patterns (e.g.
+     *                                  Request Review vs Request Endorsement); a payload
+     *                                  matching any one of these patterns is accepted.
      */
     public function __construct(
         private readonly int    $repoId,
         private readonly string $label,
         private readonly string $originId,
         private readonly string $originInbox,
-        private readonly array  $acceptedTypes = ['Offer', 'coar-notify:ReviewAction'],
+        private readonly array  $acceptedTypes = [['Offer', 'coar-notify:ReviewAction']],
     ) {}
 
     public function getRepoId(): int
@@ -47,7 +49,7 @@ final class NotifySourceConfig
         return $this->originInbox;
     }
 
-    /** @return string[] */
+    /** @return string[][] */
     public function getAcceptedTypes(): array
     {
         return $this->acceptedTypes;

--- a/library/Episciences/Notify/NotifySourceRegistry.php
+++ b/library/Episciences/Notify/NotifySourceRegistry.php
@@ -40,7 +40,10 @@ final class NotifySourceRegistry
                 label:         'HAL',
                 originId:      NOTIFY_TARGET_HAL_URL,
                 originInbox:   NOTIFY_TARGET_HAL_INBOX,
-                acceptedTypes: ['Offer', 'coar-notify:ReviewAction'],
+                acceptedTypes: [
+                    ['Offer', 'coar-notify:ReviewAction'],
+                    ['Offer', 'coar-notify:EndorsementAction'],
+                ],
             );
         }
 

--- a/library/Episciences/Notify/PayloadValidator.php
+++ b/library/Episciences/Notify/PayloadValidator.php
@@ -104,21 +104,35 @@ final class PayloadValidator
         if (empty($payload['object']['type'])) {
             return ValidationResult::failure("'object.type' is required");
         }
-        $ietfItem = $payload['object']['ietf:item'] ?? null;
-        if (!is_array($ietfItem)) {
-            return ValidationResult::failure("'object.ietf:item' is required");
+
+        $warnings = [];
+        $itemField = 'ietf:item';
+        $item      = $payload['object']['ietf:item'] ?? null;
+        if (!is_array($item)) {
+            // Some senders (e.g. HAL) put the item descriptor under 'object.url'
+            // instead of the spec-preferred 'object.ietf:item'. Tolerate it so the
+            // notification can still be processed, but flag the deviation so it
+            // can be reported back to the sender.
+            $item      = $payload['object']['url'] ?? null;
+            $itemField = 'url';
+            if (is_array($item)) {
+                $warnings[] = "'object.ietf:item' is missing; accepted non-conformant 'object.url' as a fallback";
+            }
         }
-        $ietfItemId = $ietfItem['id'] ?? null;
-        if ($ietfItemId === null || !filter_var($ietfItemId, FILTER_VALIDATE_URL)) {
+        if (!is_array($item)) {
+            return ValidationResult::failure("'object.ietf:item' (or 'object.url' fallback) is required");
+        }
+        $itemId = $item['id'] ?? null;
+        if ($itemId === null || !filter_var($itemId, FILTER_VALIDATE_URL)) {
             return ValidationResult::failure(
-                sprintf("'object.ietf:item.id' must be an HTTP URI: %s", $ietfItemId ?? 'null')
+                sprintf("'object.%s.id' must be an HTTP URI: %s", $itemField, $itemId ?? 'null')
             );
         }
-        if (empty($ietfItem['type'])) {
-            return ValidationResult::failure("'object.ietf:item.type' is required");
+        if (empty($item['type'])) {
+            return ValidationResult::failure(sprintf("'object.%s.type' is required", $itemField));
         }
-        if (empty($ietfItem['mediaType'])) {
-            return ValidationResult::failure("'object.ietf:item.mediaType' is required");
+        if (empty($item['mediaType'])) {
+            return ValidationResult::failure(sprintf("'object.%s.mediaType' is required", $itemField));
         }
 
         // --- target ----------------------------------------------------------
@@ -144,6 +158,6 @@ final class PayloadValidator
             );
         }
 
-        return ValidationResult::success();
+        return ValidationResult::success($warnings);
     }
 }

--- a/library/Episciences/Notify/ValidationResult.php
+++ b/library/Episciences/Notify/ValidationResult.php
@@ -9,14 +9,17 @@ namespace Episciences\Notify;
  */
 final class ValidationResult
 {
+    /** @param string[] $warnings Non-blocking deviations from spec tolerated during validation. */
     private function __construct(
         private readonly bool    $valid,
-        private readonly ?string $errorMessage = null
+        private readonly ?string $errorMessage = null,
+        private readonly array   $warnings = []
     ) {}
 
-    public static function success(): self
+    /** @param string[] $warnings */
+    public static function success(array $warnings = []): self
     {
-        return new self(true);
+        return new self(true, null, $warnings);
     }
 
     public static function failure(string $message): self
@@ -32,5 +35,11 @@ final class ValidationResult
     public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
+    }
+
+    /** @return string[] */
+    public function getWarnings(): array
+    {
+        return $this->warnings;
     }
 }

--- a/scripts/ProcessInboxNotificationsCommand.php
+++ b/scripts/ProcessInboxNotificationsCommand.php
@@ -224,6 +224,17 @@ class ProcessInboxNotificationsCommand extends Command
 
         try {
             $notifyPayloads = json_decode($nOriginal, true, 512, JSON_THROW_ON_ERROR);
+
+            // Some notifications are stored double-JSON-encoded by the inbox writer
+            // (the "original" column holds a JSON string of the JSON payload), in
+            // which case the first decode only yields the inner JSON as a string.
+            if (is_string($notifyPayloads)) {
+                $notifyPayloads = json_decode($notifyPayloads, true, 512, JSON_THROW_ON_ERROR);
+            }
+
+            if (!is_array($notifyPayloads)) {
+                throw new \JsonException('Decoded payload is not an object/array');
+            }
         } catch (\JsonException $e) {
             $logger->critical(sprintf(
                 'Notification [%s] contains invalid JSON payload: %s. Raw snippet: %.250s',

--- a/scripts/ProcessInboxNotificationsCommand.php
+++ b/scripts/ProcessInboxNotificationsCommand.php
@@ -85,6 +85,9 @@ class ProcessInboxNotificationsCommand extends Command
             $io->note('Dry-run mode enabled — no database writes or emails will be dispatched.');
         }
 
+        // Constants (incl. EPISCIENCES_LOG_PATH) must be defined before the logger is built
+        $this->bootstrapConstants();
+
         $logger = new Logger('inboxNotifications');
         $logger->pushHandler(new StreamHandler(
             EPISCIENCES_LOG_PATH . 'inboxNotifications_' . date('Y-m-d') . '.log',
@@ -1587,7 +1590,7 @@ class ProcessInboxNotificationsCommand extends Command
     // Bootstrap
     // -------------------------------------------------------------------------
 
-    private function bootstrap(): void
+    private function bootstrapConstants(): void
     {
         if (!defined('APPLICATION_PATH')) {
             define('APPLICATION_PATH', realpath(__DIR__ . '/../application'));
@@ -1601,14 +1604,22 @@ class ProcessInboxNotificationsCommand extends Command
         defineApplicationConstants();
         defineJournalConstants();
 
+        // Include path and fallback autoloader must be set up before any Episciences_*
+        // or namespaced Episciences\* class (e.g. AppRegistry) can be autoloaded.
         $libraries = [realpath(APPLICATION_PATH . '/../library')];
         set_include_path(implode(PATH_SEPARATOR, array_merge($libraries, [get_include_path()])));
         require_once 'Zend/Application.php';
 
-        $application = new Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
-
         $autoloader = Zend_Loader_Autoloader::getInstance();
         $autoloader->setFallbackAutoloader(true);
+    }
+
+    private function bootstrap(): void
+    {
+        // Constants, include path and the fallback autoloader are already set up by
+        // bootstrapConstants(), called earlier in execute() to build the logger.
+
+        $application = new Zend_Application('production', APPLICATION_PATH . '/configs/application.ini');
 
         $db = Zend_Db::factory('PDO_MYSQL', $application->getOption('resources')['db']['params']);
         Zend_Db_Table::setDefaultAdapter($db);

--- a/scripts/ProcessInboxNotificationsCommand.php
+++ b/scripts/ProcessInboxNotificationsCommand.php
@@ -327,6 +327,14 @@ class ProcessInboxNotificationsCommand extends Command
                 ->validate($notifyPayloads);
 
             if ($result->isValid()) {
+                foreach ($result->getWarnings() as $warning) {
+                    $logger?->warning(sprintf(
+                        'Notification [%s] accepted from a non-conformant payload: %s',
+                        $notifyPayloads['id'] ?? 'unknown',
+                        $warning
+                    ));
+                }
+
                 return true;
             }
         }

--- a/scripts/ProcessInboxNotificationsCommand.php
+++ b/scripts/ProcessInboxNotificationsCommand.php
@@ -53,6 +53,13 @@ class ProcessInboxNotificationsCommand extends Command
 
     private PreprintUrlParser $urlParser;
 
+    /**
+     * Set when the current notification was rejected because the state it
+     * describes is already superseded (not a genuine processing error).
+     * @see notificationsProcess()
+     */
+    private bool $isOutdatedNotification = false;
+
     public function __construct()
     {
         parent::__construct();
@@ -154,9 +161,10 @@ class ProcessInboxNotificationsCommand extends Command
 
         $io->progressStart($count);
 
-        $successCount = 0;
-        $failedCount  = 0;
-        $deletedCount = 0;
+        $successCount  = 0;
+        $failedCount   = 0;
+        $deletedCount  = 0;
+        $outdatedCount = 0;
 
         foreach ($notifications as $index => $notification) {
             $notifId = $notification->getId();
@@ -180,6 +188,19 @@ class ProcessInboxNotificationsCommand extends Command
                             ]);
                         }
                     }
+                } elseif ($this->isOutdatedNotification) {
+                    $outdatedCount++;
+                    $logger->info(sprintf('Notification ID %s is outdated (already superseded); excluding it from future runs.', $notifId));
+
+                    if (!$isDryRun) {
+                        try {
+                            $reader->getRepository()->updateStatus($notifId, Notification::STATUS_OUTDATED);
+                        } catch (\Throwable $statusEx) {
+                            $logger->error(sprintf('Failed to mark notification ID %s as outdated: %s', $notifId, $statusEx->getMessage()), [
+                                'trace' => $statusEx->getTraceAsString(),
+                            ]);
+                        }
+                    }
                 } else {
                     $failedCount++;
                     $logger->warning(sprintf('Notification ID %s could not be processed.', $notifId));
@@ -200,12 +221,16 @@ class ProcessInboxNotificationsCommand extends Command
         $io->progressFinish();
 
         $io->table(
-            ['Total', 'Succeeded', 'Failed / Skipped', 'Deleted from inbox'],
-            [[$count, $successCount, $failedCount, $deletedCount]]
+            ['Total', 'Succeeded', 'Outdated', 'Failed', 'Deleted from inbox'],
+            [[$count, $successCount, $outdatedCount, $failedCount, $deletedCount]]
         );
 
+        if ($outdatedCount > 0) {
+            $io->note(sprintf('%d notification(s) were outdated (already superseded) and excluded from future runs.', $outdatedCount));
+        }
+
         if ($failedCount > 0) {
-            $io->warning(sprintf('%d notification(s) failed or were skipped. Check log file for details.', $failedCount));
+            $io->warning(sprintf('%d notification(s) failed. Check log file for details.', $failedCount));
         } else {
             $io->success('All notifications processed successfully.');
         }
@@ -219,6 +244,8 @@ class ProcessInboxNotificationsCommand extends Command
         LoggerInterface      $logger,
         bool                 $isDryRun = false
     ): bool {
+        $this->isOutdatedNotification = false;
+
         $nOriginal = $notification->getOriginal();
         $notifId   = $notification->getId();
 
@@ -505,7 +532,14 @@ class ProcessInboxNotificationsCommand extends Command
 
         $logger->info(sprintf('Notification [%s]: version check status: %s', $notifId, $newVerErrors['message']));
 
-        return (bool) ($newVerErrors['canBeReplaced'] || isset($newVerErrors[self::PAPER_CONTEXT]));
+        $canApply = (bool) ($newVerErrors['canBeReplaced'] || isset($newVerErrors[self::PAPER_CONTEXT]));
+
+        if (!$canApply) {
+            // Not an error: this version was already applied, there is nothing to do.
+            $this->isOutdatedNotification = true;
+        }
+
+        return $canApply;
     }
 
     /**
@@ -543,8 +577,10 @@ class ProcessInboxNotificationsCommand extends Command
             }
 
             if ($context !== null && $context->getVersion() >= $paper->getVersion()) {
+                // Not an error: this version was already applied, there is nothing to do.
+                $this->isOutdatedNotification = true;
                 if ($logger !== null) {
-                    $logger->warning(sprintf('Abort processing paper %s: identical or older version (%d <= %d).', $data['identifier'], $paper->getVersion(), $context->getVersion()));
+                    $logger->info(sprintf('Skipping paper %s: identical or older version (%d <= %d).', $data['identifier'], $paper->getVersion(), $context->getVersion()));
                 }
                 return false;
             }

--- a/scripts/ProcessInboxNotificationsCommand.php
+++ b/scripts/ProcessInboxNotificationsCommand.php
@@ -317,27 +317,29 @@ class ProcessInboxNotificationsCommand extends Command
      */
     public function checkNotifyPayloads(array $notifyPayloads, NotifySourceConfig $source, ?LoggerInterface $logger = null): bool
     {
-        $domain    = defined('DOMAIN') ? DOMAIN : 'episciences.org';
-        $validator = new PayloadValidator(
-            $source->getAcceptedTypes(),
-            $source->getOriginInbox(),
-            $domain
-        );
+        $domain = defined('DOMAIN') ? DOMAIN : 'episciences.org';
+        $result = null;
 
-        $result = $validator->validate($notifyPayloads);
+        // A source may accept several COAR Notify patterns (e.g. Request Review vs
+        // Request Endorsement); the payload is valid if it matches any one of them.
+        foreach ($source->getAcceptedTypes() as $typePattern) {
+            $result = (new PayloadValidator($typePattern, $source->getOriginInbox(), $domain))
+                ->validate($notifyPayloads);
 
-        if (!$result->isValid()) {
-            $msg = sprintf(
-                'Notification payload validation failed for payload ID "%s": %s',
-                $notifyPayloads['id'] ?? 'unknown',
-                $result->getErrorMessage()
-            );
-            if ($logger !== null) {
-                $logger->warning($msg);
+            if ($result->isValid()) {
+                return true;
             }
         }
 
-        return $result->isValid();
+        if ($result !== null && $logger !== null) {
+            $logger->warning(sprintf(
+                'Notification payload validation failed for payload ID "%s": %s',
+                $notifyPayloads['id'] ?? 'unknown',
+                $result->getErrorMessage()
+            ));
+        }
+
+        return false;
     }
 
     /**

--- a/tests/unit/library/Episciences/notify/Episciences_Notify_NotificationsRepositoryTest.php
+++ b/tests/unit/library/Episciences/notify/Episciences_Notify_NotificationsRepositoryTest.php
@@ -23,9 +23,9 @@ class Episciences_Notify_NotificationsRepositoryTest extends TestCase
             ]
         ];
 
-        // bindValue is called twice: once for :direction, once for :limit
+        // bindValue is called three times: :direction, :statusOutdated, :limit
         $stmt = $this->createMock(\PDOStatement::class);
-        $stmt->expects(self::exactly(2))
+        $stmt->expects(self::exactly(3))
             ->method('bindValue');
         $stmt->expects(self::once())
             ->method('execute');
@@ -37,7 +37,10 @@ class Episciences_Notify_NotificationsRepositoryTest extends TestCase
         $pdo = $this->createMock(\PDO::class);
         $pdo->expects(self::once())
             ->method('prepare')
-            ->with(self::stringContains('WHERE direction = :direction'))
+            ->with(self::logicalAnd(
+                self::stringContains('WHERE direction = :direction'),
+                self::stringContains('status != :statusOutdated')
+            ))
             ->willReturn($stmt);
 
         $repository = new NotificationsRepository($pdo);
@@ -113,5 +116,23 @@ class Episciences_Notify_NotificationsRepositoryTest extends TestCase
 
         $repository = new NotificationsRepository($pdo);
         $repository->deleteById('urn:uuid:del-test');
+    }
+
+    public function testUpdateStatusExecutesUpdate(): void
+    {
+        $stmt = $this->createMock(\PDOStatement::class);
+        $stmt->expects(self::exactly(2))
+            ->method('bindValue');
+        $stmt->expects(self::once())
+            ->method('execute');
+
+        $pdo = $this->createMock(\PDO::class);
+        $pdo->expects(self::once())
+            ->method('prepare')
+            ->with(self::stringContains('UPDATE notifications SET status = :status WHERE id = :id'))
+            ->willReturn($stmt);
+
+        $repository = new NotificationsRepository($pdo);
+        $repository->updateStatus('urn:uuid:status-test', Notification::STATUS_OUTDATED);
     }
 }

--- a/tests/unit/library/Episciences/notify/NotifySourceConfigTest.php
+++ b/tests/unit/library/Episciences/notify/NotifySourceConfigTest.php
@@ -13,7 +13,7 @@ class NotifySourceConfigTest extends TestCase
     private const LABEL         = 'HAL';
     private const ORIGIN_ID     = 'https://hal.science/';
     private const ORIGIN_INBOX  = 'https://inbox.hal.science/';
-    private const ACCEPTED_TYPES = ['Offer', 'coar-notify:ReviewAction'];
+    private const ACCEPTED_TYPES = [['Offer', 'coar-notify:ReviewAction']];
 
     // -------------------------------------------------------------------------
     // Getters return constructor values
@@ -57,7 +57,7 @@ class NotifySourceConfigTest extends TestCase
             originInbox: self::ORIGIN_INBOX,
         );
 
-        self::assertSame(['Offer', 'coar-notify:ReviewAction'], $config->getAcceptedTypes());
+        self::assertSame([['Offer', 'coar-notify:ReviewAction']], $config->getAcceptedTypes());
     }
 
     // -------------------------------------------------------------------------
@@ -66,7 +66,7 @@ class NotifySourceConfigTest extends TestCase
 
     public function testCustomAcceptedTypes(): void
     {
-        $types  = ['Offer', 'coar-notify:EndorsementAction'];
+        $types  = [['Offer', 'coar-notify:EndorsementAction']];
         $config = new NotifySourceConfig(
             repoId:        self::REPO_ID,
             label:         self::LABEL,

--- a/tests/unit/library/Episciences/notify/NotifySourceRegistryTest.php
+++ b/tests/unit/library/Episciences/notify/NotifySourceRegistryTest.php
@@ -93,7 +93,7 @@ class NotifySourceRegistryTest extends TestCase
             label:        'HAL',
             originId:     'https://hal.science/',
             originInbox:  self::HAL_INBOX,
-            acceptedTypes: ['Offer', 'coar-notify:ReviewAction'],
+            acceptedTypes: [['Offer', 'coar-notify:ReviewAction']],
         );
     }
 }

--- a/tests/unit/library/Episciences/notify/PayloadValidatorTest.php
+++ b/tests/unit/library/Episciences/notify/PayloadValidatorTest.php
@@ -367,6 +367,59 @@ class PayloadValidatorTest extends TestCase
         self::assertStringContainsString("'object.ietf:item.mediaType'", $result->getErrorMessage());
     }
 
+    public function testValidPayloadHasNoWarnings(): void
+    {
+        $result = $this->validator->validate($this->buildValidPayload());
+
+        self::assertTrue($result->isValid());
+        self::assertSame([], $result->getWarnings());
+    }
+
+    // -------------------------------------------------------------------------
+    // Object item fallback: 'object.url' when 'object.ietf:item' is missing
+    // (observed on real-world HAL payloads, which do not use 'ietf:item')
+    // -------------------------------------------------------------------------
+
+    public function testObjectUrlFallbackIsAcceptedWithWarningWhenIetfItemMissing(): void
+    {
+        $payload = $this->buildValidPayload();
+        $item    = $payload['object']['ietf:item'];
+        unset($payload['object']['ietf:item']);
+        $payload['object']['url'] = $item;
+
+        $result = $this->validator->validate($payload);
+
+        self::assertTrue($result->isValid());
+        self::assertNotEmpty($result->getWarnings());
+        self::assertStringContainsString("'object.ietf:item' is missing", $result->getWarnings()[0]);
+        self::assertStringContainsString("'object.url'", $result->getWarnings()[0]);
+    }
+
+    public function testObjectUrlFallbackMissingIdReturnsFailure(): void
+    {
+        $payload = $this->buildValidPayload();
+        $item    = $payload['object']['ietf:item'];
+        unset($item['id'], $payload['object']['ietf:item']);
+        $payload['object']['url'] = $item;
+
+        $result = $this->validator->validate($payload);
+
+        self::assertFalse($result->isValid());
+        self::assertStringContainsString("'object.url.id'", $result->getErrorMessage());
+    }
+
+    public function testMissingBothIetfItemAndUrlReturnsFailure(): void
+    {
+        $payload = $this->buildValidPayload();
+        unset($payload['object']['ietf:item']);
+
+        $result = $this->validator->validate($payload);
+
+        self::assertFalse($result->isValid());
+        self::assertStringContainsString("'object.ietf:item'", $result->getErrorMessage());
+        self::assertStringContainsString("'object.url'", $result->getErrorMessage());
+    }
+
     // -------------------------------------------------------------------------
     // Target validation
     // -------------------------------------------------------------------------

--- a/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
+++ b/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
@@ -118,6 +118,18 @@ class ProcessInboxNotificationsCommandTest extends TestCase
         $this->assertTrue($this->testHandler->hasWarningRecords());
     }
 
+    public function testCheckNotifyPayloadsAcceptsAndLogsNonConformantObjectUrlFallback(): void
+    {
+        $payload = json_decode($this->payloadTest('hal-02558198v1'), true, 512, JSON_THROW_ON_ERROR);
+        $payload['object']['url'] = $payload['object']['ietf:item'];
+        unset($payload['object']['ietf:item']);
+
+        $result = $this->command->checkNotifyPayloads($payload, $this->buildHalSource(), $this->logger);
+
+        $this->assertTrue($result);
+        $this->assertTrue($this->testHandler->hasWarningThatContains("non-conformant payload"));
+    }
+
     public function testCheckNotifyPayloadsReturnsTrueForEndorsementActionWhenSourceAcceptsIt(): void
     {
         $payload         = json_decode($this->payloadTest('hal-02558198v1'), true, 512, JSON_THROW_ON_ERROR);

--- a/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
+++ b/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
@@ -328,6 +328,46 @@ class ProcessInboxNotificationsCommandTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Outdated notifications (already superseded, not a genuine failure)
+    // -------------------------------------------------------------------------
+
+    public function testResolveSubmissionApplyFlagsOutdatedWhenVersionCannotBeReplaced(): void
+    {
+        $method = new \ReflectionMethod(ProcessInboxNotificationsCommand::class, 'resolveSubmissionApply');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(
+            $this->command,
+            2,
+            ['message' => 'This version [v2] of the document already exists in journal.', 'canBeReplaced' => false],
+            $this->logger,
+            'urn:uuid:outdated-test'
+        );
+
+        $this->assertFalse($result);
+        $this->assertTrue($this->isOutdatedFlag());
+    }
+
+    public function testResolveSubmissionApplyDoesNotFlagOutdatedOnUnexpectedStatus(): void
+    {
+        $method = new \ReflectionMethod(ProcessInboxNotificationsCommand::class, 'resolveSubmissionApply');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->command, 99, [], $this->logger, 'urn:uuid:unexpected-status');
+
+        $this->assertFalse($result);
+        $this->assertFalse($this->isOutdatedFlag());
+    }
+
+    private function isOutdatedFlag(): bool
+    {
+        $property = new \ReflectionProperty(ProcessInboxNotificationsCommand::class, 'isOutdatedNotification');
+        $property->setAccessible(true);
+
+        return $property->getValue($this->command);
+    }
+
+    // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------
 

--- a/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
+++ b/tests/unit/scripts/ProcessInboxNotificationsCommandTest.php
@@ -98,7 +98,7 @@ class ProcessInboxNotificationsCommandTest extends TestCase
             label:        'DIFFERENT',
             originId:     'https://different.url/',
             originInbox:  'https://different.inbox/',
-            acceptedTypes: ['Offer', 'coar-notify:ReviewAction']
+            acceptedTypes: [['Offer', 'coar-notify:ReviewAction']]
         );
 
         $result = $this->command->checkNotifyPayloads($validPayload, $source, $this->logger);
@@ -116,6 +116,28 @@ class ProcessInboxNotificationsCommandTest extends TestCase
 
         $this->assertFalse($result);
         $this->assertTrue($this->testHandler->hasWarningRecords());
+    }
+
+    public function testCheckNotifyPayloadsReturnsTrueForEndorsementActionWhenSourceAcceptsIt(): void
+    {
+        $payload         = json_decode($this->payloadTest('hal-02558198v1'), true, 512, JSON_THROW_ON_ERROR);
+        $payload['type'] = ['Offer', 'coar-notify:EndorsementAction'];
+
+        $source = new NotifySourceConfig(
+            repoId:       1,
+            label:        'HAL',
+            originId:     defined('NOTIFY_TARGET_HAL_URL') ? NOTIFY_TARGET_HAL_URL : 'https://hal.science/',
+            originInbox:  defined('NOTIFY_TARGET_HAL_INBOX') ? NOTIFY_TARGET_HAL_INBOX : 'https://inbox-preprod.hal.science/',
+            acceptedTypes: [
+                ['Offer', 'coar-notify:ReviewAction'],
+                ['Offer', 'coar-notify:EndorsementAction'],
+            ],
+        );
+
+        $result = $this->command->checkNotifyPayloads($payload, $source, $this->logger);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->testHandler->hasWarningRecords());
     }
 
     // -------------------------------------------------------------------------
@@ -320,7 +342,7 @@ class ProcessInboxNotificationsCommandTest extends TestCase
             label:        'HAL',
             originId:     defined('NOTIFY_TARGET_HAL_URL') ? NOTIFY_TARGET_HAL_URL : 'https://hal.science/',
             originInbox:  defined('NOTIFY_TARGET_HAL_INBOX') ? NOTIFY_TARGET_HAL_INBOX : 'https://inbox-preprod.hal.science/',
-            acceptedTypes: ['Offer', 'coar-notify:ReviewAction']
+            acceptedTypes: [['Offer', 'coar-notify:ReviewAction']]
         );
     }
 


### PR DESCRIPTION
## Summary
Port of fixes made while debugging `notify:process-inbox` on `preprod-epi-manager`, where all 69 pending inbound notifications were failing:

- **Bootstrap ordering**: the Symfony Console migration built the logger (needs `EPISCIENCES_LOG_PATH`) and registered `AppRegistry` before `bootstrap()` ran, which is what defines those. Split into `bootstrapConstants()`, run first.
- **Double-JSON-encoded payloads**: some inbound notifications have their `original` column double-JSON-encoded by the inbox writer; the first `json_decode()` then yields a string instead of an array, so `origin.inbox`/`id` silently resolved empty and everything was rejected as unknown origin.
- **`coar-notify:EndorsementAction` support**: the registry only accepted the Request Review pattern; `NotifySourceConfig::acceptedTypes` is now a list of accepted patterns, tried in turn.
- **`object.url` tolerance**: real-world HAL payloads put the item descriptor under `object.url` instead of the spec-preferred `object.ietf:item`. `PayloadValidator` now accepts `object.url` as a fallback and surfaces a warning (logged per notification) so the deviation can be reported back to HAL, instead of rejecting every notification.
- **`Notification::STATUS_OUTDATED`**: notifications whose outcome is a deterministic non-issue (version already applied, or a newer one already exists) were bucketed as generic failures and refetched/re-logged forever since the payload never changes. They're now persisted as `STATUS_OUTDATED` (distinct from `STATUS_FAILED`) and excluded from future `findInbound()` calls, without inflating the failure count.

All changes verified against real production inbox data in a local `docker compose` environment.

## Test plan
- [x] `tests/unit/library/Episciences/notify/*` and `tests/unit/scripts/ProcessInboxNotificationsCommandTest.php` pass (1 pre-existing, environment-config-dependent failure unrelated to these changes)
- [x] PHPStan level 6 clean on all touched files
- [x] Manually verified against the real pending inbox in a local dev environment (dry-run and live)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking notifications whose state has been superseded.
  * Added support for endorsement actions in notification processing.
  * Added fallback handling for payloads using `object.url`, with validation warnings.
  * Added support for double-encoded notification payloads.

* **Bug Fixes**
  * Outdated notifications are excluded from future inbound processing.
  * Improved reporting distinguishes outdated notifications from processing failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->