### PR TITLE
fix(user): centralize email-availability checks and refresh identity consistently

### DIFF
--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -3,6 +3,7 @@
 use Ccsd\Auth\AdapterFactory;
 use Episciences\Altcha\ChallengeHelper;
 use Episciences\Trait\LocaleByCookieTrait;
+use Episciences\User\EmailPolicy;
 
 
 class UserDefaultController extends Zend_Controller_Action
@@ -580,6 +581,21 @@ class UserDefaultController extends Zend_Controller_Action
             $user->setRegistrationDate(); // Episciences registration
             $user->setScreenName();
 
+            // Revalidate against the value actually stored: the form validator alone
+            // cannot see a conflict created between its check and this write.
+            if (EmailPolicy::findConflictingUid($user->getEmail(), 0) !== null) {
+                $form->getElement('EMAIL')->addError(
+                    str_replace(
+                        '%value%',
+                        $user->getEmail(),
+                        $this->view->translate('A record matching email (%value%) was found.  Use login retrieve tools')
+                    )
+                );
+                $this->view->form = $form;
+                $this->render('create');
+                return;
+            }
+
             if ($isAllowedToAddUserAccounts) {
                 // admin: new account does not need to be activated, no mail is sent
                 $user->setValid(1);
@@ -1082,7 +1098,24 @@ class UserDefaultController extends Zend_Controller_Action
 
         $request = $this->getRequest();
 
-        $form = new Ccsd_User_Form_AccountEditEmail();
+        $targetUid = $this->resolveEmailChangeTargetUid($request);
+
+        if ($targetUid === 0) {
+            return;
+        }
+
+        $target = new Episciences_User();
+        try {
+            $target->findWithCAS($targetUid);
+        } catch (Zend_Db_Statement_Exception $e) {
+            trigger_error($e->getMessage(), E_USER_ERROR);
+        }
+
+        if (!$target->getUid()) {
+            return;
+        }
+
+        $form = new Ccsd_User_Form_AccountEditEmail(['excludeUid' => $targetUid]);
 
         $form->setAction($this->view->url());
         $form->setActions(true)->createSubmitButton('submit', [
@@ -1090,33 +1123,43 @@ class UserDefaultController extends Zend_Controller_Action
             'class' => 'btn btn-primary'
         ]);
 
-        $userUid = $request->isPost() ? $request->getPost('USER_UID') : $request->getParam('userid');
-        $userUid = (int)$userUid;
+        $form->setDefault('EMAIL', $target->getEmail());
+        $form->setDefault('USER_UID', $target->getUid());
 
-        if (
-            $userUid &&
-            $userUid !== Episciences_Auth::getUid() &&
-            Episciences_Auth::isSecretary()
-        ) {
-            $user = new Episciences_User();
-            try {
-                $user->find($userUid);
-            } catch (Zend_Db_Statement_Exception $e) {
-                trigger_error($e->getMessage(), E_USER_ERROR);
-            }
-        } else {
-            $user = Episciences_Auth::getUser();
-        }
-
-        if (!$user->getUid()) {
-            return;
-        }
-
-        $form->setDefault('EMAIL', $user->getEmail());
-        $form->setDefault('USER_UID', $user->getUid());
-        $this->processChangeEmail($request, $form);
+        $this->processChangeEmail($request, $form, $targetUid, (string)$target->getEmail());
 
         $this->view->form = $form;
+    }
+
+    /**
+     * Resolves which account this request is allowed to change the email of.
+     *
+     * Returns the acting user's own UID by default. A secretary may target
+     * another account (?userid= / hidden USER_UID field), but only one
+     * holding a role in the current review, unless they are an administrator.
+     * Returns 0 when the request targets an account the caller isn't allowed
+     * to touch.
+     */
+    private function resolveEmailChangeTargetUid(Zend_Controller_Request_Http $request): int
+    {
+        $self = (int)Episciences_Auth::getUid();
+        $requested = (int)($request->isPost()
+            ? $request->getPost('USER_UID')
+            : $request->getParam('userid'));
+
+        if ($requested === 0 || $requested === $self) {
+            return $self;
+        }
+
+        if (!Episciences_Auth::isSecretary()) {
+            return 0;
+        }
+
+        if (Episciences_Auth::isAdministrator()) {
+            return $requested;
+        }
+
+        return (new Episciences_User())->hasRoles($requested, RVID) ? $requested : 0;
     }
 
     /**
@@ -1835,19 +1878,26 @@ class UserDefaultController extends Zend_Controller_Action
     /**
      * @param Zend_Controller_Request_Http $request
      * @param Ccsd_User_Form_AccountEditEmail $form
+     * @param int $targetUid Account whose email is being changed (self, or another account for a secretary).
+     * @param string $currentEmail The target account's email as currently stored.
      * @return void
      * @throws Zend_Form_Exception
      * @throws Exception
      */
 
-    private function processChangeEmail(Zend_Controller_Request_Http $request, Ccsd_User_Form_AccountEditEmail $form): void
+    private function processChangeEmail(
+        Zend_Controller_Request_Http $request,
+        Ccsd_User_Form_AccountEditEmail $form,
+        int $targetUid,
+        string $currentEmail
+    ): void
     {
 
         $userMapper = new Ccsd_User_Models_UserMapper();
 
-        $userLogins = $userMapper->findLoginByEmail($form->getValue('EMAIL'));
+        $userLogins = $userMapper->findLoginByEmail($currentEmail);
 
-        $isNotAllowedToChangeEmail = isset($userLogins) && count($userLogins) > 1;
+        $isNotAllowedToChangeEmail = $userLogins !== null && count($userLogins) > 1;
 
 
         if ($isNotAllowedToChangeEmail) {
@@ -1876,87 +1926,91 @@ class UserDefaultController extends Zend_Controller_Action
 
         $this->view->isNotAllowedToChangeEmail = $isNotAllowedToChangeEmail;
 
+        if (!$request->isPost() || !$request->get('submit')) {
+            return;
+        }
 
         $post = $request->getPost();
 
         $fController = $request->getParam('forward-controller', 'user');
         $fAction = $request->getParam('forward-action', 'change_account_email');
 
+        $self = (int)Episciences_Auth::getUid();
 
-        if ($request->isPost() && $request->get('submit') && $form->isValid($post)) {
-
-            $postedUid = (int)$post['USER_UID'];
-
-
-            $resultMessage = Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE;
-
-
-            if (!$isNotAllowedToChangeEmail) {
-
-                if ($postedUid && Episciences_Auth::isSecretary()) {
-                    $user = new Episciences_User();
-                    try {
-                        $user->find($post['USER_UID']);
-                    } catch (Zend_Db_Statement_Exception $e) {
-                        trigger_error($e->getMessage(), E_USER_ERROR);
-                    }
-                } else {
-                    $user = Episciences_Auth::getUser();
-                }
-
-                $newEmail = filter_var((string)$form->getValue('EMAIL'), FILTER_SANITIZE_EMAIL);
-
-                if ($newEmail !== '' && !$userMapper->emailIsUsedByAnotherAccount($newEmail, (int)$user->getUid())) {
-
-                    $user->setEmail($newEmail);
-
-                    if ($user->save()) {
-
-                        if (Episciences_Auth::getUid() === $postedUid) {
-                            //If you modify your own account, you update the session
-                            Episciences_User::forgetStaticCache((int)Episciences_Auth::getUid());
-                            $user = new Episciences_User();
-                            $user->find(Episciences_Auth::getUid());
-                            Episciences_Auth::getInstance()->clearIdentity();
-                            Episciences_Auth::setIdentity($user);
-
-                        }
-
-                        $resultMessage = Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS;
-                    }
-                } else {
-                    $form->getElement('EMAIL')->addError(
-                        str_replace(
-                            '%value%',
-                            (string)$form->getValue('EMAIL'),
-                            $this->view->translate('A record matching email (%value%) was found. Use login retrieve tools')
-                        )
-                    );
-                }
-
-            }
-
-            $alertType = ($resultMessage === Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS) ? self::SUCCESS : self::ERROR;
-
-
-            $message = $this->view->translate($resultMessage);
-            $this->_helper->FlashMessenger->setNamespace($alertType)->addMessage($message);
-
-
-            if ($alertType === self::SUCCESS) {
-                $url = $fController . '/' . $fAction;
-
-                if ($postedUid) {
-
-                    $url .= '?userid=' . $postedUid;
-
-                }
-
-                $this->redirect($url);
-            }
-
-
+        if ($isNotAllowedToChangeEmail) {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            return;
         }
+
+        if (!$form->isValid($post)) {
+            return;
+        }
+
+        $newEmail = EmailPolicy::normalize((string)$form->getValue('EMAIL'));
+
+        if ($newEmail === '') {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            return;
+        }
+
+        // Nothing to do: submitting the address already on the account is a success, not a conflict.
+        if (EmailPolicy::isSameAddress($newEmail, $currentEmail)) {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
+            $this->_helper->FlashMessenger->setNamespace(self::SUCCESS)->addMessage($message);
+            $url = $fController . '/' . $fAction;
+            if ($targetUid !== $self) {
+                $url .= '?userid=' . $targetUid;
+            }
+            $this->redirect($url);
+            return;
+        }
+
+        if (EmailPolicy::findConflictingUid($newEmail, $targetUid) !== null) {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            return;
+        }
+
+        // Load a detached object: never mutate the session identity object directly.
+        $target = new Episciences_User();
+        try {
+            $target->findWithCAS($targetUid);
+        } catch (Zend_Db_Statement_Exception $e) {
+            trigger_error($e->getMessage(), E_USER_ERROR);
+        }
+
+        if (!$target->getUid()) {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            return;
+        }
+
+        $target->setEmail($newEmail);
+
+        if (!$target->save()) {
+            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
+            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            return;
+        }
+
+        if ($targetUid === $self) {
+            // Modifying your own account: refresh the session from a fresh read, not the stale request-level cache.
+            Episciences_User::forgetStaticCache($targetUid);
+            $fresh = new Episciences_User();
+            $fresh->findWithCAS($targetUid);
+            Episciences_Auth::updateIdentity($fresh);
+        }
+
+        $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
+        $this->_helper->FlashMessenger->setNamespace(self::SUCCESS)->addMessage($message);
+
+        $url = $fController . '/' . $fAction;
+        if ($targetUid !== $self) {
+            $url .= '?userid=' . $targetUid;
+        }
+        $this->redirect($url);
 
     }
 

--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -1126,7 +1126,7 @@ class UserDefaultController extends Zend_Controller_Action
         $form->setDefault('EMAIL', $target->getEmail());
         $form->setDefault('USER_UID', $target->getUid());
 
-        $this->processChangeEmail($request, $form, $targetUid, (string)$target->getEmail());
+        $this->processChangeEmail($request, $form, $target);
 
         $this->view->form = $form;
     }
@@ -1878,8 +1878,8 @@ class UserDefaultController extends Zend_Controller_Action
     /**
      * @param Zend_Controller_Request_Http $request
      * @param Ccsd_User_Form_AccountEditEmail $form
-     * @param int $targetUid Account whose email is being changed (self, or another account for a secretary).
-     * @param string $currentEmail The target account's email as currently stored.
+     * @param Episciences_User $target Already-loaded, detached account whose email is being changed
+     *                                  (self, or another account for a secretary).
      * @return void
      * @throws Zend_Form_Exception
      * @throws Exception
@@ -1888,10 +1888,11 @@ class UserDefaultController extends Zend_Controller_Action
     private function processChangeEmail(
         Zend_Controller_Request_Http $request,
         Ccsd_User_Form_AccountEditEmail $form,
-        int $targetUid,
-        string $currentEmail
+        Episciences_User $target
     ): void
     {
+        $targetUid = $target->getUid();
+        $currentEmail = (string)$target->getEmail();
 
         $userMapper = new Ccsd_User_Models_UserMapper();
 
@@ -1940,8 +1941,7 @@ class UserDefaultController extends Zend_Controller_Action
         $self = (int)Episciences_Auth::getUid();
 
         if ($isNotAllowedToChangeEmail) {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
-            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            $this->flashChangeEmailMessage(self::ERROR, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
             return;
         }
 
@@ -1952,48 +1952,26 @@ class UserDefaultController extends Zend_Controller_Action
         $newEmail = EmailPolicy::normalize((string)$form->getValue('EMAIL'));
 
         if ($newEmail === '') {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
-            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            $this->flashChangeEmailMessage(self::ERROR, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
             return;
         }
 
         // Nothing to do: submitting the address already on the account is a success, not a conflict.
         if (EmailPolicy::isSameAddress($newEmail, $currentEmail)) {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
-            $this->_helper->FlashMessenger->setNamespace(self::SUCCESS)->addMessage($message);
-            $url = $fController . '/' . $fAction;
-            if ($targetUid !== $self) {
-                $url .= '?userid=' . $targetUid;
-            }
-            $this->redirect($url);
+            $this->flashChangeEmailMessage(self::SUCCESS, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
+            $this->redirectToForward($fController, $fAction, $targetUid, $self);
             return;
         }
 
         if (EmailPolicy::findConflictingUid($newEmail, $targetUid) !== null) {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
-            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
-            return;
-        }
-
-        // Load a detached object: never mutate the session identity object directly.
-        $target = new Episciences_User();
-        try {
-            $target->findWithCAS($targetUid);
-        } catch (Zend_Db_Statement_Exception $e) {
-            trigger_error($e->getMessage(), E_USER_ERROR);
-        }
-
-        if (!$target->getUid()) {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
-            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            $this->flashChangeEmailMessage(self::ERROR, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
             return;
         }
 
         $target->setEmail($newEmail);
 
         if (!$target->save()) {
-            $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
-            $this->_helper->FlashMessenger->setNamespace(self::ERROR)->addMessage($message);
+            $this->flashChangeEmailMessage(self::ERROR, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_FAILURE);
             return;
         }
 
@@ -2005,15 +1983,33 @@ class UserDefaultController extends Zend_Controller_Action
             Episciences_Auth::updateIdentity($fresh);
         }
 
-        $message = $this->view->translate(Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
-        $this->_helper->FlashMessenger->setNamespace(self::SUCCESS)->addMessage($message);
+        $this->flashChangeEmailMessage(self::SUCCESS, Ccsd_User_Models_User::ACCOUNT_RESET_EMAIL_SUCCESS);
+        $this->redirectToForward($fController, $fAction, $targetUid, $self);
+    }
 
+    /**
+     * Translates $translationKey and pushes it to the flash messenger under $namespace
+     * (self::SUCCESS / self::ERROR). Factors out the pattern repeated across every
+     * outcome branch of processChangeEmail().
+     */
+    private function flashChangeEmailMessage(string $namespace, string $translationKey): void
+    {
+        $message = $this->view->translate($translationKey);
+        $this->_helper->FlashMessenger->setNamespace($namespace)->addMessage($message);
+    }
+
+    /**
+     * Redirects to the forward controller/action, appending ?userid= when the
+     * target isn't the acting user's own account. Factors out the pattern
+     * repeated across every success branch of processChangeEmail().
+     */
+    private function redirectToForward(string $fController, string $fAction, int $targetUid, int $self): void
+    {
         $url = $fController . '/' . $fAction;
         if ($targetUid !== $self) {
             $url .= '?userid=' . $targetUid;
         }
         $this->redirect($url);
-
     }
 
     /**

--- a/application/modules/common/controllers/UserDefaultController.php
+++ b/application/modules/common/controllers/UserDefaultController.php
@@ -1932,8 +1932,10 @@ class UserDefaultController extends Zend_Controller_Action
 
         $post = $request->getPost();
 
-        $fController = $request->getParam('forward-controller', 'user');
-        $fAction = $request->getParam('forward-action', 'change_account_email');
+        // Restrict to safe internal route segments: rejects anything containing a
+        // scheme/host/path separator, so this can never become an off-site redirect.
+        $fController = $this->sanitizeForwardRouteSegment($request->getParam('forward-controller', 'user'), 'user');
+        $fAction = $this->sanitizeForwardRouteSegment($request->getParam('forward-action', 'change_account_email'), 'change_account_email');
 
         $self = (int)Episciences_Auth::getUid();
 
@@ -2014,6 +2016,17 @@ class UserDefaultController extends Zend_Controller_Action
 
     }
 
+    /**
+     * Restricts a 'forward-controller' / 'forward-action' request value to a safe
+     * internal route segment (letters, digits, underscore, hyphen), falling back
+     * to $default otherwise. Prevents it from being used to build an off-site
+     * redirect URL (e.g. a scheme/host smuggled in as "forward-controller").
+     */
+    private function sanitizeForwardRouteSegment(mixed $value, string $default): string
+    {
+        $value = (string)$value;
+        return preg_match('/^[a-zA-Z][a-zA-Z0-9_-]*$/', $value) ? $value : $default;
+    }
 
     /**
      * @param array $userLogins

--- a/library/Ccsd/User/Form/AccountEditEmail.php
+++ b/library/Ccsd/User/Form/AccountEditEmail.php
@@ -1,5 +1,7 @@
 <?php
 
+use Episciences\User\Validate\EmailAvailability;
+
 /**
  *
  * edit account email form
@@ -7,6 +9,14 @@
  */
 class Ccsd_User_Form_AccountEditEmail extends Ccsd_Form
 {
+    /** UID excluded from the email-availability check: the account being edited. */
+    private int $_excludeUid = 0;
+
+    public function setExcludeUid(int $uid): self
+    {
+        $this->_excludeUid = $uid;
+        return $this;
+    }
 
     public function init (): void
     {
@@ -16,17 +26,12 @@ class Ccsd_User_Form_AccountEditEmail extends Ccsd_Form
         $email = $this->getElement('EMAIL');
 
         if ($email) {
-            $options = array(
-                'table' => 'T_UTILISATEURS',
-                'field' => 'EMAIL',
-                'adapter' => Ccsd_Db_Adapter_Cas::getAdapter()
-            );
-            $validator = new Zend_Validate_Db_NoRecordExists($options);
-            $validator -> setMessage(Zend_Registry::get('Zend_Translate')->translate("A record matching email (%value%) was found. Use login retrieve tools"));
+            $message = Zend_Registry::get('Zend_Translate')->translate("A record matching email (%value%) was found. Use login retrieve tools");
+            $validator = new EmailAvailability($this->_excludeUid, $message);
             $email->addValidator($validator);
         }
     }
-    
+
 }
 
 

--- a/library/Ccsd/User/Form/Accountcreate.php
+++ b/library/Ccsd/User/Form/Accountcreate.php
@@ -1,5 +1,7 @@
 <?php
 
+use Episciences\User\Validate\EmailAvailability;
+
 /**
  * Formulaire de création de compte
  * @author rtournoy
@@ -30,13 +32,10 @@ class Ccsd_User_Form_Accountcreate extends Ccsd_Form
 
         $email = $this->getElement('EMAIL');
         if ($email) {
-            $options = array(
-                'table' => 'T_UTILISATEURS',
-                'field' => 'EMAIL',
-                'adapter' => Ccsd_Db_Adapter_Cas::getAdapter()
+            $validator = new EmailAvailability(
+                0,
+                "A record matching email (%value%) was found.  Use login retrieve tools"
             );
-            $validator = new Zend_Validate_Db_NoRecordExists($options);
-            $validator -> setMessage("A record matching email (%value%) was found.  Use login retrieve tools");
             $email->addValidator($validator);
         }
     }

--- a/library/Ccsd/User/Models/User.php
+++ b/library/Ccsd/User/Models/User.php
@@ -404,8 +404,24 @@ class Ccsd_User_Models_User
      */
     public function setEmail($_email)
     {
-        $this->_email = filter_var($_email, FILTER_SANITIZE_EMAIL);
+        $this->_email = self::normalizeEmail((string)$_email);
         return $this;
+    }
+
+    /**
+     * Normalizes an email the same way it will be stored: this is the single
+     * source of truth for what counts as "the same address" written to
+     * T_UTILISATEURS.EMAIL, so that an availability check never diverges from
+     * the value actually persisted.
+     *
+     * No case-folding: T_UTILISATEURS has no explicit COLLATE, so it defaults
+     * to utf8mb3_general_ci, already case- and trailing-space-insensitive at
+     * the SQL comparison level.
+     */
+    public static function normalizeEmail(string $email): string
+    {
+        $normalized = filter_var(trim($email), FILTER_SANITIZE_EMAIL);
+        return $normalized === false ? '' : $normalized;
     }
 
     /**

--- a/library/Ccsd/User/Models/UserMapper.php
+++ b/library/Ccsd/User/Models/UserMapper.php
@@ -119,7 +119,10 @@ class Ccsd_User_Models_UserMapper {
             ));
 
             if (1 != $result) {
-                return false;
+                // 0 rows affected: either the UID is gone (real failure) or the
+                // UPDATE was a same-second no-op (MySQL reports 0 when the row's
+                // data is already identical). Only the former is an error.
+                return $this->uidExists((int)$user->getUid()) ? $user->getUid() : false;
             } else {
                 return $user->getUid();
             }
@@ -308,16 +311,49 @@ class Ccsd_User_Models_UserMapper {
     }
 
     /**
-     * Checks whether the given email is already used by an account other than $excludeUid.
+     * Returns the UIDs of every account currently using the given email.
      * Comparison is delegated to MySQL (utf8mb3_general_ci: case- and
      * trailing-space-insensitive), consistently with the form validator.
+     *
+     * @return int[]
      */
-    public function emailIsUsedByAnotherAccount(string $email, int $excludeUid): bool
+    public function findUidsByEmail(string $email): array
     {
         $select = $this->getDbTable()->select()
             ->from($this->getDbTable(), ['UID'])
-            ->where('EMAIL = ?', $email)
-            ->where('UID != ?', $excludeUid)
+            ->where('EMAIL = ?', $email);
+
+        $uids = [];
+
+        foreach ($this->getDbTable()->fetchAll($select) as $row) {
+            $uids[] = (int)$row['UID'];
+        }
+
+        return $uids;
+    }
+
+    /**
+     * Checks whether the given email is already used by an account other than $excludeUid.
+     */
+    public function emailIsUsedByAnotherAccount(string $email, int $excludeUid): bool
+    {
+        foreach ($this->findUidsByEmail($email) as $uid) {
+            if ($uid !== $excludeUid) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether an account with the given UID still exists.
+     */
+    public function uidExists(int $uid): bool
+    {
+        $select = $this->getDbTable()->select()
+            ->from($this->getDbTable(), ['UID'])
+            ->where('UID = ?', $uid)
             ->limit(1);
 
         return (bool)$this->getDbTable()->fetchRow($select);

--- a/library/Ccsd/User/Models/UserMapper.php
+++ b/library/Ccsd/User/Models/UserMapper.php
@@ -311,7 +311,9 @@ class Ccsd_User_Models_UserMapper {
     }
 
     /**
-     * Returns the UIDs of every account currently using the given email.
+     * Returns the UIDs of every account currently using the given email, ordered
+     * by UID so that callers picking the first match (e.g. to resolve which
+     * duplicate account to attach to) get a deterministic result.
      * Comparison is delegated to MySQL (utf8mb3_general_ci: case- and
      * trailing-space-insensitive), consistently with the form validator.
      *
@@ -321,7 +323,8 @@ class Ccsd_User_Models_UserMapper {
     {
         $select = $this->getDbTable()->select()
             ->from($this->getDbTable(), ['UID'])
-            ->where('EMAIL = ?', $email);
+            ->where('EMAIL = ?', $email)
+            ->order('UID ASC');
 
         $uids = [];
 
@@ -330,20 +333,6 @@ class Ccsd_User_Models_UserMapper {
         }
 
         return $uids;
-    }
-
-    /**
-     * Checks whether the given email is already used by an account other than $excludeUid.
-     */
-    public function emailIsUsedByAnotherAccount(string $email, int $excludeUid): bool
-    {
-        foreach ($this->findUidsByEmail($email) as $uid) {
-            if ($uid !== $excludeUid) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/library/Episciences/Reviewer/AccountResolver.php
+++ b/library/Episciences/Reviewer/AccountResolver.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Episciences\User\EmailAlreadyInUseException;
+use Episciences\User\EmailPolicy;
+
 /**
  * Resolves (looks up or creates) a real CAS reviewer account from an invitation
  * that was sent to a temporary account / bare email address.
@@ -209,7 +212,11 @@ class Episciences_Reviewer_AccountResolver
      * @param string|null $lang Two-letter language code; defaults to the review default.
      * @param string $login Pre-resolved, available login.
      * @param string $plainPassword Strong random password (will be hashed by the entity).
+     * @param (callable(string): int[])|null $uidsFinder Injectable for tests; defaults to EmailPolicy's own lookup.
      * @return Episciences_Reviewer
+     * @throws EmailAlreadyInUseException When the email is already used by another account
+     *         (including a non-validated one: {@see findValidAccountByEmail()} only filters VALID=1,
+     *         which is not enough to prevent a duplicate here).
      * @throws Zend_Db_Adapter_Exception
      * @throws Zend_Db_Statement_Exception
      */
@@ -219,13 +226,21 @@ class Episciences_Reviewer_AccountResolver
         string  $email,
         ?string $lang,
         string  $login,
-        string  $plainPassword
+        string  $plainPassword,
+        ?callable $uidsFinder = null
     ): Episciences_Reviewer
     {
+        $normalizedEmail = EmailPolicy::normalize($email);
+        $conflictingUid = EmailPolicy::findConflictingUid($normalizedEmail, 0, $uidsFinder);
+
+        if ($conflictingUid !== null) {
+            throw new EmailAlreadyInUseException($conflictingUid, $normalizedEmail);
+        }
+
         $user = new Episciences_Reviewer();
         $user->setFirstname($firstname);
         $user->setLastname($lastname);
-        $user->setEmail($email);
+        $user->setEmail($normalizedEmail);
         $user->setUsername($login);
         $user->setPassword($plainPassword);
         $user->setLangueid($lang ?: Episciences_Review::DEFAULT_LANG);
@@ -362,14 +377,21 @@ class Episciences_Reviewer_AccountResolver
 
         $password = self::generateStrongPassword();
 
-        $user = self::createReviewerAccount(
-            $identity['firstname'],
-            $identity['lastname'],
-            $identity['email'],
-            $identity['lang'],
-            $login,
-            $password
-        );
+        try {
+            $user = self::createReviewerAccount(
+                $identity['firstname'],
+                $identity['lastname'],
+                $identity['email'],
+                $identity['lang'],
+                $login,
+                $password
+            );
+        } catch (EmailAlreadyInUseException $e) {
+            // Someone (including a non-validated account) already holds this address:
+            // attach to it instead of creating a duplicate.
+            $user = self::attachExistingAccount($e->getUid());
+            return $user ? ['user' => $user, 'created' => false] : null;
+        }
 
         return ['user' => $user, 'created' => true];
     }

--- a/library/Episciences/Reviewer/AccountResolver.php
+++ b/library/Episciences/Reviewer/AccountResolver.php
@@ -168,6 +168,7 @@ class Episciences_Reviewer_AccountResolver
      *
      * @param int $uid
      * @return Episciences_Reviewer|null Null when the CAS account cannot be loaded.
+     * @throws RuntimeException When the screen name / language backfill fails to save.
      * @throws Zend_Db_Adapter_Exception
      * @throws Zend_Db_Statement_Exception
      */
@@ -193,8 +194,8 @@ class Episciences_Reviewer_AccountResolver
             $needsSave = true;
         }
 
-        if ($needsSave) {
-            $user->save();
+        if ($needsSave && $user->save() === false) {
+            throw new RuntimeException(sprintf('Failed to save CAS account #%d while attaching reviewer role', $uid));
         }
 
         $user->addRole(Episciences_Acl::ROLE_REVIEWER);
@@ -217,6 +218,7 @@ class Episciences_Reviewer_AccountResolver
      * @throws EmailAlreadyInUseException When the email is already used by another account
      *         (including a non-validated one: {@see findValidAccountByEmail()} only filters VALID=1,
      *         which is not enough to prevent a duplicate here).
+     * @throws RuntimeException When the new account fails to save.
      * @throws Zend_Db_Adapter_Exception
      * @throws Zend_Db_Statement_Exception
      */
@@ -247,8 +249,11 @@ class Episciences_Reviewer_AccountResolver
         $user->setTime_registered();
         $user->setValid(1);
 
-        $uid = (int)$user->save();
-        $user->setUid($uid);
+        $result = $user->save();
+        if ($result === false) {
+            throw new RuntimeException(sprintf('Failed to save new CAS reviewer account for email "%s"', $normalizedEmail));
+        }
+        $user->setUid((int)$result);
 
         $user->addRole(Episciences_Acl::ROLE_REVIEWER);
         $user->setScreenName($user->getFullName());

--- a/library/Episciences/User.php
+++ b/library/Episciences/User.php
@@ -475,6 +475,11 @@ class Episciences_User extends Ccsd_User_Models_User
 
         if ($isCasRecording) {
             $casId = parent::save($forceInsert);
+
+            if ($casId === false) {
+                trigger_error('CAS write failed for UID ' . $this->getUid(), E_USER_WARNING);
+                return false;
+            }
         }
 
         $uid = ($casId) ?: $this->getUid();
@@ -569,11 +574,17 @@ class Episciences_User extends Ccsd_User_Models_User
                 return false;
             }
 
+            // hasLocalData() above may have cached this UID's row before this write;
+            // drop it so the next find() re-reads the row this save() just wrote.
+            self::forgetStaticCache((int)$uid);
+
             return $uid;
         }
 
         // Mise à jour des données locales
         $this->_db->update(T_USERS, $data, ['UID = ?' => $this->getUid()]);
+
+        self::forgetStaticCache((int)$this->getUid());
 
         return $this->getUid();
 

--- a/library/Episciences/User/EmailAlreadyInUseException.php
+++ b/library/Episciences/User/EmailAlreadyInUseException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Episciences\User;
+
+use RuntimeException;
+
+/**
+ * Thrown when an operation would create or assign an email already used by
+ * another account. Carries that account's UID so the caller can fall back to
+ * attaching it instead of creating a duplicate.
+ */
+final class EmailAlreadyInUseException extends RuntimeException
+{
+    private int $uid;
+
+    public function __construct(int $uid, string $email)
+    {
+        parent::__construct(sprintf('Email "%s" is already in use by account #%d', $email, $uid));
+        $this->uid = $uid;
+    }
+
+    public function getUid(): int
+    {
+        return $this->uid;
+    }
+}

--- a/library/Episciences/User/EmailPolicy.php
+++ b/library/Episciences/User/EmailPolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Episciences\User;
+
+use Ccsd_User_Models_User;
+use Ccsd_User_Models_UserMapper;
+
+/**
+ * Single point of decision for "is this email available" across every entry
+ * point that can create or change an account's email (change-email form,
+ * account creation, reviewer invitation acceptance).
+ */
+final class EmailPolicy
+{
+    public static function normalize(string $raw): string
+    {
+        return Ccsd_User_Models_User::normalizeEmail($raw);
+    }
+
+    /**
+     * Whether two addresses are the same account-identifying value.
+     * Matches T_UTILISATEURS' utf8mb3_general_ci + PAD SPACE comparison:
+     * case-insensitive, trailing spaces ignored. Used only to short-circuit
+     * the "nothing changed" case, not as a general equality/dedup rule
+     * (no Gmail-style dot/+tag folding).
+     */
+    public static function isSameAddress(string $a, string $b): bool
+    {
+        return strcasecmp(rtrim($a), rtrim($b)) === 0;
+    }
+
+    /**
+     * Normalizes $rawEmail and returns the UID of another account already
+     * using it, or null if the address is available. $excludeUid = 0 means
+     * "creating a new account": any match is a conflict.
+     *
+     * @param ?callable(string): int[] $uidsFinder Injectable for tests; defaults
+     *     to Ccsd_User_Models_UserMapper::findUidsByEmail().
+     */
+    public static function findConflictingUid(string $rawEmail, int $excludeUid, ?callable $uidsFinder = null): ?int
+    {
+        $normalized = self::normalize($rawEmail);
+        $finder = $uidsFinder ?? static function (string $email): array {
+            return (new Ccsd_User_Models_UserMapper())->findUidsByEmail($email);
+        };
+
+        foreach ($finder($normalized) as $uid) {
+            if ((int)$uid !== $excludeUid) {
+                return (int)$uid;
+            }
+        }
+
+        return null;
+    }
+}

--- a/library/Episciences/User/Validate/EmailAvailability.php
+++ b/library/Episciences/User/Validate/EmailAvailability.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Episciences\User\Validate;
+
+use Episciences\User\EmailPolicy;
+use Zend_Validate_Interface;
+
+/**
+ * Replaces Zend_Validate_Db_NoRecordExists on EMAIL form elements: unlike that
+ * validator, this one excludes the account being edited, so re-submitting an
+ * unchanged address is not rejected as "already taken".
+ */
+final class EmailAvailability implements Zend_Validate_Interface
+{
+    public const NOT_AVAILABLE = 'emailNotAvailable';
+
+    public const DEFAULT_MESSAGE = 'A record matching email (%value%) was found. Use login retrieve tools';
+
+    /** @var array<string, string> */
+    private array $messages = [];
+
+    /** @var (callable(string): int[])|null */
+    private $uidsFinder;
+
+    /**
+     * @param int $excludeUid UID to exclude from the conflict search (0 when creating an account: any match conflicts).
+     * @param (callable(string): int[])|null $uidsFinder Injectable for tests; defaults to EmailPolicy's own lookup.
+     */
+    public function __construct(
+        private readonly int $excludeUid = 0,
+        private readonly string $message = self::DEFAULT_MESSAGE,
+        ?callable $uidsFinder = null
+    ) {
+        $this->uidsFinder = $uidsFinder;
+    }
+
+    public function isValid($value): bool
+    {
+        $this->messages = [];
+        $email = (string)$value;
+
+        if (EmailPolicy::findConflictingUid($email, $this->excludeUid, $this->uidsFinder) !== null) {
+            $this->messages[self::NOT_AVAILABLE] = str_replace('%value%', $email, $this->message);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
@@ -107,34 +107,4 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
         $this->assertSame('asmith', $result->USERNAME);
     }
 
-    // -------------------------------------------------------------------------
-    // emailIsUsedByAnotherAccount() — UID exclusion logic, no DB adapter required
-    // findUidsByEmail() itself is left untested: the Zend_Db_Table_Select it
-    // returns requires a real adapter.
-    // -------------------------------------------------------------------------
-
-    public function testEmailIsUsedByAnotherAccountReturnsFalseWhenOnlyExcludedUidMatches(): void
-    {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
-        $mapper->method('findUidsByEmail')->willReturn([42]);
-
-        $this->assertFalse($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
-    }
-
-    public function testEmailIsUsedByAnotherAccountReturnsTrueWhenAnotherUidMatches(): void
-    {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
-        $mapper->method('findUidsByEmail')->willReturn([42, 77]);
-
-        $this->assertTrue($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
-    }
-
-    public function testEmailIsUsedByAnotherAccountReturnsFalseWhenNoRowMatches(): void
-    {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
-        $mapper->method('findUidsByEmail')->willReturn([]);
-
-        $this->assertFalse($mapper->emailIsUsedByAnotherAccount('nobody@b.org', 0));
-    }
-
 }

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserMapperTest.php
@@ -109,81 +109,30 @@ class Ccsd_User_Models_UserMapperTest extends TestCase
 
     // -------------------------------------------------------------------------
     // emailIsUsedByAnotherAccount() — UID exclusion logic, no DB adapter required
+    // findUidsByEmail() itself is left untested: the Zend_Db_Table_Select it
+    // returns requires a real adapter.
     // -------------------------------------------------------------------------
-
-    /**
-     * @param array<string, int[]> $uidsByEmail
-     */
-    private function makeFakeTable(array $uidsByEmail): object
-    {
-        return new class($uidsByEmail) {
-            private ?string $email = null;
-            private ?int $excludeUid = null;
-
-            public function __construct(private readonly array $uidsByEmail)
-            {
-            }
-
-            public function select(): self
-            {
-                return $this;
-            }
-
-            public function from(self $table, $cols = '*'): self
-            {
-                return $this;
-            }
-
-            public function where(string $cond, $value = null): self
-            {
-                if ($cond === 'EMAIL = ?') {
-                    $this->email = (string)$value;
-                }
-                if ($cond === 'UID != ?') {
-                    $this->excludeUid = (int)$value;
-                }
-
-                return $this;
-            }
-
-            public function limit($count, $offset = null): self
-            {
-                return $this;
-            }
-
-            public function fetchRow($select): ?array
-            {
-                foreach ($this->uidsByEmail[$this->email] ?? [] as $uid) {
-                    if ($uid !== $this->excludeUid) {
-                        return ['UID' => $uid];
-                    }
-                }
-
-                return null;
-            }
-        };
-    }
 
     public function testEmailIsUsedByAnotherAccountReturnsFalseWhenOnlyExcludedUidMatches(): void
     {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
-        $mapper->method('getDbTable')->willReturn($this->makeFakeTable(['a@b.org' => [42]]));
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
+        $mapper->method('findUidsByEmail')->willReturn([42]);
 
         $this->assertFalse($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
     }
 
     public function testEmailIsUsedByAnotherAccountReturnsTrueWhenAnotherUidMatches(): void
     {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
-        $mapper->method('getDbTable')->willReturn($this->makeFakeTable(['a@b.org' => [42, 77]]));
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
+        $mapper->method('findUidsByEmail')->willReturn([42, 77]);
 
         $this->assertTrue($mapper->emailIsUsedByAnotherAccount('a@b.org', 42));
     }
 
     public function testEmailIsUsedByAnotherAccountReturnsFalseWhenNoRowMatches(): void
     {
-        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['getDbTable']);
-        $mapper->method('getDbTable')->willReturn($this->makeFakeTable([]));
+        $mapper = $this->createPartialMock(Ccsd_User_Models_UserMapper::class, ['findUidsByEmail']);
+        $mapper->method('findUidsByEmail')->willReturn([]);
 
         $this->assertFalse($mapper->emailIsUsedByAnotherAccount('nobody@b.org', 0));
     }

--- a/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTest.php
+++ b/tests/unit/library/Ccsd/User/Ccsd_User_Models_UserTest.php
@@ -250,6 +250,31 @@ class Ccsd_User_Models_UserTest extends TestCase
         $this->assertSame('user@example.com', $this->user->getEmail());
     }
 
+    /**
+     * @return list<array{string}>
+     */
+    public static function normalizeEmailMatchesSetEmailProvider(): array
+    {
+        return [
+            ['user@example.com'],
+            [' user@example.com '],
+            ['user name@example.com'],
+            ['user<>name@example.com'],
+            ['John@Example.ORG'],
+            [''],
+        ];
+    }
+
+    /**
+     * @dataProvider normalizeEmailMatchesSetEmailProvider
+     */
+    public function testNormalizeEmailMatchesSetEmailGetEmail(string $raw): void
+    {
+        $this->user->setEmail($raw);
+
+        $this->assertSame($this->user->getEmail(), Ccsd_User_Models_User::normalizeEmail($raw));
+    }
+
     // -------------------------------------------------------------------------
     // setFirstname / getFirstname / setLastname / getLastname
     // -------------------------------------------------------------------------

--- a/tests/unit/library/Episciences/Episciences_UserSaveGuardTest.php
+++ b/tests/unit/library/Episciences/Episciences_UserSaveGuardTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace unit\library\Episciences;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Structural regression guard for Episciences_User::save() (D7): a failed CAS
+ * write (Ccsd_User_Models_UserMapper::save() returning false) must abort
+ * before touching T_USERS, instead of silently continuing with a stale/wrong
+ * UID.
+ *
+ * This is a structural guard, not a behavioral one: exercising the actual
+ * failure path requires the auth database, which this suite does not have.
+ * It only proves the early-return is present and precedes the T_USERS writes.
+ *
+ * @covers \Episciences_User
+ */
+final class Episciences_UserSaveGuardTest extends TestCase
+{
+    private string $method;
+
+    protected function setUp(): void
+    {
+        $source = (string)file_get_contents(
+            APPLICATION_PATH . '/../library/Episciences/User.php'
+        );
+
+        $start = strpos($source, 'public function save(');
+        self::assertNotFalse($start, 'Episciences_User::save() not found');
+
+        $end = strpos($source, "\n    public function ", $start + 1);
+        self::assertNotFalse($end, 'could not find the end of Episciences_User::save()');
+
+        $this->method = substr($source, $start, $end - $start);
+    }
+
+    public function testSaveChecksForCasWriteFailure(): void
+    {
+        self::assertMatchesRegularExpression('/\$casId\s*===\s*false/', $this->method,
+            'save() must check for a failed CAS write ($casId === false)');
+    }
+
+    public function testSaveAbortsBeforeWritingLocalDataOnCasFailure(): void
+    {
+        $guardPos = preg_match('/\$casId\s*===\s*false/', $this->method, $matches, PREG_OFFSET_CAPTURE)
+            ? $matches[0][1]
+            : false;
+        $insertPos = strpos($this->method, 'insert(T_USERS');
+        $updatePos = strpos($this->method, 'update(T_USERS');
+
+        self::assertNotFalse($guardPos, 'save() must check for a failed CAS write');
+        self::assertNotFalse($insertPos, 'save() must insert into T_USERS on account creation');
+        self::assertNotFalse($updatePos, 'save() must update T_USERS on account modification');
+        self::assertLessThan($insertPos, $guardPos,
+            'the CAS-failure guard must run before the T_USERS insert (D7)');
+        self::assertLessThan($updatePos, $guardPos,
+            'the CAS-failure guard must run before the T_USERS update (D7)');
+    }
+
+    public function testSaveReturnsFalseOnCasWriteFailure(): void
+    {
+        $guardPos = strpos($this->method, '$casId === false');
+        self::assertNotFalse($guardPos, 'save() must check for a failed CAS write');
+
+        $afterGuard = substr($this->method, $guardPos, 220);
+        self::assertStringContainsString('return false;', $afterGuard,
+            'save() must return false immediately when the CAS write failed (D7)');
+    }
+}

--- a/tests/unit/library/Episciences/Reviewer/Episciences_Reviewer_AccountResolverTest.php
+++ b/tests/unit/library/Episciences/Reviewer/Episciences_Reviewer_AccountResolverTest.php
@@ -2,6 +2,8 @@
 
 namespace unit\library\Episciences\Reviewer;
 
+use Episciences\User\EmailAlreadyInUseException;
+use Episciences\User\EmailPolicy;
 use Episciences_Reviewer_AccountResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -129,5 +131,70 @@ class Episciences_Reviewer_AccountResolverTest extends TestCase
         $second = Episciences_Reviewer_AccountResolver::generateStrongPassword(32);
 
         self::assertNotSame($first, $second);
+    }
+
+    // -------------------------------------------------------------------------
+    // createReviewerAccount() email-conflict guard — no DB required: the
+    // conflict finder is injected, so the method returns before touching the
+    // database.
+    // -------------------------------------------------------------------------
+
+    public function testCreateReviewerAccountThrowsWhenConflictFinderSignalsUid(): void
+    {
+        $this->expectException(EmailAlreadyInUseException::class);
+
+        Episciences_Reviewer_AccountResolver::createReviewerAccount(
+            'Fabio',
+            'Zanasi',
+            'fabio@example.org',
+            'en',
+            'fzanasi',
+            'irrelevant-password',
+            static fn(string $email): array => [42]
+        );
+    }
+
+    public function testCreateReviewerAccountExceptionCarriesConflictingUid(): void
+    {
+        try {
+            Episciences_Reviewer_AccountResolver::createReviewerAccount(
+                'Fabio',
+                'Zanasi',
+                'fabio@example.org',
+                'en',
+                'fzanasi',
+                'irrelevant-password',
+                static fn(string $email): array => [42]
+            );
+            self::fail('Expected EmailAlreadyInUseException');
+        } catch (EmailAlreadyInUseException $e) {
+            self::assertSame(42, $e->getUid());
+        }
+    }
+
+    public function testCreateReviewerAccountPassesNormalizedEmailToConflictFinder(): void
+    {
+        $rawEmail = ' Fabio<>@Example.org ';
+        $capturedEmail = null;
+
+        try {
+            Episciences_Reviewer_AccountResolver::createReviewerAccount(
+                'Fabio',
+                'Zanasi',
+                $rawEmail,
+                'en',
+                'fzanasi',
+                'irrelevant-password',
+                function (string $email) use (&$capturedEmail): array {
+                    $capturedEmail = $email;
+                    return [42];
+                }
+            );
+            self::fail('Expected EmailAlreadyInUseException');
+        } catch (EmailAlreadyInUseException $e) {
+            // expected
+        }
+
+        self::assertSame(EmailPolicy::normalize($rawEmail), $capturedEmail);
     }
 }

--- a/tests/unit/library/Episciences/User/EmailPolicyTest.php
+++ b/tests/unit/library/Episciences/User/EmailPolicyTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace unit\library\Episciences\User;
+
+use Ccsd_User_Models_User;
+use Episciences\User\EmailPolicy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Episciences\User\EmailPolicy
+ */
+class EmailPolicyTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // normalize()
+    // -------------------------------------------------------------------------
+
+    public function testNormalizeTrimsLeadingAndTrailingSpaces(): void
+    {
+        self::assertSame('a@b.org', EmailPolicy::normalize(' a@b.org '));
+    }
+
+    /**
+     * Regression guard for D2: proves that the value the form validated could
+     * diverge from the value actually written, unless both go through the
+     * same normalization.
+     */
+    public function testNormalizeStripsWhatFilterSanitizeEmailRemoves(): void
+    {
+        self::assertSame('ab@c.org', EmailPolicy::normalize('a b@c.org'));
+        self::assertSame('xy@z.org', EmailPolicy::normalize('x<y>@z.org'));
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public static function normalizeIdempotentProvider(): array
+    {
+        return [
+            ['a@b.org'],
+            [' A@B.ORG '],
+            ['x<y>@z.org'],
+            [''],
+        ];
+    }
+
+    /**
+     * @dataProvider normalizeIdempotentProvider
+     */
+    public function testNormalizeIsIdempotent(string $raw): void
+    {
+        $once = EmailPolicy::normalize($raw);
+        $twice = EmailPolicy::normalize($once);
+
+        self::assertSame($once, $twice);
+    }
+
+    /**
+     * Guards the collation decision: T_UTILISATEURS defaults to
+     * utf8mb3_general_ci, already case-insensitive at the SQL level, so
+     * normalize() must not fold case itself.
+     */
+    public function testNormalizeDoesNotChangeCase(): void
+    {
+        self::assertSame('John@Example.ORG', EmailPolicy::normalize('John@Example.ORG'));
+    }
+
+    public function testNormalizeMatchesSetEmailGetEmail(): void
+    {
+        $raw = ' John<>Doe@Example.ORG ';
+
+        $user = new Ccsd_User_Models_User();
+        $user->setEmail($raw);
+
+        self::assertSame($user->getEmail(), EmailPolicy::normalize($raw));
+    }
+
+    // -------------------------------------------------------------------------
+    // isSameAddress()
+    // -------------------------------------------------------------------------
+
+    public function testIsSameAddressTrueForCaseAndTrailingSpaceDifferences(): void
+    {
+        self::assertTrue(EmailPolicy::isSameAddress('a@b.org', 'A@B.ORG '));
+    }
+
+    public function testIsSameAddressFalseForDifferentLocalPart(): void
+    {
+        self::assertFalse(EmailPolicy::isSameAddress('a.b@x.org', 'ab@x.org'));
+    }
+
+    public function testIsSameAddressFalseForPlusTag(): void
+    {
+        // Deliberately no Gmail-style +tag folding.
+        self::assertFalse(EmailPolicy::isSameAddress('a+1@x.org', 'a@x.org'));
+    }
+
+    // -------------------------------------------------------------------------
+    // findConflictingUid()
+    // -------------------------------------------------------------------------
+
+    public function testFindConflictingUidReturnsNullWhenFinderReturnsNothing(): void
+    {
+        $result = EmailPolicy::findConflictingUid('a@b.org', 42, static fn(string $email): array => []);
+
+        self::assertNull($result);
+    }
+
+    public function testFindConflictingUidReturnsNullWhenOnlyExcludedUidMatches(): void
+    {
+        $result = EmailPolicy::findConflictingUid('a@b.org', 42, static fn(string $email): array => [42]);
+
+        self::assertNull($result);
+    }
+
+    public function testFindConflictingUidReturnsOtherUidWhenPresent(): void
+    {
+        $result = EmailPolicy::findConflictingUid('a@b.org', 42, static fn(string $email): array => [42, 77]);
+
+        self::assertSame(77, $result);
+    }
+
+    public function testFindConflictingUidWithExcludeUidZeroTreatsAnyMatchAsConflict(): void
+    {
+        $result = EmailPolicy::findConflictingUid('a@b.org', 0, static fn(string $email): array => [77]);
+
+        self::assertSame(77, $result);
+    }
+
+    public function testFindConflictingUidPassesNormalizedEmailToFinder(): void
+    {
+        $captured = null;
+
+        EmailPolicy::findConflictingUid(' A<>@B.ORG ', 0, function (string $email) use (&$captured): array {
+            $captured = $email;
+            return [];
+        });
+
+        self::assertSame(EmailPolicy::normalize(' A<>@B.ORG '), $captured);
+    }
+}

--- a/tests/unit/library/Episciences/User/Validate/EmailAvailabilityTest.php
+++ b/tests/unit/library/Episciences/User/Validate/EmailAvailabilityTest.php
@@ -53,12 +53,16 @@ class EmailAvailabilityTest extends TestCase
 
     public function testMessagesAreResetBetweenCalls(): void
     {
-        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => [77]);
+        $calls = 0;
+        $finder = function (string $email) use (&$calls): array {
+            $calls++;
+            return $calls === 1 ? [77] : [];
+        };
+        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, $finder);
 
         self::assertFalse($validator->isValid('a@b.org'));
         self::assertNotEmpty($validator->getMessages());
 
-        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => []);
         self::assertTrue($validator->isValid('a@b.org'));
         self::assertSame([], $validator->getMessages());
     }

--- a/tests/unit/library/Episciences/User/Validate/EmailAvailabilityTest.php
+++ b/tests/unit/library/Episciences/User/Validate/EmailAvailabilityTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace unit\library\Episciences\User\Validate;
+
+use Episciences\User\Validate\EmailAvailability;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Episciences\User\Validate\EmailAvailability
+ */
+class EmailAvailabilityTest extends TestCase
+{
+    public function testIsValidFalseWhenFinderSignalsAnotherUid(): void
+    {
+        $validator = new EmailAvailability(42, 'A record matching email (%value%) was found.', static fn(string $email): array => [42, 77]);
+
+        self::assertFalse($validator->isValid('a@b.org'));
+    }
+
+    public function testGetMessagesContainsSubstitutedValueOnFailure(): void
+    {
+        $validator = new EmailAvailability(42, 'A record matching email (%value%) was found.', static fn(string $email): array => [42, 77]);
+
+        $validator->isValid('a@b.org');
+
+        self::assertSame(
+            ['emailNotAvailable' => 'A record matching email (a@b.org) was found.'],
+            $validator->getMessages()
+        );
+    }
+
+    public function testIsValidTrueWhenOnlyExcludedUidMatches(): void
+    {
+        $validator = new EmailAvailability(42, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => [42]);
+
+        self::assertTrue($validator->isValid('a@b.org'));
+        self::assertSame([], $validator->getMessages());
+    }
+
+    public function testIsValidTrueWhenFinderReturnsNothing(): void
+    {
+        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => []);
+
+        self::assertTrue($validator->isValid('a@b.org'));
+    }
+
+    public function testIsValidWithExcludeUidZeroRejectsAnyMatch(): void
+    {
+        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => [77]);
+
+        self::assertFalse($validator->isValid('a@b.org'));
+    }
+
+    public function testMessagesAreResetBetweenCalls(): void
+    {
+        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => [77]);
+
+        self::assertFalse($validator->isValid('a@b.org'));
+        self::assertNotEmpty($validator->getMessages());
+
+        $validator = new EmailAvailability(0, EmailAvailability::DEFAULT_MESSAGE, static fn(string $email): array => []);
+        self::assertTrue($validator->isValid('a@b.org'));
+        self::assertSame([], $validator->getMessages());
+    }
+}

--- a/tests/unit/modules/common/controllers/UserDefaultControllerRequestGuardTest.php
+++ b/tests/unit/modules/common/controllers/UserDefaultControllerRequestGuardTest.php
@@ -147,4 +147,84 @@ final class UserDefaultControllerRequestGuardTest extends TestCase
         self::assertStringNotContainsString("\$_SERVER['HTTP_HOST']", $method,
             'logoutAction must not build the return URL from the request host');
     }
+
+    // -----------------------------------------------------------------------
+    // Change-email flow: account-duplication / account-hijack regression guards
+    // -----------------------------------------------------------------------
+
+    public function testProcessChangeEmailNeverMutatesTheSessionIdentityDirectly(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        self::assertStringNotContainsString('Episciences_Auth::getUser()', $method,
+            'processChangeEmail must load a detached object, never Episciences_Auth::getUser() (D4)');
+    }
+
+    public function testProcessChangeEmailChecksSharedAccountsOnTheStoredEmail(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        self::assertStringContainsString('findLoginByEmail($currentEmail)', $method,
+            'the "multiple accounts" check must run on the address actually stored, not the raw submitted value (D3)');
+    }
+
+    public function testProcessChangeEmailNormalizesBeforeStoring(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        self::assertStringContainsString('EmailPolicy::normalize', $method,
+            'processChangeEmail must normalize the submitted value the same way it will be stored (D2)');
+    }
+
+    public function testProcessChangeEmailChecksAvailabilityBeforeWriting(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        $conflictPos = strpos($method, 'findConflictingUid');
+        $setEmailPos = strpos($method, '->setEmail(');
+        $savePos = strpos($method, '->save()');
+
+        self::assertNotFalse($conflictPos, 'processChangeEmail must check for a conflicting UID');
+        self::assertNotFalse($setEmailPos, 'processChangeEmail must call setEmail()');
+        self::assertNotFalse($savePos, 'processChangeEmail must call save()');
+        self::assertLessThan($setEmailPos, $conflictPos,
+            'the availability check must run before setEmail() (D1)');
+        self::assertLessThan($savePos, $setEmailPos,
+            'setEmail() must run before save()');
+    }
+
+    public function testProcessChangeEmailDropsStaleCacheBeforeRefreshingSession(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        $forgetPos = strpos($method, 'forgetStaticCache');
+        $updatePos = strpos($method, 'updateIdentity');
+
+        self::assertNotFalse($forgetPos, 'processChangeEmail must drop the stale identity cache entry (D5)');
+        self::assertNotFalse($updatePos, 'processChangeEmail must refresh the session identity');
+        self::assertLessThan($updatePos, $forgetPos,
+            'the cache must be dropped before the session is refreshed from it (D5)');
+    }
+
+    public function testProcessChangeEmailComparesUidsAsIntegers(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        self::assertDoesNotMatchRegularExpression('/getUid\(\)\s*===\s*\$postedUid/', $method,
+            'processChangeEmail must not compare getUid() to the raw posted value (D6)');
+        self::assertStringContainsString('(int)Episciences_Auth::getUid()', $method,
+            'processChangeEmail must cast the acting user\'s UID to int before comparing (D6)');
+    }
+
+    public function testResolveEmailChangeTargetUidScopesSecretariesToTheirReview(): void
+    {
+        $method = $this->extractMethod('resolveEmailChangeTargetUid');
+        self::assertStringContainsString('isSecretary()', $method,
+            'resolveEmailChangeTargetUid must require the secretary role to target another account (D8)');
+        self::assertStringContainsString('hasRoles(', $method,
+            'resolveEmailChangeTargetUid must check the target has a role in the current review (D8)');
+        self::assertStringContainsString('RVID', $method,
+            'resolveEmailChangeTargetUid must scope the role check to the current review (D8)');
+    }
+
+    public function testChangeAccountEmailActionUsesTheSharedTargetResolver(): void
+    {
+        $method = $this->extractMethod('changeaccountemailAction');
+        self::assertStringContainsString('resolveEmailChangeTargetUid(', $method,
+            'changeaccountemailAction must resolve its target the same way processChangeEmail does (D8)');
+    }
 }

--- a/tests/unit/modules/common/controllers/UserDefaultControllerRequestGuardTest.php
+++ b/tests/unit/modules/common/controllers/UserDefaultControllerRequestGuardTest.php
@@ -227,4 +227,60 @@ final class UserDefaultControllerRequestGuardTest extends TestCase
         self::assertStringContainsString('resolveEmailChangeTargetUid(', $method,
             'changeaccountemailAction must resolve its target the same way processChangeEmail does (D8)');
     }
+
+    // -----------------------------------------------------------------------
+    // processChangeEmail — open-redirect guard on forward-controller/forward-action
+    // -----------------------------------------------------------------------
+
+    public function testProcessChangeEmailSanitizesForwardRouteSegments(): void
+    {
+        $method = $this->extractMethod('processChangeEmail');
+        self::assertStringContainsString(
+            "sanitizeForwardRouteSegment(\$request->getParam('forward-controller'",
+            $method,
+            'processChangeEmail must sanitize forward-controller before using it to build a redirect URL (CWE-601)'
+        );
+        self::assertStringContainsString(
+            "sanitizeForwardRouteSegment(\$request->getParam('forward-action'",
+            $method,
+            'processChangeEmail must sanitize forward-action before using it to build a redirect URL (CWE-601)'
+        );
+    }
+
+    /**
+     * Extracts the validation regex from sanitizeForwardRouteSegment() and exercises
+     * it directly: proves the pattern itself rejects anything that could turn the
+     * redirect into an off-site URL, independently of how the method is wired in.
+     */
+    public function testSanitizeForwardRouteSegmentRegexRejectsUnsafeValues(): void
+    {
+        $method = $this->extractMethod('sanitizeForwardRouteSegment');
+        self::assertMatchesRegularExpression('/preg_match\(/', $method,
+            'sanitizeForwardRouteSegment must validate the value with preg_match()');
+
+        self::assertMatchesRegularExpression("/preg_match\\('([^']+)'/", $method, 'could not locate the validation pattern');
+        preg_match("/preg_match\\('([^']+)'/", $method, $matches);
+        $pattern = $matches[1];
+
+        $unsafe = [
+            'http://evil.example',
+            'https://evil.example',
+            '//evil.example',
+            '../../etc/passwd',
+            'a/b',
+            "a\nb",
+            '',
+            '1action',
+        ];
+
+        foreach ($unsafe as $value) {
+            self::assertSame(0, preg_match($pattern, $value), "expected \"$value\" to be rejected");
+        }
+
+        $safe = ['user', 'change_account_email', 'some-action', 'a1'];
+
+        foreach ($safe as $value) {
+            self::assertSame(1, preg_match($pattern, $value), "expected \"$value\" to be accepted");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #1161: introduces `Episciences\User\EmailPolicy` as the single point of decision for "is this email available", used consistently by the change-email form, account creation, and reviewer-invitation acceptance instead of separate, slightly-diverging checks.
- The change-email action now resolves its target account through one shared, review-scoped helper instead of trusting the raw posted field directly.
- `Episciences_User::save()` now invalidates its own request-level identity cache on every successful write, instead of only on the one call site patched in #1161.
- A failed CAS-side write no longer silently continues to update local account data with a stale UID.

## Test plan
- [x] New unit tests: `EmailPolicy`, `EmailAvailability` validator, `AccountResolver` conflict guard, structural guards for the controller and `Episciences_User::save()`
- [x] `make phpstan LEVEL=6` on touched/new files: no new errors vs. base
- [x] Full `make test-php` suite: no regression introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent email normalisation and availability checks across account creation, email changes and reviewer invitations.
  * Existing accounts can now be recognised and linked when a reviewer invitation uses an email already in use.
  * Users can update their email address without being incorrectly flagged for reusing their current address.

* **Bug Fixes**
  * Improved protection against duplicate accounts and conflicting email addresses.
  * Prevented local account updates when the underlying account save fails.
  * Refreshed account information after email changes to avoid displaying stale details.
  * Blocked unsafe redirects during email-change workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->