### PR TITLE
fix(user): revalidate email availability against the saved value

### DIFF
--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -1902,20 +1902,33 @@ class UserDefaultController extends Zend_Controller_Action
                     $user = Episciences_Auth::getUser();
                 }
 
-                $user->setEmail($form->getValue('EMAIL'));
+                $newEmail = filter_var((string)$form->getValue('EMAIL'), FILTER_SANITIZE_EMAIL);
 
-                if ($user->save()) {
+                if ($newEmail !== '' && !$userMapper->emailIsUsedByAnotherAccount($newEmail, (int)$user->getUid())) {
 
-                    if (Episciences_Auth::getUid() === $postedUid) {
-                        //If you modify your own account, you update the session
-                        $user = new Episciences_User();
-                        $user->find(Episciences_Auth::getUid());
-                        Episciences_Auth::getInstance()->clearIdentity();
-                        Episciences_Auth::setIdentity($user);
+                    $user->setEmail($newEmail);
 
+                    if ($user->save()) {
+
+                        if (Episciences_Auth::getUid() === $postedUid) {
+                            //If you modify your own account, you update the session
+                            $user = new Episciences_User();
+                            $user->find(Episciences_Auth::getUid());
+                            Episciences_Auth::getInstance()->clearIdentity();
+                            Episciences_Auth::setIdentity($user);
+
+                        }
+
+                        $resultMessage = Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS;
                     }
-
-                    $resultMessage = Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS;
+                } else {
+                    $form->getElement('EMAIL')->addError(
+                        str_replace(
+                            '%value%',
+                            (string)$form->getValue('EMAIL'),
+                            $this->view->translate('A record matching email (%value%) was found. Use login retrieve tools')
+                        )
+                    );
                 }
 
             }

--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -1912,6 +1912,7 @@ class UserDefaultController extends Zend_Controller_Action
 
                         if (Episciences_Auth::getUid() === $postedUid) {
                             //If you modify your own account, you update the session
+                            Episciences_User::forgetStaticCache((int)Episciences_Auth::getUid());
                             $user = new Episciences_User();
                             $user->find(Episciences_Auth::getUid());
                             Episciences_Auth::getInstance()->clearIdentity();

--- a/library/Ccsd/User/Models/UserMapper.php
+++ b/library/Ccsd/User/Models/UserMapper.php
@@ -308,6 +308,22 @@ class Ccsd_User_Models_UserMapper {
     }
 
     /**
+     * Checks whether the given email is already used by an account other than $excludeUid.
+     * Comparison is delegated to MySQL (utf8mb3_general_ci: case- and
+     * trailing-space-insensitive), consistently with the form validator.
+     */
+    public function emailIsUsedByAnotherAccount(string $email, int $excludeUid): bool
+    {
+        $select = $this->getDbTable()->select()
+            ->from($this->getDbTable(), ['UID'])
+            ->where('EMAIL = ?', $email)
+            ->where('UID != ?', $excludeUid)
+            ->limit(1);
+
+        return (bool)$this->getDbTable()->fetchRow($select);
+    }
+
+    /**
      * Trouve un utilisateur avec un compte actif, par son login, sinon renvoi
      * null
      *

--- a/library/Episciences/User.php
+++ b/library/Episciences/User.php
@@ -61,6 +61,16 @@ class Episciences_User extends Ccsd_User_Models_User
         self::$_identityMap = [];
     }
 
+    /**
+     * Drop one entry from the static request-level memory cache, so the next
+     * find() re-reads the row from the database instead of a value cached
+     * earlier in the same request.
+     */
+    public static function forgetStaticCache(int $uid): void
+    {
+        unset(self::$_identityMap[$uid]);
+    }
+
     protected ?string $_orcid = null;
     protected ?array $_affiliations = null;
 

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
@@ -107,4 +107,85 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
         $this->assertSame('asmith', $result->USERNAME);
     }
 
+    // -------------------------------------------------------------------------
+    // emailIsUsedByAnotherAccount() — UID exclusion logic, no DB adapter required
+    // -------------------------------------------------------------------------
+
+    /**
+     * @param array<string, int[]> $uidsByEmail
+     */
+    private function makeFakeTable(array $uidsByEmail): object
+    {
+        return new class($uidsByEmail) {
+            private ?string $email = null;
+            private ?int $excludeUid = null;
+
+            public function __construct(private readonly array $uidsByEmail)
+            {
+            }
+
+            public function select(): self
+            {
+                return $this;
+            }
+
+            public function from(self $table, $cols = '*'): self
+            {
+                return $this;
+            }
+
+            public function where(string $cond, $value = null): self
+            {
+                if ($cond === 'EMAIL = ?') {
+                    $this->email = (string)$value;
+                }
+                if ($cond === 'UID != ?') {
+                    $this->excludeUid = (int)$value;
+                }
+
+                return $this;
+            }
+
+            public function limit($count, $offset = null): self
+            {
+                return $this;
+            }
+
+            public function fetchRow($select): ?array
+            {
+                foreach ($this->uidsByEmail[$this->email] ?? [] as $uid) {
+                    if ($uid !== $this->excludeUid) {
+                        return ['UID' => $uid];
+                    }
+                }
+
+                return null;
+            }
+        };
+    }
+
+    public function testEmailIsUsedByAnotherAccountReturnsFalseWhenOnlyExcludedUidMatches(): void
+    {
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
+        $mapper->method('getDbTable')->willReturn($this->makeFakeTable(['a@b.org' => [42]]));
+
+        $this->assertFalse($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
+    }
+
+    public function testEmailIsUsedByAnotherAccountReturnsTrueWhenAnotherUidMatches(): void
+    {
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
+        $mapper->method('getDbTable')->willReturn($this->makeFakeTable(['a@b.org' => [42, 77]]));
+
+        $this->assertTrue($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
+    }
+
+    public function testEmailIsUsedByAnotherAccountReturnsFalseWhenNoRowMatches(): void
+    {
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
+        $mapper->method('getDbTable')->willReturn($this->makeFakeTable([]));
+
+        $this->assertFalse($mapper->emailIsUsedByAnotherAccount('nobody@b.org', 0));
+    }
+
 }

--- a/tests/unit/library/Episciences/user/Episciences_UserTest.php
+++ b/tests/unit/library/Episciences/user/Episciences_UserTest.php
@@ -772,6 +772,54 @@ class Episciences_UserTest extends TestCase
         }
     }
 
+    public function testForgetStaticCacheRemovesOnlyTargetUid(): void
+    {
+        $keptUid = 11111;
+        $forgottenUid = 22222;
+        $keptData = [
+            'UID' => $keptUid,
+            'USERNAME' => 'keptuser',
+            'EMAIL' => 'kept@example.com',
+            'SCREEN_NAME' => 'Kept User',
+            'LASTNAME' => 'User',
+            'FIRSTNAME' => 'Kept',
+            'MIDDLENAME' => '',
+            'CIV' => 'M.',
+            'LANGUEID' => 'en',
+            'API_PASSWORD' => 'hashed_pw',
+            'IS_VALID' => 1,
+            'REGISTRATION_DATE' => '2026-01-01 12:00:00',
+            'MODIFICATION_DATE' => '2026-01-02 12:00:00',
+            'uuid' => 'kept-uuid',
+            'AFFILIATIONS' => null,
+            'BIOGRAPHY' => null,
+            'ORCID' => null,
+        ];
+
+        Episciences_User::setStaticCache($keptUid, $keptData);
+        Episciences_User::setStaticCache($forgottenUid, ['UID' => $forgottenUid, 'uuid' => 'forgotten-uuid']);
+
+        Episciences_User::forgetStaticCache($forgottenUid);
+
+        // The forgotten UID is gone: find() falls through to a real DB query, which errors here.
+        try {
+            $this->user->find($forgottenUid);
+            $this->fail('Expected an exception when querying database after forgetting the cache entry');
+        } catch (\Throwable $e) {
+            $this->assertTrue(true);
+        }
+
+        // The other UID is untouched, still served from cache.
+        $result = (new Episciences_User())->find($keptUid);
+        $this->assertSame($keptData['UID'], $result['UID']);
+    }
+
+    public function testForgetStaticCacheOnAbsentUidDoesNotThrow(): void
+    {
+        Episciences_User::forgetStaticCache(999999999);
+        $this->assertTrue(true);
+    }
+
     // -------------------------------------------------------------------------
     // hasLocalData() via identity map — no DB required
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The change-email form validated the raw submitted address, but the value actually written to the database first passes through a sanitization filter, so the checked value and the persisted value could diverge.
- Add a server-side recheck, on the exact value that will be saved, against other accounts before writing it.

## Test plan
- [x] New unit tests for the added lookup (UID-exclusion logic), no DB required
- [x] `make phpstan LEVEL=6` on the touched files: no new errors vs. base
- [x] Full `make test-php` suite: no regression introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Email changes are now sanitised and checked for validity before being saved.
  - Users are notified when an email address is empty or already associated with another account.
  - Existing email addresses can still be retained when updating other account details.
- **Tests**
  - Added coverage to verify that duplicate email addresses are detected correctly while allowing the current account’s existing address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->