### PR TITLE
Migrate Scholexplorer dataset enrichment to API v3

### DIFF
--- a/application/modules/journal/views/scripts/paper/paper_datasets_software.phtml
+++ b/application/modules/journal/views/scripts/paper/paper_datasets_software.phtml
@@ -84,8 +84,7 @@ $isAllowedToManageRelations = Episciences_Auth::isAllowedToManagePaper() || $pap
                         </div>
                     <?php endif; ?>
                     <div style="margin-bottom: 4px"></div>
-                    <?php if ((string)$source !== Episciences_Repositories::SCHOLEXPLORER_ID
-                        && ($software->getName() === 'doi'
+                    <?php if (($software->getName() === 'doi'
                             || Episciences_Tools::isDoiWithUrl($software->getValue()) || $software->getName() === 'arXiv')
                         && $software->getMetatext() !== null) {
                         try {

--- a/config/dist-dev.pwd.json
+++ b/config/dist-dev.pwd.json
@@ -137,8 +137,14 @@
     "PLUS_API_TOKEN": "four random common words"
   },
   "OPENAIRE": {
-    "AUTH_URL": "https://aai.openaire.eu/token",
+    "AUTH_URL": "https://aai.openaire.eu/oidc/token",
     "API_URL": "https://api.openaire.eu/graph/v3/research-products",
+    "CLIENT_ID": "",
+    "CLIENT_SECRET": ""
+  },
+  "SCHOLEXPLORER": {
+    "AUTH_URL": "https://aai.openaire.eu/oidc/token",
+    "API_URL": "https://api.scholexplorer.openaire.eu/v3/Links",
     "CLIENT_ID": "",
     "CLIENT_SECRET": ""
   }

--- a/config/dist-pwd.json
+++ b/config/dist-pwd.json
@@ -155,10 +155,16 @@
     "PLUS_API_TOKEN": "Ash-nazg-durbatulûk"
   },
   "OPENAIRE": {
-    "AUTH_URL": "https://aai.openaire.eu/token",
+    "AUTH_URL": "https://aai.openaire.eu/oidc/token",
     "API_URL": "https://api.openaire.eu/graph/v3/research-products",
     "CLIENT_ID": "YOUR-OPENAIRE-CLIENT-ID",
     "CLIENT_SECRET": "YOUR-OPENAIRE-CLIENT-SECRET"
+  },
+  "SCHOLEXPLORER": {
+    "AUTH_URL": "https://aai.openaire.eu/oidc/token",
+    "API_URL": "https://api.scholexplorer.openaire.eu/v3/Links",
+    "CLIENT_ID": "YOUR-SCHOLEXPLORER-CLIENT-ID",
+    "CLIENT_SECRET": "YOUR-SCHOLEXPLORER-CLIENT-SECRET"
   },
   "NEXT": {
     "BASE_URL": "https://next.example.org",

--- a/library/Episciences/Api/AbstractApiClient.php
+++ b/library/Episciences/Api/AbstractApiClient.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 namespace Episciences\Api;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
  * Base class for all Episciences API clients.
  *
- * Provides shared caching helpers, default HTTP headers, and JSON constants.
+ * Provides shared caching helpers, default HTTP headers, JSON constants, and the
+ * common OpenAIRE-AAI HTTP request logic (bi-mode auth, adaptive throttling,
+ * 401/429 retry) reused by every client that talks to a graph.openaire.eu endpoint.
  * Concrete subclasses must inject a Guzzle Client and a PSR-6 cache pool
  * (either real FilesystemAdapter or ArrayAdapter for tests).
  */
@@ -20,15 +25,192 @@ abstract class AbstractApiClient
     public const ONE_MONTH = 3600 * 24 * 31;
     protected const JSON_MAX_DEPTH = 512;
 
+    // Rate limits per https://graph.openaire.eu/docs/apis/terms#authentication--limits
+    protected const AUTH_THROTTLE_MICROSECONDS = 500000; // 500ms (~2 req/s, quota 7200 req/h, authenticated)
+    protected const UNAUTH_THROTTLE_SECONDS    = 60;      // 60s (1 req/min, quota 60 req/h, anonymous)
+    protected const MAX_RETRIES = 3;
+
     protected Client $client;
     protected CacheItemPoolInterface $cache;
     protected LoggerInterface $logger;
+    protected ?OpenAireTokenProvider $tokenProvider = null;
 
     public function __construct(Client $client, CacheItemPoolInterface $cache, LoggerInterface $logger)
     {
         $this->client = $client;
         $this->cache = $cache;
         $this->logger = $logger;
+    }
+
+    /**
+     * True when a token provider is set up with client credentials (authenticated mode).
+     */
+    public function isAuthenticated(): bool
+    {
+        return $this->tokenProvider?->isConfigured() ?? false;
+    }
+
+    // -------------------------------------------------------------------------
+    // HTTP request with bi-mode auth, adaptive throttling, and 401/429 retry
+    // -------------------------------------------------------------------------
+
+    /**
+     * Issue the GET request, handling authentication, throttling, and 401/429 retry.
+     * Returns the raw response body, or null on unrecoverable error / exhausted retries.
+     *
+     * $serviceLabel is used only to prefix log messages (e.g. "OpenAIRE", "Scholexplorer").
+     */
+    protected function requestWithRetry(string $url, int $paperId, string $serviceLabel): ?string
+    {
+        $token   = $this->tokenProvider?->getAccessToken();
+        $headers = $this->defaultHeaders();
+
+        if ($token !== null) {
+            $headers['Authorization'] = 'Bearer ' . $token;
+            $this->throttleAuthenticated();
+        } else {
+            $this->logger->warning(
+                "{$serviceLabel} unauthenticated mode active: throttling for " . static::UNAUTH_THROTTLE_SECONDS . 's (rate limit: 60 req/h)'
+            );
+            $this->throttleUnauthenticated();
+        }
+
+        $attempt = 0;
+        $tokenRefreshed = false;
+        while ($attempt < static::MAX_RETRIES) {
+            $attempt++;
+            try {
+                $response = $this->client->get($url, [
+                    'headers'         => $headers,
+                    'timeout'         => 30,
+                    'allow_redirects' => [
+                        'max'       => 2,
+                        'strict'    => true,
+                        'referer'   => true,
+                        'protocols' => ['https'],
+                    ],
+                    'verify'          => true,
+                ]);
+
+                $this->logRateLimitStatus($response, $serviceLabel);
+                return $response->getBody()->getContents();
+            } catch (ClientException $e) {
+                $statusCode = $e->getResponse()->getStatusCode();
+
+                // 401 Unauthorized: token revoked/expired in authenticated mode -> refresh and
+                // retry once. Gated on a dedicated flag (not the attempt counter) so a 401
+                // occurring after a prior 429 backoff still gets a token refresh attempt.
+                if ($statusCode === 401 && $token !== null && $this->tokenProvider !== null && !$tokenRefreshed) {
+                    $tokenRefreshed = true;
+                    $this->logger->warning("{$serviceLabel} 401 Unauthorized received, refreshing token...");
+                    $this->tokenProvider->clearTokenCache();
+                    $token = $this->tokenProvider->getAccessToken();
+                    if ($token !== null) {
+                        $headers['Authorization'] = 'Bearer ' . $token;
+                        continue;
+                    }
+                }
+
+                // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
+                if ($statusCode === 429) {
+                    // Never block the request thread outside CLI execution (e.g. a request
+                    // triggered synchronously from a controller action).
+                    if (!$this->isCliContext()) {
+                        $this->logger->warning(
+                            "{$serviceLabel} 429 Too Many Requests for paper {$paperId}; not retrying outside CLI execution (would block the request)"
+                        );
+                        return null;
+                    }
+
+                    if ($attempt >= static::MAX_RETRIES) {
+                        $this->logger->critical(
+                            "{$serviceLabel} API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
+                        );
+                        return null;
+                    }
+
+                    $retryAfter   = (int) $e->getResponse()->getHeaderLine('Retry-After');
+                    $sleepSeconds = $token !== null
+                        ? ($retryAfter > 0 ? $retryAfter : ($attempt * 3))
+                        : max(static::UNAUTH_THROTTLE_SECONDS, $retryAfter);
+
+                    $this->logger->warning(
+                        "{$serviceLabel} 429 Too Many Requests for paper {$paperId} (attempt {$attempt}/" . static::MAX_RETRIES . "). Waiting {$sleepSeconds}s..."
+                    );
+                    $this->backoff($sleepSeconds);
+                    continue;
+                }
+
+                $this->logger->error("{$serviceLabel} API error for paper {$paperId} (HTTP {$statusCode}): " . $e->getMessage());
+                return null;
+            } catch (GuzzleException $e) {
+                $this->logger->error("{$serviceLabel} API connection error for paper {$paperId}: " . $e->getMessage());
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Log rate-limit response headers (x-ratelimit-used / x-ratelimit-limit), if present.
+     */
+    protected function logRateLimitStatus(ResponseInterface $response, string $serviceLabel): void
+    {
+        $used  = $response->getHeaderLine('x-ratelimit-used');
+        $limit = $response->getHeaderLine('x-ratelimit-limit');
+        if ($used === '' || $limit === '') {
+            return;
+        }
+
+        $this->logger->debug("{$serviceLabel} Rate Limit status: {$used}/{$limit}");
+        if ((int) $limit > 0 && (int) $used > ((int) $limit * 0.85)) {
+            $this->logger->warning("{$serviceLabel} Rate Limit threshold > 85%: {$used}/{$limit}");
+        }
+    }
+
+    /**
+     * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleAuthenticated(): void
+    {
+        if (!$this->isCliContext()) {
+            $this->logger->debug('authenticated throttle skipped outside CLI execution');
+            return;
+        }
+        usleep(static::AUTH_THROTTLE_MICROSECONDS);
+    }
+
+    /**
+     * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleUnauthenticated(): void
+    {
+        if (!$this->isCliContext()) {
+            $this->logger->debug('unauthenticated throttle skipped outside CLI execution');
+            return;
+        }
+        sleep(static::UNAUTH_THROTTLE_SECONDS);
+    }
+
+    /**
+     * Reactive backoff wait after an HTTP 429 response.
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function backoff(int $seconds): void
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * True when running under the CLI SAPI (batch commands), false for an HTTP request.
+     * Extracted as an overridable seam so tests can simulate the HTTP path.
+     */
+    protected function isCliContext(): bool
+    {
+        return PHP_SAPI === 'cli';
     }
 
     /**

--- a/library/Episciences/Api/OpenAireApiClient.php
+++ b/library/Episciences/Api/OpenAireApiClient.php
@@ -3,15 +3,12 @@ declare(strict_types=1);
 
 namespace Episciences\Api;
 
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface;
 use GuzzleHttp\Client;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -34,15 +31,9 @@ class OpenAireApiClient extends AbstractApiClient
     private const MAX_RESPONSE_SIZE = 5242880; // 5 MB
     private const ORCID_SCHEMES = ['orcid', 'orcid_pending'];
 
-    // Rate limits per https://graph.openaire.eu/docs/apis/terms#authentication--limits
-    private const AUTH_THROTTLE_MICROSECONDS = 500000; // 500ms (~2 req/s, quota 7200 req/h, authenticated)
-    private const UNAUTH_THROTTLE_SECONDS    = 60;      // 60s (1 req/min, quota 60 req/h, anonymous)
-    private const MAX_RETRIES = 3;
-
     private CacheItemPoolInterface $globalCache;
     private CacheItemPoolInterface $authorsCache;
     private CacheItemPoolInterface $fundingCache;
-    private ?OpenAireTokenProvider $tokenProvider;
 
     public function __construct(
         Client               $client,
@@ -58,14 +49,6 @@ class OpenAireApiClient extends AbstractApiClient
         $this->authorsCache  = $authorsCache;
         $this->fundingCache  = $fundingCache;
         $this->tokenProvider = $tokenProvider;
-    }
-
-    /**
-     * True when a token provider is set up with client credentials (authenticated mode).
-     */
-    public function isAuthenticated(): bool
-    {
-        return $this->tokenProvider?->isConfigured() ?? false;
     }
 
     // -------------------------------------------------------------------------
@@ -97,7 +80,7 @@ class OpenAireApiClient extends AbstractApiClient
         $url = rtrim($apiBaseUrl, '/') . '?pid=' . urlencode($doi);
         $this->logger->info("Fetching OpenAIRE data for DOI {$doi}");
 
-        $body = $this->requestWithRetry($url, $paperId);
+        $body = $this->requestWithRetry($url, $paperId, 'OpenAIRE');
         if ($body === null) {
             return null;
         }
@@ -129,176 +112,6 @@ class OpenAireApiClient extends AbstractApiClient
         $this->globalCache->save($item);
 
         return $decoded;
-    }
-
-    // -------------------------------------------------------------------------
-    // HTTP request with bi-mode auth, adaptive throttling, and 401/429 retry
-    // -------------------------------------------------------------------------
-
-    /**
-     * Issue the GET request, handling authentication, throttling, and 401/429 retry.
-     * Returns the raw response body, or null on unrecoverable error / exhausted retries.
-     */
-    private function requestWithRetry(string $url, int $paperId): ?string
-    {
-        $token   = $this->tokenProvider?->getAccessToken();
-        $headers = $this->defaultHeaders();
-
-        if ($token !== null) {
-            $headers['Authorization'] = 'Bearer ' . $token;
-            $this->throttleAuthenticated();
-        } else {
-            $this->logger->warning(
-                'OpenAIRE unauthenticated mode active: throttling for ' . self::UNAUTH_THROTTLE_SECONDS . 's (rate limit: 60 req/h)'
-            );
-            $this->throttleUnauthenticated();
-        }
-
-        $attempt = 0;
-        while ($attempt < self::MAX_RETRIES) {
-            $attempt++;
-            try {
-                $response = $this->client->get($url, [
-                    'headers'         => $headers,
-                    'timeout'         => 30,
-                    'allow_redirects' => [
-                        'max'       => 2,
-                        'strict'    => true,
-                        'referer'   => true,
-                        'protocols' => ['https'],
-                    ],
-                    'verify'          => true,
-                ]);
-
-                $this->logRateLimitStatus($response);
-                return $response->getBody()->getContents();
-            } catch (ClientException $e) {
-                $statusCode = $e->getResponse()->getStatusCode();
-
-                // 401 Unauthorized: token revoked/expired in authenticated mode -> refresh and retry once.
-                if ($statusCode === 401 && $token !== null && $this->tokenProvider !== null && $attempt === 1) {
-                    $this->logger->warning('OpenAIRE 401 Unauthorized received, refreshing token...');
-                    $this->tokenProvider->clearTokenCache();
-                    $token = $this->tokenProvider->getAccessToken();
-                    if ($token !== null) {
-                        $headers['Authorization'] = 'Bearer ' . $token;
-                        continue;
-                    }
-                }
-
-                // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
-                if ($statusCode === 429) {
-                    // Never block the request thread: this path is also reachable synchronously
-                    // from PaperController/AdministratepaperController via updateRecordData().
-                    if (!$this->isCliContext()) {
-                        $this->logger->warning(
-                            "OpenAIRE 429 Too Many Requests for paper {$paperId}; not retrying outside CLI execution (would block the request)"
-                        );
-                        return null;
-                    }
-
-                    if ($attempt >= self::MAX_RETRIES) {
-                        $this->logger->critical(
-                            "OpenAIRE API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
-                        );
-                        return null;
-                    }
-
-                    $retryAfter   = (int) $e->getResponse()->getHeaderLine('Retry-After');
-                    $sleepSeconds = $token !== null
-                        ? ($retryAfter > 0 ? $retryAfter : ($attempt * 3))
-                        : max(self::UNAUTH_THROTTLE_SECONDS, $retryAfter);
-
-                    $this->logger->warning(
-                        "OpenAIRE 429 Too Many Requests for paper {$paperId} (attempt {$attempt}/" . self::MAX_RETRIES . "). Waiting {$sleepSeconds}s..."
-                    );
-                    $this->backoff($sleepSeconds);
-                    continue;
-                }
-
-                $this->logger->error("OpenAIRE API error for paper {$paperId} (HTTP {$statusCode}): " . $e->getMessage());
-                return null;
-            } catch (GuzzleException $e) {
-                $this->logger->error("OpenAIRE API connection error for paper {$paperId}: " . $e->getMessage());
-                return null;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Log OpenAIRE rate-limit response headers (x-ratelimit-used / x-ratelimit-limit), if present.
-     */
-    private function logRateLimitStatus(ResponseInterface $response): void
-    {
-        $used  = $response->getHeaderLine('x-ratelimit-used');
-        $limit = $response->getHeaderLine('x-ratelimit-limit');
-        if ($used === '' || $limit === '') {
-            return;
-        }
-
-        $this->logger->debug("OpenAIRE Rate Limit status: {$used}/{$limit}");
-        if ((int) $limit > 0 && (int) $used > ((int) $limit * 0.85)) {
-            $this->logger->warning("OpenAIRE Rate Limit threshold > 85%: {$used}/{$limit}");
-        }
-    }
-
-    /**
-     * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
-     * Extracted as an overridable seam so tests can skip the real delay.
-     *
-     * Restricted to CLI execution for the same reason as throttleUnauthenticated(): a
-     * request triggered from PaperController/AdministratepaperController must never be
-     * delayed for UI/UX reasons. Skipping the 500ms pacing on an isolated HTTP-triggered
-     * call is safe — the pacing only matters for back-to-back CLI batch requests.
-     */
-    protected function throttleAuthenticated(): void
-    {
-        if (!$this->isCliContext()) {
-            $this->logger->debug('OpenAIRE authenticated throttle skipped outside CLI execution (HTTP request path)');
-            return;
-        }
-        usleep(self::AUTH_THROTTLE_MICROSECONDS);
-    }
-
-    /**
-     * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
-     * Extracted as an overridable seam so tests can skip the real delay.
-     *
-     * Restricted to CLI execution: this path is also reachable synchronously from
-     * PaperController/AdministratepaperController via PapersManager::updateRecordData(),
-     * and a 60s sleep() would block a PHP-FPM worker for a full minute per request.
-     */
-    protected function throttleUnauthenticated(): void
-    {
-        if (!$this->isCliContext()) {
-            $this->logger->debug('OpenAIRE unauthenticated throttle skipped outside CLI execution (HTTP request path)');
-            return;
-        }
-        sleep(self::UNAUTH_THROTTLE_SECONDS);
-    }
-
-    /**
-     * Reactive backoff wait after an HTTP 429 response.
-     * Extracted as an overridable seam so tests can skip the real delay.
-     *
-     * Only ever called from a CLI context: requestWithRetry() returns before reaching
-     * this call outside CLI execution, so the request thread is never blocked here.
-     */
-    protected function backoff(int $seconds): void
-    {
-        sleep($seconds);
-    }
-
-    /**
-     * True when running under the CLI SAPI (batch commands), false for an HTTP request
-     * (e.g. PaperController/AdministratepaperController). Extracted as an overridable
-     * seam so tests can simulate the HTTP path without faking the global PHP_SAPI value.
-     */
-    protected function isCliContext(): bool
-    {
-        return PHP_SAPI === 'cli';
     }
 
     // -------------------------------------------------------------------------

--- a/library/Episciences/Api/OpenAireTokenProvider.php
+++ b/library/Episciences/Api/OpenAireTokenProvider.php
@@ -22,7 +22,7 @@ use Psr\Log\LoggerInterface;
 class OpenAireTokenProvider
 {
     private const CACHE_KEY = 'openaire_access_token';
-    private const DEFAULT_AUTH_URL = 'https://aai.openaire.eu/token';
+    private const DEFAULT_AUTH_URL = 'https://aai.openaire.eu/oidc/token';
     private const SAFETY_MARGIN_SECONDS = 120; // renew 2 minutes before actual expiry
     private const MIN_TTL_SECONDS = 60;
     private const JSON_MAX_DEPTH = 512;

--- a/library/Episciences/Api/ScholexplorerApiClient.php
+++ b/library/Episciences/Api/ScholexplorerApiClient.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 namespace Episciences\Api;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
 use Monolog\Logger;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -19,7 +16,7 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
  * @see https://graph.openaire.eu/docs/apis/scholexplorer/v3/version
  *
  * Cache namespaces:
- *  - scholexplorerLinkData  : md5($doi) . '_v3_links.json'
+ *  - scholexplorerLinkData  : md5($doi . '|' . $targetType . '|' . $bidirectional) . '_v3_links.json'
  *  - scholexplorerAuthToken : dedicated FilesystemAdapter pool for OpenAireTokenProvider
  *                             (same 'openaire_access_token' cache key as the OpenAIRE Graph
  *                             client, but isolated in its own pool — no collision).
@@ -30,27 +27,50 @@ class ScholexplorerApiClient extends AbstractApiClient
     private const MAX_RESPONSE_SIZE = 5242880; // 5 MB
     private const PAGE_SIZE = 50; // max 100
 
-    // Rate limits per https://graph.openaire.eu/docs/apis/terms#authentication--limits
-    private const AUTH_THROTTLE_MICROSECONDS = 500000; // 500ms (~2 req/s, quota 7200 req/h, authenticated)
-    private const UNAUTH_THROTTLE_SECONDS    = 60;      // 60s (1 req/min, quota 60 req/h, anonymous)
-    private const MAX_RETRIES = 3;
-
     // Priority order for canonical identifier selection (Identifier[].IDScheme).
     private const IDENTIFIER_SCHEME_PRIORITY = ['doi', 'handle', 'swhid', 'url'];
 
     // Reciprocal relationship mapping applied when the connected entity was found via
     // a targetPid query (i.e. it declared our DOI as its target): the relationship name
     // carried by the Scholix record describes "entity -> our article", so it must be
-    // flipped to describe "our article -> entity" before being stored.
+    // flipped to describe "our article -> entity" before being stored. Covers the full
+    // DataCite/Scholix relation-type vocabulary as a symmetric involution.
     private const RELATIONSHIP_INVERSES = [
-        'IsSupplementTo'     => 'IsSupplementedBy',
-        'IsSupplementedBy'   => 'IsSupplementTo',
-        'References'         => 'IsReferencedBy',
-        'IsReferencedBy'     => 'References',
-        'IsRelatedTo'        => 'IsRelatedTo',
+        'IsCitedBy'           => 'Cites',
+        'Cites'               => 'IsCitedBy',
+        'IsSupplementTo'      => 'IsSupplementedBy',
+        'IsSupplementedBy'    => 'IsSupplementTo',
+        'IsContinuedBy'       => 'Continues',
+        'Continues'           => 'IsContinuedBy',
+        'IsDescribedBy'       => 'Describes',
+        'Describes'           => 'IsDescribedBy',
+        'HasMetadata'         => 'IsMetadataFor',
+        'IsMetadataFor'       => 'HasMetadata',
+        'HasVersion'          => 'IsVersionOf',
+        'IsVersionOf'         => 'HasVersion',
+        'IsNewVersionOf'      => 'IsPreviousVersionOf',
+        'IsPreviousVersionOf' => 'IsNewVersionOf',
+        'IsPartOf'            => 'HasPart',
+        'HasPart'             => 'IsPartOf',
+        'IsReferencedBy'      => 'References',
+        'References'          => 'IsReferencedBy',
+        'IsDocumentedBy'      => 'Documents',
+        'Documents'           => 'IsDocumentedBy',
+        'IsCompiledBy'        => 'Compiles',
+        'Compiles'            => 'IsCompiledBy',
+        'IsVariantFormOf'     => 'IsOriginalFormOf',
+        'IsOriginalFormOf'    => 'IsVariantFormOf',
+        'IsIdenticalTo'       => 'IsIdenticalTo',
+        'IsReviewedBy'        => 'Reviews',
+        'Reviews'             => 'IsReviewedBy',
+        'IsDerivedFrom'       => 'IsSourceOf',
+        'IsSourceOf'          => 'IsDerivedFrom',
+        'IsRequiredBy'        => 'Requires',
+        'Requires'            => 'IsRequiredBy',
+        'IsObsoletedBy'       => 'Obsoletes',
+        'Obsoletes'           => 'IsObsoletedBy',
+        'IsRelatedTo'         => 'IsRelatedTo',
     ];
-
-    private ?OpenAireTokenProvider $tokenProvider;
 
     public function __construct(
         Client $client,
@@ -60,14 +80,6 @@ class ScholexplorerApiClient extends AbstractApiClient
     ) {
         parent::__construct($client, $cache, $logger);
         $this->tokenProvider = $tokenProvider;
-    }
-
-    /**
-     * True when a token provider is set up with client credentials (authenticated mode).
-     */
-    public function isAuthenticated(): bool
-    {
-        return $this->tokenProvider?->isConfigured() ?? false;
     }
 
     // -------------------------------------------------------------------------
@@ -94,7 +106,7 @@ class ScholexplorerApiClient extends AbstractApiClient
         bool $bidirectional = true,
         bool $forceRefresh = false
     ): array {
-        $cacheKey = md5($doi) . '_v3_links.json';
+        $cacheKey = md5($doi . '|' . $targetType . '|' . ($bidirectional ? '1' : '0')) . '_v3_links.json';
 
         if (!$forceRefresh) {
             $cached = $this->getCached($cacheKey);
@@ -149,7 +161,7 @@ class ScholexplorerApiClient extends AbstractApiClient
 
         do {
             $url  = $this->buildUrl($doi, $pidParam, $typeParam, $entityType, $page);
-            $body = $this->requestWithRetry($url, $docId);
+            $body = $this->requestWithRetry($url, $docId, 'Scholexplorer');
 
             if ($body === null) {
                 break;
@@ -239,9 +251,19 @@ class ScholexplorerApiClient extends AbstractApiClient
                 continue;
             }
 
-            $relationshipName = $item['RelationshipType']['Name'] ?? 'IsRelatedTo';
+            $relationshipTypeNode = $item['RelationshipType'] ?? null;
+            $relationshipName = is_array($relationshipTypeNode) ? ($relationshipTypeNode['Name'] ?? null) : null;
+            if (!is_string($relationshipName) || $relationshipName === '') {
+                $relationshipName = 'IsRelatedTo';
+            }
             if ($direction === 'targetPid') {
-                $relationshipName = self::RELATIONSHIP_INVERSES[$relationshipName] ?? $relationshipName;
+                if (isset(self::RELATIONSHIP_INVERSES[$relationshipName])) {
+                    $relationshipName = self::RELATIONSHIP_INVERSES[$relationshipName];
+                } else {
+                    $this->logger->warning(
+                        "Scholexplorer: no known inverse for relationship type '{$relationshipName}'; storing as-is"
+                    );
+                }
             }
 
             $publisher = $connectedEntity['Publisher'][0]['name'] ?? null;
@@ -411,174 +433,41 @@ class ScholexplorerApiClient extends AbstractApiClient
         return ['literal' => $name];
     }
 
+    /**
+     * Extract a plausible year from a Scholix PublicationDate. Only accepts a bare
+     * "YYYY" or an ISO 8601 "YYYY-MM-DD" prefix, so non-date strings (e.g. an epoch
+     * millisecond timestamp) are rejected rather than mismatched to their leading digits.
+     */
     private function extractYear(string $date): ?int
     {
-        if (preg_match('/(\d{4})/', $date, $matches) === 1) {
+        if (preg_match('/^(\d{4})(?:-\d{2}-\d{2})?$/', trim($date), $matches) === 1) {
             return (int) $matches[1];
         }
         return null;
     }
 
     // -------------------------------------------------------------------------
-    // HTTP request with bi-mode auth, adaptive throttling, and 401/429 retry
-    // -------------------------------------------------------------------------
-
-    /**
-     * Issue the GET request, handling authentication, throttling, and 401/429 retry.
-     * Returns the raw response body, or null on unrecoverable error / exhausted retries.
-     */
-    private function requestWithRetry(string $url, int $paperId): ?string
-    {
-        $token   = $this->tokenProvider?->getAccessToken();
-        $headers = $this->defaultHeaders();
-
-        if ($token !== null) {
-            $headers['Authorization'] = 'Bearer ' . $token;
-            $this->throttleAuthenticated();
-        } else {
-            $this->logger->warning(
-                'Scholexplorer unauthenticated mode active: throttling for ' . self::UNAUTH_THROTTLE_SECONDS . 's (rate limit: 60 req/h)'
-            );
-            $this->throttleUnauthenticated();
-        }
-
-        $attempt = 0;
-        while ($attempt < self::MAX_RETRIES) {
-            $attempt++;
-            try {
-                $response = $this->client->get($url, [
-                    'headers'         => $headers,
-                    'timeout'         => 30,
-                    'allow_redirects' => [
-                        'max'       => 2,
-                        'strict'    => true,
-                        'referer'   => true,
-                        'protocols' => ['https'],
-                    ],
-                    'verify'          => true,
-                ]);
-
-                $this->logRateLimitStatus($response);
-                return $response->getBody()->getContents();
-            } catch (ClientException $e) {
-                $statusCode = $e->getResponse()->getStatusCode();
-
-                // 401 Unauthorized: token revoked/expired in authenticated mode -> refresh and retry once.
-                if ($statusCode === 401 && $token !== null && $this->tokenProvider !== null && $attempt === 1) {
-                    $this->logger->warning('Scholexplorer 401 Unauthorized received, refreshing token...');
-                    $this->tokenProvider->clearTokenCache();
-                    $token = $this->tokenProvider->getAccessToken();
-                    if ($token !== null) {
-                        $headers['Authorization'] = 'Bearer ' . $token;
-                        continue;
-                    }
-                }
-
-                // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
-                if ($statusCode === 429) {
-                    // Never block the request thread: enrichment:links only runs in CLI,
-                    // but this seam matches OpenAireApiClient's guard for consistency and safety.
-                    if (!$this->isCliContext()) {
-                        $this->logger->warning(
-                            "Scholexplorer 429 Too Many Requests for paper {$paperId}; not retrying outside CLI execution (would block the request)"
-                        );
-                        return null;
-                    }
-
-                    if ($attempt >= self::MAX_RETRIES) {
-                        $this->logger->critical(
-                            "Scholexplorer API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
-                        );
-                        return null;
-                    }
-
-                    $retryAfter   = (int) $e->getResponse()->getHeaderLine('Retry-After');
-                    $sleepSeconds = $token !== null
-                        ? ($retryAfter > 0 ? $retryAfter : ($attempt * 3))
-                        : max(self::UNAUTH_THROTTLE_SECONDS, $retryAfter);
-
-                    $this->logger->warning(
-                        "Scholexplorer 429 Too Many Requests for paper {$paperId} (attempt {$attempt}/" . self::MAX_RETRIES . "). Waiting {$sleepSeconds}s..."
-                    );
-                    $this->backoff($sleepSeconds);
-                    continue;
-                }
-
-                $this->logger->error("Scholexplorer API error for paper {$paperId} (HTTP {$statusCode}): " . $e->getMessage());
-                return null;
-            } catch (GuzzleException $e) {
-                $this->logger->error("Scholexplorer API connection error for paper {$paperId}: " . $e->getMessage());
-                return null;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Log Scholexplorer rate-limit response headers (x-ratelimit-used / x-ratelimit-limit), if present.
-     */
-    private function logRateLimitStatus(ResponseInterface $response): void
-    {
-        $used  = $response->getHeaderLine('x-ratelimit-used');
-        $limit = $response->getHeaderLine('x-ratelimit-limit');
-        if ($used === '' || $limit === '') {
-            return;
-        }
-
-        $this->logger->debug("Scholexplorer Rate Limit status: {$used}/{$limit}");
-        if ((int) $limit > 0 && (int) $used > ((int) $limit * 0.85)) {
-            $this->logger->warning("Scholexplorer Rate Limit threshold > 85%: {$used}/{$limit}");
-        }
-    }
-
-    /**
-     * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
-     * Extracted as an overridable seam so tests can skip the real delay.
-     */
-    protected function throttleAuthenticated(): void
-    {
-        if (!$this->isCliContext()) {
-            $this->logger->debug('Scholexplorer authenticated throttle skipped outside CLI execution');
-            return;
-        }
-        usleep(self::AUTH_THROTTLE_MICROSECONDS);
-    }
-
-    /**
-     * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
-     * Extracted as an overridable seam so tests can skip the real delay.
-     */
-    protected function throttleUnauthenticated(): void
-    {
-        if (!$this->isCliContext()) {
-            $this->logger->debug('Scholexplorer unauthenticated throttle skipped outside CLI execution');
-            return;
-        }
-        sleep(self::UNAUTH_THROTTLE_SECONDS);
-    }
-
-    /**
-     * Reactive backoff wait after an HTTP 429 response.
-     * Extracted as an overridable seam so tests can skip the real delay.
-     */
-    protected function backoff(int $seconds): void
-    {
-        sleep($seconds);
-    }
-
-    /**
-     * True when running under the CLI SAPI (batch commands), false for an HTTP request.
-     * Extracted as an overridable seam so tests can simulate the HTTP path.
-     */
-    protected function isCliContext(): bool
-    {
-        return PHP_SAPI === 'cli';
-    }
-
-    // -------------------------------------------------------------------------
     // Static factory
     // -------------------------------------------------------------------------
+
+    /**
+     * Read a credential/config constant, falling back to a second constant, then to
+     * a default. Used by create() to prefer SCHOLEXPLORER_* config over OPENAIRE_*.
+     */
+    private static function resolveConfigConstant(string $constant, ?string $fallbackConstant, ?string $default = null): ?string
+    {
+        // @phpstan-ignore notIdentical.alwaysTrue
+        if (defined($constant) && (string) constant($constant) !== '') {
+            return (string) constant($constant);
+        }
+
+        // @phpstan-ignore notIdentical.alwaysTrue
+        if ($fallbackConstant !== null && defined($fallbackConstant) && (string) constant($fallbackConstant) !== '') {
+            return (string) constant($fallbackConstant);
+        }
+
+        return $default;
+    }
 
     /**
      * Build a production-ready instance using FilesystemAdapter caches and a file logger.
@@ -596,23 +485,9 @@ class ScholexplorerApiClient extends AbstractApiClient
         $logger   = $logger ?? new Logger('scholexplorer_api_client');
 
         if ($tokenProvider === null) {
-            // @phpstan-ignore notIdentical.alwaysTrue
-            $clientId = defined('SCHOLEXPLORER_CLIENT_ID') && (string) constant('SCHOLEXPLORER_CLIENT_ID') !== ''
-                ? (string) constant('SCHOLEXPLORER_CLIENT_ID')
-                // @phpstan-ignore notIdentical.alwaysTrue
-                : (defined('OPENAIRE_CLIENT_ID') && (string) constant('OPENAIRE_CLIENT_ID') !== '' ? (string) constant('OPENAIRE_CLIENT_ID') : null);
-
-            // @phpstan-ignore notIdentical.alwaysTrue
-            $clientSecret = defined('SCHOLEXPLORER_CLIENT_SECRET') && (string) constant('SCHOLEXPLORER_CLIENT_SECRET') !== ''
-                ? (string) constant('SCHOLEXPLORER_CLIENT_SECRET')
-                // @phpstan-ignore notIdentical.alwaysTrue
-                : (defined('OPENAIRE_CLIENT_SECRET') && (string) constant('OPENAIRE_CLIENT_SECRET') !== '' ? (string) constant('OPENAIRE_CLIENT_SECRET') : null);
-
-            // @phpstan-ignore notIdentical.alwaysTrue
-            $authUrl = defined('SCHOLEXPLORER_AUTH_URL') && (string) constant('SCHOLEXPLORER_AUTH_URL') !== ''
-                ? (string) constant('SCHOLEXPLORER_AUTH_URL')
-                // @phpstan-ignore notIdentical.alwaysTrue
-                : (defined('OPENAIRE_AUTH_URL') && (string) constant('OPENAIRE_AUTH_URL') !== '' ? (string) constant('OPENAIRE_AUTH_URL') : 'https://aai.openaire.eu/oidc/token');
+            $clientId     = self::resolveConfigConstant('SCHOLEXPLORER_CLIENT_ID', 'OPENAIRE_CLIENT_ID');
+            $clientSecret = self::resolveConfigConstant('SCHOLEXPLORER_CLIENT_SECRET', 'OPENAIRE_CLIENT_SECRET');
+            $authUrl      = self::resolveConfigConstant('SCHOLEXPLORER_AUTH_URL', 'OPENAIRE_AUTH_URL', 'https://aai.openaire.eu/oidc/token');
 
             $tokenProvider = new OpenAireTokenProvider(
                 new Client(),

--- a/library/Episciences/Api/ScholexplorerApiClient.php
+++ b/library/Episciences/Api/ScholexplorerApiClient.php
@@ -1,0 +1,634 @@
+<?php
+declare(strict_types=1);
+
+namespace Episciences\Api;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\GuzzleException;
+use Monolog\Logger;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+/**
+ * Scholexplorer API v3 client (OpenAIRE Scholix 3.0 schema).
+ *
+ * @see https://graph.openaire.eu/docs/apis/scholexplorer/v3/version
+ *
+ * Cache namespaces:
+ *  - scholexplorerLinkData  : md5($doi) . '_v3_links.json'
+ *  - scholexplorerAuthToken : dedicated FilesystemAdapter pool for OpenAireTokenProvider
+ *                             (same 'openaire_access_token' cache key as the OpenAIRE Graph
+ *                             client, but isolated in its own pool — no collision).
+ */
+class ScholexplorerApiClient extends AbstractApiClient
+{
+    private const DEFAULT_API_URL = 'https://api.scholexplorer.openaire.eu/v3/Links';
+    private const MAX_RESPONSE_SIZE = 5242880; // 5 MB
+    private const PAGE_SIZE = 50; // max 100
+
+    // Rate limits per https://graph.openaire.eu/docs/apis/terms#authentication--limits
+    private const AUTH_THROTTLE_MICROSECONDS = 500000; // 500ms (~2 req/s, quota 7200 req/h, authenticated)
+    private const UNAUTH_THROTTLE_SECONDS    = 60;      // 60s (1 req/min, quota 60 req/h, anonymous)
+    private const MAX_RETRIES = 3;
+
+    // Priority order for canonical identifier selection (Identifier[].IDScheme).
+    private const IDENTIFIER_SCHEME_PRIORITY = ['doi', 'handle', 'swhid', 'url'];
+
+    // Reciprocal relationship mapping applied when the connected entity was found via
+    // a targetPid query (i.e. it declared our DOI as its target): the relationship name
+    // carried by the Scholix record describes "entity -> our article", so it must be
+    // flipped to describe "our article -> entity" before being stored.
+    private const RELATIONSHIP_INVERSES = [
+        'IsSupplementTo'     => 'IsSupplementedBy',
+        'IsSupplementedBy'   => 'IsSupplementTo',
+        'References'         => 'IsReferencedBy',
+        'IsReferencedBy'     => 'References',
+        'IsRelatedTo'        => 'IsRelatedTo',
+    ];
+
+    private ?OpenAireTokenProvider $tokenProvider;
+
+    public function __construct(
+        Client $client,
+        CacheItemPoolInterface $cache,
+        LoggerInterface $logger,
+        ?OpenAireTokenProvider $tokenProvider = null
+    ) {
+        parent::__construct($client, $cache, $logger);
+        $this->tokenProvider = $tokenProvider;
+    }
+
+    /**
+     * True when a token provider is set up with client credentials (authenticated mode).
+     */
+    public function isAuthenticated(): bool
+    {
+        return $this->tokenProvider?->isConfigured() ?? false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Links fetch (bidirectional, paginated, cached, deduplicated)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fetch Scholix links for a DOI, cached in the scholexplorerLinkData pool.
+     *
+     * Queries sourcePid={doi}&targetType={targetType} and, unless $bidirectional is
+     * false, also targetPid={doi}&sourceType={targetType}, merges both directions,
+     * and deduplicates by canonical identifier (see extractCanonicalIdentifier()).
+     *
+     * Returns an array of link items, each shaped as:
+     *   ['identifier', 'scheme', 'link', 'relationship', 'publisher', 'type', 'raw']
+     *
+     * @return array<int, array<string, mixed>>
+     * @throws InvalidArgumentException
+     */
+    public function fetchLinksForDoi(
+        string $doi,
+        int $docId,
+        string $targetType = 'dataset',
+        bool $bidirectional = true,
+        bool $forceRefresh = false
+    ): array {
+        $cacheKey = md5($doi) . '_v3_links.json';
+
+        if (!$forceRefresh) {
+            $cached = $this->getCached($cacheKey);
+            if ($cached !== null) {
+                $this->logger->info("Scholexplorer links from cache for DOI {$doi}");
+                try {
+                    $decoded = json_decode($cached, true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
+                } catch (\JsonException $e) {
+                    $this->logger->error("Scholexplorer cache JSON decode error for DOI {$doi}: " . $e->getMessage());
+                    $decoded = [];
+                }
+                return is_array($decoded) ? $decoded : [];
+            }
+        }
+
+        $this->logger->info("Fetching Scholexplorer links for DOI {$doi}");
+
+        $directed = array_map(
+            static fn(array $item): array => ['direction' => 'sourcePid', 'item' => $item],
+            $this->fetchDirection($doi, $docId, 'sourcePid', 'targetType', $targetType)
+        );
+
+        if ($bidirectional) {
+            $directed = array_merge($directed, array_map(
+                static fn(array $item): array => ['direction' => 'targetPid', 'item' => $item],
+                $this->fetchDirection($doi, $docId, 'targetPid', 'sourceType', $targetType)
+            ));
+        }
+
+        $unique = $this->deduplicateLinks($directed);
+
+        $this->saveToCache($cacheKey, json_encode($unique, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $unique;
+    }
+
+    /**
+     * Fetch every page of Scholix "result" records for one query direction.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchDirection(
+        string $doi,
+        int $docId,
+        string $pidParam,
+        string $typeParam,
+        string $entityType
+    ): array {
+        $items = [];
+        $page = 0;
+        $totalPages = 1;
+
+        do {
+            $url  = $this->buildUrl($doi, $pidParam, $typeParam, $entityType, $page);
+            $body = $this->requestWithRetry($url, $docId);
+
+            if ($body === null) {
+                break;
+            }
+
+            if (strlen($body) > self::MAX_RESPONSE_SIZE) {
+                $this->logger->error(sprintf(
+                    'Scholexplorer response too large for DOI %s (%d bytes)',
+                    $doi,
+                    strlen($body)
+                ));
+                break;
+            }
+
+            try {
+                $decoded = json_decode($body, true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                $this->logger->error(sprintf(
+                    'JSON decode error for paper %d (Scholexplorer): %s',
+                    $docId,
+                    $e->getMessage()
+                ));
+                break;
+            }
+
+            $pageItems = $decoded['result'] ?? [];
+            if (!is_array($pageItems)) {
+                break;
+            }
+
+            $items = array_merge($items, $pageItems);
+            $totalPages = max(1, (int) ($decoded['totalPages'] ?? 1));
+            $page++;
+        } while ($page < $totalPages);
+
+        return $items;
+    }
+
+    private function buildUrl(string $doi, string $pidParam, string $typeParam, string $entityType, int $page): string
+    {
+        // @phpstan-ignore notIdentical.alwaysTrue
+        $apiBaseUrl = (defined('SCHOLEXPLORER_API_URL') && (string) constant('SCHOLEXPLORER_API_URL') !== '')
+            ? (string) constant('SCHOLEXPLORER_API_URL')
+            : self::DEFAULT_API_URL;
+
+        $query = http_build_query([
+            $pidParam  => $doi,
+            $typeParam => $entityType,
+            'page'     => $page,
+            'size'     => self::PAGE_SIZE,
+        ]);
+
+        return rtrim($apiBaseUrl, '/') . '?' . $query;
+    }
+
+    /**
+     * Merge the sourcePid/targetPid result sets, keeping a single entry per connected
+     * entity (keyed by "{type}:{canonical identifier}") and harmonizing the relationship
+     * name to always describe "our article -> connected entity".
+     *
+     * @param array<int, array{direction: string, item: array<string, mixed>}> $directedItems
+     * @return array<int, array<string, mixed>>
+     */
+    private function deduplicateLinks(array $directedItems): array
+    {
+        $unique = [];
+
+        foreach ($directedItems as $directed) {
+            $direction = $directed['direction'];
+            $item      = $directed['item'];
+
+            $connectedEntity = $direction === 'sourcePid' ? ($item['target'] ?? null) : ($item['source'] ?? null);
+            if (!is_array($connectedEntity)) {
+                continue;
+            }
+
+            $identifiers = $connectedEntity['Identifier'] ?? [];
+            $canonical   = $this->extractCanonicalIdentifier(is_array($identifiers) ? $identifiers : []);
+            if ($canonical === null) {
+                continue;
+            }
+
+            $entityType = strtolower((string) ($connectedEntity['Type'] ?? 'dataset'));
+            $uniqueKey  = $entityType . ':' . $canonical['id'];
+
+            if (isset($unique[$uniqueKey])) {
+                continue;
+            }
+
+            $relationshipName = $item['RelationshipType']['Name'] ?? 'IsRelatedTo';
+            if ($direction === 'targetPid') {
+                $relationshipName = self::RELATIONSHIP_INVERSES[$relationshipName] ?? $relationshipName;
+            }
+
+            $publisher = $connectedEntity['Publisher'][0]['name'] ?? null;
+
+            $unique[$uniqueKey] = [
+                'identifier'   => $canonical['id'],
+                'scheme'       => $canonical['scheme'],
+                'link'         => $canonical['url'],
+                'relationship' => $relationshipName,
+                'publisher'    => is_string($publisher) ? $publisher : null,
+                'type'         => $entityType,
+                'raw'          => $connectedEntity,
+            ];
+        }
+
+        return array_values($unique);
+    }
+
+    // -------------------------------------------------------------------------
+    // Canonical identifier extraction & normalization
+    // -------------------------------------------------------------------------
+
+    /**
+     * Select the canonical persistent identifier for a Scholix entity, following the
+     * priority order doi > handle > swhid > url. OpenAIRE-internal identifiers (any
+     * other IDScheme) are never eligible.
+     *
+     * @param array<int, mixed> $identifiers Decoded JSON from an external API: element shape is not guaranteed.
+     * @return array{id: string, scheme: string, url: ?string}|null
+     */
+    public function extractCanonicalIdentifier(array $identifiers): ?array
+    {
+        foreach (self::IDENTIFIER_SCHEME_PRIORITY as $priorityScheme) {
+            foreach ($identifiers as $identifier) {
+                if (!is_array($identifier)) {
+                    continue;
+                }
+
+                $scheme = strtolower((string) ($identifier['IDScheme'] ?? ''));
+                $id     = $identifier['ID'] ?? null;
+
+                if ($scheme !== $priorityScheme || !is_string($id) || $id === '') {
+                    continue;
+                }
+
+                $url = $identifier['IDURL'] ?? null;
+
+                return [
+                    'id'     => $this->normalizeIdentifier($id),
+                    'scheme' => $priorityScheme,
+                    'url'    => is_string($url) && $url !== '' ? $url : null,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeIdentifier(string $id): string
+    {
+        $id = trim($id);
+        foreach (['https://doi.org/', 'http://dx.doi.org/', 'https://dx.doi.org/'] as $prefix) {
+            if (stripos($id, $prefix) === 0) {
+                $id = substr($id, strlen($prefix));
+                break;
+            }
+        }
+        return strtolower($id);
+    }
+
+    // -------------------------------------------------------------------------
+    // CSL-JSON fallback (used when Crossref/DataCite metadata is unavailable)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a synthetic CSL-JSON structure directly from a Scholix entity (source or
+     * target), used as a resilient fallback when Episciences_DoiTools::getMetadataFromDoi()
+     * fails (network error, rate limit, non-DOI identifier).
+     *
+     * @param array<string, mixed> $entity
+     * @return array<string, mixed>
+     */
+    public function buildFallbackCsl(array $entity, string $relationshipName): array
+    {
+        $csl = [
+            'type' => strtolower((string) ($entity['Type'] ?? 'dataset')),
+        ];
+
+        $title = $entity['Title'] ?? null;
+        if (is_string($title) && $title !== '') {
+            $csl['title'] = $title;
+        }
+
+        $authors = $this->buildCslAuthors(is_array($entity['Creator'] ?? null) ? $entity['Creator'] : []);
+        if (!empty($authors)) {
+            $csl['author'] = $authors;
+        }
+
+        $year = $this->extractYear((string) ($entity['PublicationDate'] ?? ''));
+        if ($year !== null) {
+            $csl['issued'] = ['date-parts' => [[$year]]];
+        }
+
+        $publisherName = $entity['Publisher'][0]['name'] ?? null;
+        if (is_string($publisherName) && $publisherName !== '') {
+            $csl['publisher'] = $publisherName;
+        }
+
+        $identifiers = is_array($entity['Identifier'] ?? null) ? $entity['Identifier'] : [];
+        $canonical   = $this->extractCanonicalIdentifier($identifiers);
+        if ($canonical !== null) {
+            if ($canonical['scheme'] === 'doi') {
+                $csl['DOI'] = $canonical['id'];
+            }
+            if ($canonical['url'] !== null) {
+                $csl['URL'] = $canonical['url'];
+            }
+        }
+
+        return $csl;
+    }
+
+    /**
+     * @param array<int, mixed> $creators
+     * @return array<int, array<string, string>>
+     */
+    private function buildCslAuthors(array $creators): array
+    {
+        $authors = [];
+
+        foreach ($creators as $creator) {
+            if (!is_array($creator) || empty($creator['name']) || !is_string($creator['name'])) {
+                continue;
+            }
+
+            $author = $this->splitCreatorName($creator['name']);
+
+            foreach ((array) ($creator['identifier'] ?? []) as $creatorIdentifier) {
+                if (!is_array($creatorIdentifier)) {
+                    continue;
+                }
+                $idScheme = strtolower((string) ($creatorIdentifier['IDScheme'] ?? ''));
+                $idValue  = $creatorIdentifier['ID'] ?? null;
+                if ($idScheme === 'orcid' && is_string($idValue) && $idValue !== '') {
+                    $author['ORCID'] = str_starts_with($idValue, 'http')
+                        ? $idValue
+                        : 'https://orcid.org/' . $idValue;
+                }
+            }
+
+            $authors[] = $author;
+        }
+
+        return $authors;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function splitCreatorName(string $name): array
+    {
+        if (str_contains($name, ',')) {
+            [$family, $given] = array_map('trim', explode(',', $name, 2));
+            return $given !== '' ? ['family' => $family, 'given' => $given] : ['family' => $family];
+        }
+
+        return ['literal' => $name];
+    }
+
+    private function extractYear(string $date): ?int
+    {
+        if (preg_match('/(\d{4})/', $date, $matches) === 1) {
+            return (int) $matches[1];
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // HTTP request with bi-mode auth, adaptive throttling, and 401/429 retry
+    // -------------------------------------------------------------------------
+
+    /**
+     * Issue the GET request, handling authentication, throttling, and 401/429 retry.
+     * Returns the raw response body, or null on unrecoverable error / exhausted retries.
+     */
+    private function requestWithRetry(string $url, int $paperId): ?string
+    {
+        $token   = $this->tokenProvider?->getAccessToken();
+        $headers = $this->defaultHeaders();
+
+        if ($token !== null) {
+            $headers['Authorization'] = 'Bearer ' . $token;
+            $this->throttleAuthenticated();
+        } else {
+            $this->logger->warning(
+                'Scholexplorer unauthenticated mode active: throttling for ' . self::UNAUTH_THROTTLE_SECONDS . 's (rate limit: 60 req/h)'
+            );
+            $this->throttleUnauthenticated();
+        }
+
+        $attempt = 0;
+        while ($attempt < self::MAX_RETRIES) {
+            $attempt++;
+            try {
+                $response = $this->client->get($url, [
+                    'headers'         => $headers,
+                    'timeout'         => 30,
+                    'allow_redirects' => [
+                        'max'       => 2,
+                        'strict'    => true,
+                        'referer'   => true,
+                        'protocols' => ['https'],
+                    ],
+                    'verify'          => true,
+                ]);
+
+                $this->logRateLimitStatus($response);
+                return $response->getBody()->getContents();
+            } catch (ClientException $e) {
+                $statusCode = $e->getResponse()->getStatusCode();
+
+                // 401 Unauthorized: token revoked/expired in authenticated mode -> refresh and retry once.
+                if ($statusCode === 401 && $token !== null && $this->tokenProvider !== null && $attempt === 1) {
+                    $this->logger->warning('Scholexplorer 401 Unauthorized received, refreshing token...');
+                    $this->tokenProvider->clearTokenCache();
+                    $token = $this->tokenProvider->getAccessToken();
+                    if ($token !== null) {
+                        $headers['Authorization'] = 'Bearer ' . $token;
+                        continue;
+                    }
+                }
+
+                // 429 Too Many Requests: back off and retry, up to MAX_RETRIES attempts.
+                if ($statusCode === 429) {
+                    // Never block the request thread: enrichment:links only runs in CLI,
+                    // but this seam matches OpenAireApiClient's guard for consistency and safety.
+                    if (!$this->isCliContext()) {
+                        $this->logger->warning(
+                            "Scholexplorer 429 Too Many Requests for paper {$paperId}; not retrying outside CLI execution (would block the request)"
+                        );
+                        return null;
+                    }
+
+                    if ($attempt >= self::MAX_RETRIES) {
+                        $this->logger->critical(
+                            "Scholexplorer API: rate limit (429) exhausted after {$attempt} attempts for paper {$paperId}, giving up"
+                        );
+                        return null;
+                    }
+
+                    $retryAfter   = (int) $e->getResponse()->getHeaderLine('Retry-After');
+                    $sleepSeconds = $token !== null
+                        ? ($retryAfter > 0 ? $retryAfter : ($attempt * 3))
+                        : max(self::UNAUTH_THROTTLE_SECONDS, $retryAfter);
+
+                    $this->logger->warning(
+                        "Scholexplorer 429 Too Many Requests for paper {$paperId} (attempt {$attempt}/" . self::MAX_RETRIES . "). Waiting {$sleepSeconds}s..."
+                    );
+                    $this->backoff($sleepSeconds);
+                    continue;
+                }
+
+                $this->logger->error("Scholexplorer API error for paper {$paperId} (HTTP {$statusCode}): " . $e->getMessage());
+                return null;
+            } catch (GuzzleException $e) {
+                $this->logger->error("Scholexplorer API connection error for paper {$paperId}: " . $e->getMessage());
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Log Scholexplorer rate-limit response headers (x-ratelimit-used / x-ratelimit-limit), if present.
+     */
+    private function logRateLimitStatus(ResponseInterface $response): void
+    {
+        $used  = $response->getHeaderLine('x-ratelimit-used');
+        $limit = $response->getHeaderLine('x-ratelimit-limit');
+        if ($used === '' || $limit === '') {
+            return;
+        }
+
+        $this->logger->debug("Scholexplorer Rate Limit status: {$used}/{$limit}");
+        if ((int) $limit > 0 && (int) $used > ((int) $limit * 0.85)) {
+            $this->logger->warning("Scholexplorer Rate Limit threshold > 85%: {$used}/{$limit}");
+        }
+    }
+
+    /**
+     * Proactive throttle before an authenticated request (~2 req/s, quota 7200 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleAuthenticated(): void
+    {
+        if (!$this->isCliContext()) {
+            $this->logger->debug('Scholexplorer authenticated throttle skipped outside CLI execution');
+            return;
+        }
+        usleep(self::AUTH_THROTTLE_MICROSECONDS);
+    }
+
+    /**
+     * Proactive throttle before an anonymous request (1 req/min, quota 60 req/h).
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function throttleUnauthenticated(): void
+    {
+        if (!$this->isCliContext()) {
+            $this->logger->debug('Scholexplorer unauthenticated throttle skipped outside CLI execution');
+            return;
+        }
+        sleep(self::UNAUTH_THROTTLE_SECONDS);
+    }
+
+    /**
+     * Reactive backoff wait after an HTTP 429 response.
+     * Extracted as an overridable seam so tests can skip the real delay.
+     */
+    protected function backoff(int $seconds): void
+    {
+        sleep($seconds);
+    }
+
+    /**
+     * True when running under the CLI SAPI (batch commands), false for an HTTP request.
+     * Extracted as an overridable seam so tests can simulate the HTTP path.
+     */
+    protected function isCliContext(): bool
+    {
+        return PHP_SAPI === 'cli';
+    }
+
+    // -------------------------------------------------------------------------
+    // Static factory
+    // -------------------------------------------------------------------------
+
+    /**
+     * Build a production-ready instance using FilesystemAdapter caches and a file logger.
+     *
+     * A Scholexplorer-specific client ID/secret/auth URL (config/pwd.json "SCHOLEXPLORER")
+     * is used when configured, so that batch enrichment does not consume the OpenAIRE
+     * Research Graph quota; otherwise falls back to the OPENAIRE_* credentials, and
+     * finally to unauthenticated mode.
+     *
+     * Constants APPLICATION_PATH must be defined by the bootstrap.
+     */
+    public static function create(?OpenAireTokenProvider $tokenProvider = null, ?LoggerInterface $logger = null): self
+    {
+        $cacheDir = dirname(APPLICATION_PATH) . '/cache/';
+        $logger   = $logger ?? new Logger('scholexplorer_api_client');
+
+        if ($tokenProvider === null) {
+            // @phpstan-ignore notIdentical.alwaysTrue
+            $clientId = defined('SCHOLEXPLORER_CLIENT_ID') && (string) constant('SCHOLEXPLORER_CLIENT_ID') !== ''
+                ? (string) constant('SCHOLEXPLORER_CLIENT_ID')
+                // @phpstan-ignore notIdentical.alwaysTrue
+                : (defined('OPENAIRE_CLIENT_ID') && (string) constant('OPENAIRE_CLIENT_ID') !== '' ? (string) constant('OPENAIRE_CLIENT_ID') : null);
+
+            // @phpstan-ignore notIdentical.alwaysTrue
+            $clientSecret = defined('SCHOLEXPLORER_CLIENT_SECRET') && (string) constant('SCHOLEXPLORER_CLIENT_SECRET') !== ''
+                ? (string) constant('SCHOLEXPLORER_CLIENT_SECRET')
+                // @phpstan-ignore notIdentical.alwaysTrue
+                : (defined('OPENAIRE_CLIENT_SECRET') && (string) constant('OPENAIRE_CLIENT_SECRET') !== '' ? (string) constant('OPENAIRE_CLIENT_SECRET') : null);
+
+            // @phpstan-ignore notIdentical.alwaysTrue
+            $authUrl = defined('SCHOLEXPLORER_AUTH_URL') && (string) constant('SCHOLEXPLORER_AUTH_URL') !== ''
+                ? (string) constant('SCHOLEXPLORER_AUTH_URL')
+                // @phpstan-ignore notIdentical.alwaysTrue
+                : (defined('OPENAIRE_AUTH_URL') && (string) constant('OPENAIRE_AUTH_URL') !== '' ? (string) constant('OPENAIRE_AUTH_URL') : 'https://aai.openaire.eu/oidc/token');
+
+            $tokenProvider = new OpenAireTokenProvider(
+                new Client(),
+                new FilesystemAdapter('scholexplorerAuthToken', self::ONE_MONTH, $cacheDir),
+                $logger,
+                $clientId,
+                $clientSecret,
+                $authUrl
+            );
+        }
+
+        return new self(
+            new Client(),
+            new FilesystemAdapter('scholexplorerLinkData', self::ONE_MONTH, $cacheDir),
+            $logger,
+            $tokenProvider
+        );
+    }
+}

--- a/public/const.php
+++ b/public/const.php
@@ -369,6 +369,10 @@ function fixUndefinedConstantsForCodeAnalysis(): void
         define('OPENAIRE_API_URL', '');
         define('OPENAIRE_CLIENT_ID', '');
         define('OPENAIRE_CLIENT_SECRET', '');
+        define('SCHOLEXPLORER_AUTH_URL', '');
+        define('SCHOLEXPLORER_API_URL', 'https://api.scholexplorer.openaire.eu/v3/Links');
+        define('SCHOLEXPLORER_CLIENT_ID', '');
+        define('SCHOLEXPLORER_CLIENT_SECRET', '');
 
         // DOI Configuration
         define('DOI_AGENCY', '');

--- a/scripts/ClearOpenAireCacheCommand.php
+++ b/scripts/ClearOpenAireCacheCommand.php
@@ -6,37 +6,46 @@ use Monolog\Logger;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Symfony Console command: purge the OpenAIRE Research Graph enrichment caches.
+ * Symfony Console command: purge the OpenAIRE Research Graph / Scholexplorer enrichment caches.
  *
- * Clears the three PSR-6 pools shared by GetCreatorDataCommand, GetFundingDataCommand
- * and GetClassificationJelCommand in one shot, without querying the API. Needed after
- * an OpenAIRE API format migration (e.g. v1 -> Graph v3): cache keys carry no version
- * marker (md5($doi)), so a cache hit on a pre-migration entry silently returns the old
- * format to the new extraction code instead of triggering a fresh API call.
+ * Clears the PSR-6 pools shared by GetCreatorDataCommand, GetFundingDataCommand,
+ * GetClassificationJelCommand and (with --scholexplorer/--all) GetLinkDataCommand, without
+ * querying the API. Needed after an API format migration (e.g. v1 -> v3): cache keys carry
+ * no version marker (md5($doi)), so a cache hit on a pre-migration entry silently returns
+ * the old format to the new extraction code instead of triggering a fresh API call.
  */
 class ClearOpenAireCacheCommand extends Command
 {
     protected static $defaultName = 'enrichment:clear-cache';
 
-    private const CACHE_POOLS = [
+    private const OPENAIRE_CACHE_POOLS = [
         'openAireResearchGraph',
         'enrichmentAuthors',
         'enrichmentFunding',
     ];
 
+    private const SCHOLEXPLORER_CACHE_POOLS = [
+        'scholexplorerLinkData',
+        'scholexplorerAuthToken',
+    ];
+
     protected function configure(): void
     {
-        $this->setDescription('Purge the OpenAIRE Research Graph enrichment caches (global, creators, funding)');
+        $this
+            ->setDescription('Purge the OpenAIRE Research Graph / Scholexplorer enrichment caches')
+            ->addOption('scholexplorer', null, InputOption::VALUE_NONE, 'Also purge the Scholexplorer cache pools')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Purge every cache pool (OpenAIRE + Scholexplorer)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->title('OpenAIRE enrichment cache purge');
+        $io->title('OpenAIRE / Scholexplorer enrichment cache purge');
 
         $this->bootstrap();
 
@@ -51,7 +60,12 @@ class ClearOpenAireCacheCommand extends Command
         $cacheDir   = dirname(APPLICATION_PATH) . '/cache/';
         $allCleared = true;
 
-        foreach (self::CACHE_POOLS as $pool) {
+        $pools = self::OPENAIRE_CACHE_POOLS;
+        if ($input->getOption('scholexplorer') || $input->getOption('all')) {
+            $pools = array_merge($pools, self::SCHOLEXPLORER_CACHE_POOLS);
+        }
+
+        foreach ($pools as $pool) {
             $cache   = new FilesystemAdapter($pool, 0, $cacheDir);
             $cleared = $cache->clear();
             $allCleared = $allCleared && $cleared;

--- a/scripts/GetLinkDataCommand.php
+++ b/scripts/GetLinkDataCommand.php
@@ -1,12 +1,10 @@
 <?php
 declare(strict_types=1);
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
+use Episciences\Api\ScholexplorerApiClient;
 use Episciences\Console\ProgressAwareStreamHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -14,25 +12,28 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Symfony Console command: enrich dataset link data from Scholexplorer.
+ * Symfony Console command: enrich dataset link data from Scholexplorer API v3
+ * (Scholix 3.0 schema).
  *
- * Replaces: scripts/getLinkData.php (JournalScript)
- *
- * Uses Symfony Cache instead of custom file-based cache.
+ * Replaces: scripts/getLinkData.php (JournalScript), then the Scholexplorer API v1 client.
  */
 class GetLinkDataCommand extends Command
 {
     protected static $defaultName = 'enrichment:links';
 
-    private const API_URL = 'https://api.scholexplorer.openaire.eu';
-    private const ONE_MONTH = 3600 * 24 * 31;
+    private const VALID_TYPES = ['dataset', 'software', 'all'];
 
     protected function configure(): void
     {
         $this
-            ->setDescription('Enrich dataset link data from Scholexplorer (OpenAIRE)')
+            ->setDescription('Enrich dataset link data from Scholexplorer (OpenAIRE v3)')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Run without writing to the database')
-            ->addOption('rvcode', null, InputOption::VALUE_REQUIRED, 'Restrict processing to one journal (RV code)');
+            ->addOption('rvcode', null, InputOption::VALUE_REQUIRED, 'Restrict processing to one journal (RV code)')
+            ->addOption('doi', null, InputOption::VALUE_REQUIRED, 'Target a single DOI')
+            ->addOption('docid', null, InputOption::VALUE_REQUIRED, 'Target a single paper doc_id')
+            ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'Target typology (dataset|software|all)', 'dataset')
+            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Bypass cache and force network request')
+            ->addOption('no-bidirectional', null, InputOption::VALUE_NONE, 'Disable reciprocal targetPid lookup');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -40,8 +41,18 @@ class GetLinkDataCommand extends Command
         $io     = new SymfonyStyle($input, $output);
         $dryRun = (bool) $input->getOption('dry-run');
         $rvcode = $input->getOption('rvcode');
+        $doiOption   = $input->getOption('doi');
+        $docIdOption = $input->getOption('docid');
+        $type        = (string) $input->getOption('type');
+        $noCache       = (bool) $input->getOption('no-cache');
+        $bidirectional = !$input->getOption('no-bidirectional');
 
-        $io->title('Link data enrichment (Scholexplorer)');
+        if (!in_array($type, self::VALID_TYPES, true)) {
+            $io->error(sprintf("Invalid --type value '%s'. Expected one of: %s.", $type, implode(', ', self::VALID_TYPES)));
+            return Command::FAILURE;
+        }
+
+        $io->title('Link data enrichment (Scholexplorer API v3)');
 
         $this->bootstrap();
 
@@ -68,8 +79,10 @@ class GetLinkDataCommand extends Command
             $logger->info("Filtering on journal: {$rvcode} (RVID {$rvid})");
         }
 
-        $client = new Client();
-        $cache  = new FilesystemAdapter('scholexplorerLinkData', self::ONE_MONTH, dirname(APPLICATION_PATH) . '/cache/');
+        $client = ScholexplorerApiClient::create(null, $logger);
+        $logger->info($client->isAuthenticated()
+            ? 'Scholexplorer client authenticated (7200 req/h)'
+            : 'Scholexplorer client anonymous (60 req/h)');
 
         $db     = Zend_Db_Table_Abstract::getDefaultAdapter();
         $select = $db->select()
@@ -78,8 +91,15 @@ class GetLinkDataCommand extends Command
             ->where('DOI IS NOT NULL')
             ->where('DOI != ""')
             ->where('STATUS = ?', Episciences_Paper::STATUS_PUBLISHED);
+
         if ($rvid !== null) {
             $select->where('RVID = ?', $rvid);
+        }
+        if ($doiOption !== null) {
+            $select->where('DOI = ?', (string) $doiOption);
+        }
+        if ($docIdOption !== null) {
+            $select->where('DOCID = ?', (int) $docIdOption);
         }
 
         $rows = $db->fetchAll($select);
@@ -87,105 +107,34 @@ class GetLinkDataCommand extends Command
         $stdoutHandler?->setProgressBar($progressBar);
         $progressBar->start();
 
+        $requestedTypes = $type === 'all' ? ['dataset', 'software'] : [$type];
+
         foreach ($rows as $value) {
             $docId   = (int) $value['DOCID'];
             $doiTrim = trim($value['DOI']);
 
-            // Use DOI suffix as cache key (same as old file-name scheme)
-            $doiParts = explode('/', $doiTrim, 2);
-            $cacheKey = isset($doiParts[1]) ? md5($doiParts[1]) : md5($doiTrim);
-            $cacheKey .= '_link';
-
-            $cacheItem = $cache->getItem($cacheKey);
-
-            if ($cacheItem->isHit()) {
-                $apiResult = (string) $cacheItem->get();
-                $logger->info('Dataset links from cache for DOI ' . $doiTrim);
-            } else {
-                $apiUrl = self::API_URL . '/v1/linksFromPid?pid=' . $doiTrim;
-                $logger->info('Fetching dataset links from Scholexplorer for DOI ' . $doiTrim);
-
-                try {
-                    $apiResult = $client->get($apiUrl, [
-                        'headers' => [
-                            'User-Agent'   => 'CCSD Episciences support@episciences.org',
-                            'Content-Type' => 'application/json',
-                            'Accept'       => 'application/json',
-                        ],
-                    ])->getBody()->getContents();
-                } catch (GuzzleException $e) {
-                    $logger->error('Scholexplorer API error for DOI ' . $doiTrim . ': ' . $e->getMessage());
-                    $progressBar->advance();
-                    continue;
-                }
-
-                $decoded = json_decode($apiResult, true, 512, JSON_THROW_ON_ERROR);
-                if (!empty($decoded)) {
-                    $cacheItem->set($apiResult);
-                    $cacheItem->expiresAfter(self::ONE_MONTH);
-                    $cache->save($cacheItem);
-                }
+            $links = [];
+            foreach ($requestedTypes as $requestedType) {
+                $links = array_merge(
+                    $links,
+                    $client->fetchLinksForDoi($doiTrim, $docId, $requestedType, $bidirectional, $noCache)
+                );
             }
 
-            $decoded = json_decode($apiResult, true, 512, JSON_THROW_ON_ERROR);
-            if (empty($decoded)) {
+            if (empty($links)) {
                 $progressBar->advance();
-                sleep(1);
                 continue;
             }
 
-            $filtered = array_filter(array_map(static function (array $valuesResult): array|false {
-                if (!isset($valuesResult['target']['objectType'])) {
-                    return false;
-                }
-                $objectType = $valuesResult['target']['objectType'];
-                if ($objectType !== 'dataset' && $objectType !== 'datasets') {
-                    return false;
-                }
-                return $valuesResult;
-            }, $decoded));
+            if (!$dryRun) {
+                $this->purgeExistingLinks($db, $docId);
 
-            if (!empty($filtered) && !$dryRun) {
-                // Remove existing Scholexplorer data for this paper
-                $getTargetId = $db->select()
-                    ->distinct()
-                    ->from('paper_datasets', ['id_paper_datasets_meta'])
-                    ->where('doc_id IS NOT NULL')
-                    ->where('source_id = ?', Episciences_Repositories::SCHOLEXPLORER_ID)
-                    ->where('doc_id = ?', $docId);
-                $idToDelete = $db->fetchOne($getTargetId);
-                if (is_string($idToDelete)) {
-                    Episciences_Paper_DatasetsMetadataManager::deleteMetaDataAndDatasetsByIdMd((int) $idToDelete);
-                    $logger->info('Old dataset links removed for DOI ' . $doiTrim);
-                }
-
-                foreach ($filtered as $ar) {
-                    foreach ($ar['target']['identifiers'] as $identifier) {
-                        try {
-                            $csl                 = Episciences_DoiTools::getMetadataFromDoi($identifier['identifier']);
-                            $lastMetatextInserted = Episciences_Paper_DatasetsMetadataManager::insert(['metatext' => $csl]);
-                            $enrichment          = Episciences_Paper_DatasetsManager::insert([[
-                                'docId'                => $docId,
-                                'code'                 => 'dataset',
-                                'name'                 => $identifier['schema'],
-                                'value'                => $identifier['identifier'],
-                                'link'                 => $identifier['schema'],
-                                'sourceId'             => Episciences_Repositories::SCHOLEXPLORER_ID,
-                                'relationship'         => $ar['relationship']['name'],
-                                'idPaperDatasetsMeta'  => $lastMetatextInserted,
-                            ]]);
-                            if ($enrichment >= 1) {
-                                $logger->info('Dataset link saved for DOI ' . $doiTrim);
-                            }
-                        } catch (Exception $e) {
-                            $logger->error('Dataset link insert error for DOI ' . $doiTrim . ': ' . $e->getMessage());
-                        }
-                    }
+                foreach ($links as $linkItem) {
+                    $this->insertLink($client, $docId, $linkItem, $logger, $doiTrim);
                 }
             }
 
             $progressBar->advance();
-            sleep(1);
         }
 
         $progressBar->finish();
@@ -194,6 +143,76 @@ class GetLinkDataCommand extends Command
         $io->success('Link data enrichment completed.');
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Remove every existing Scholexplorer-sourced dataset link (and its metadata row)
+     * for this paper, ahead of a fresh insertion of the deduplicated link set.
+     *
+     * Fetches all matching id_paper_datasets_meta values (fetchAll, not fetchOne) so
+     * a paper with several pre-existing links does not leave orphaned metadata rows.
+     */
+    private function purgeExistingLinks(Zend_Db_Adapter_Abstract $db, int $docId): void
+    {
+        $existingMetaIds = $db->fetchCol(
+            $db->select()
+                ->distinct()
+                ->from(T_PAPER_DATASETS, ['id_paper_datasets_meta'])
+                ->where('doc_id = ?', $docId)
+                ->where('source_id = ?', Episciences_Repositories::SCHOLEXPLORER_ID)
+                ->where('id_paper_datasets_meta IS NOT NULL')
+        );
+
+        $db->delete(T_PAPER_DATASETS, [
+            'doc_id = ?'    => $docId,
+            'source_id = ?' => Episciences_Repositories::SCHOLEXPLORER_ID,
+        ]);
+
+        if (!empty($existingMetaIds)) {
+            $db->delete(T_PAPER_DATASETS_META, ['id IN (?)' => $existingMetaIds]);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $linkItem
+     */
+    private function insertLink(ScholexplorerApiClient $client, int $docId, array $linkItem, Logger $logger, string $doiTrim): void
+    {
+        $canonicalId = (string) $linkItem['identifier'];
+        $scheme      = (string) $linkItem['scheme'];
+        $url         = $linkItem['link'];
+        $relName     = (string) $linkItem['relationship'];
+        $code        = (string) $linkItem['type'];
+        $rawEntity   = is_array($linkItem['raw']) ? $linkItem['raw'] : [];
+
+        $csl = null;
+        if ($scheme === 'doi') {
+            $fetched = Episciences_DoiTools::getMetadataFromDoi($canonicalId);
+            $csl = $fetched !== '' ? $fetched : null;
+        }
+        if ($csl === null) {
+            $csl = json_encode(
+                $client->buildFallbackCsl($rawEntity, $relName),
+                JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            );
+        }
+
+        $metaId = Episciences_Paper_DatasetsMetadataManager::insert(['metatext' => $csl]);
+
+        $enrichment = Episciences_Paper_DatasetsManager::insert([[
+            'docId'               => $docId,
+            'code'                => $code,
+            'name'                => $scheme,
+            'value'               => $canonicalId,
+            'link'                => is_string($url) && $url !== '' ? $url : $scheme,
+            'sourceId'            => Episciences_Repositories::SCHOLEXPLORER_ID,
+            'relationship'        => $relName,
+            'idPaperDatasetsMeta' => $metaId,
+        ]]);
+
+        if ($enrichment >= 1) {
+            $logger->info("Dataset link saved for DOI {$doiTrim}: {$canonicalId}");
+        }
     }
 
     private function bootstrap(): void

--- a/scripts/GetLinkDataCommand.php
+++ b/scripts/GetLinkDataCommand.php
@@ -113,24 +113,22 @@ class GetLinkDataCommand extends Command
             $docId   = (int) $value['DOCID'];
             $doiTrim = trim($value['DOI']);
 
-            $links = [];
+            // Each requested type is fetched, purged and re-inserted independently: a
+            // type whose fetch failed or returned nothing must not touch the previously
+            // stored links of the OTHER requested type (see purgeExistingLinks()).
             foreach ($requestedTypes as $requestedType) {
-                $links = array_merge(
-                    $links,
-                    $client->fetchLinksForDoi($doiTrim, $docId, $requestedType, $bidirectional, $noCache)
-                );
-            }
+                $typeLinks = $client->fetchLinksForDoi($doiTrim, $docId, $requestedType, $bidirectional, $noCache);
 
-            if (empty($links)) {
-                $progressBar->advance();
-                continue;
-            }
+                if (empty($typeLinks)) {
+                    continue;
+                }
 
-            if (!$dryRun) {
-                $this->purgeExistingLinks($db, $docId);
+                if (!$dryRun) {
+                    $this->purgeExistingLinks($db, $docId, $requestedType);
 
-                foreach ($links as $linkItem) {
-                    $this->insertLink($client, $docId, $linkItem, $logger, $doiTrim);
+                    foreach ($typeLinks as $linkItem) {
+                        $this->insertLink($client, $docId, $linkItem, $logger, $doiTrim);
+                    }
                 }
             }
 
@@ -146,13 +144,15 @@ class GetLinkDataCommand extends Command
     }
 
     /**
-     * Remove every existing Scholexplorer-sourced dataset link (and its metadata row)
-     * for this paper, ahead of a fresh insertion of the deduplicated link set.
+     * Remove every existing Scholexplorer-sourced link (and its metadata row) of the
+     * given type for this paper, ahead of a fresh insertion of that type's deduplicated
+     * link set. Scoped to $type so purging one type (e.g. 'dataset') never deletes the
+     * other type's previously stored links (e.g. 'software').
      *
      * Fetches all matching id_paper_datasets_meta values (fetchAll, not fetchOne) so
      * a paper with several pre-existing links does not leave orphaned metadata rows.
      */
-    private function purgeExistingLinks(Zend_Db_Adapter_Abstract $db, int $docId): void
+    private function purgeExistingLinks(Zend_Db_Adapter_Abstract $db, int $docId, string $type): void
     {
         $existingMetaIds = $db->fetchCol(
             $db->select()
@@ -160,12 +160,14 @@ class GetLinkDataCommand extends Command
                 ->from(T_PAPER_DATASETS, ['id_paper_datasets_meta'])
                 ->where('doc_id = ?', $docId)
                 ->where('source_id = ?', Episciences_Repositories::SCHOLEXPLORER_ID)
+                ->where('code = ?', $type)
                 ->where('id_paper_datasets_meta IS NOT NULL')
         );
 
         $db->delete(T_PAPER_DATASETS, [
             'doc_id = ?'    => $docId,
             'source_id = ?' => Episciences_Repositories::SCHOLEXPLORER_ID,
+            'code = ?'      => $type,
         ]);
 
         if (!empty($existingMetaIds)) {

--- a/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
+++ b/tests/unit/library/Episciences/Api/OpenAireTokenProviderTest.php
@@ -139,7 +139,7 @@ class OpenAireTokenProviderTest extends TestCase
 
         $provider->getAccessToken();
 
-        $this->assertSame('https://aai.openaire.eu/token', (string) $history[0]['request']->getUri());
+        $this->assertSame('https://aai.openaire.eu/oidc/token', (string) $history[0]['request']->getUri());
     }
 
     public function testGetAccessToken_CustomAuthUrl_IsUsed(): void

--- a/tests/unit/library/Episciences/Api/ScholexplorerApiClientTest.php
+++ b/tests/unit/library/Episciences/Api/ScholexplorerApiClientTest.php
@@ -1,0 +1,446 @@
+<?php
+
+namespace unit\library\Episciences\Api;
+
+use Episciences\Api\OpenAireTokenProvider;
+use Episciences\Api\ScholexplorerApiClient;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Unit tests for ScholexplorerApiClient (Scholexplorer API v3 / Scholix 3.0 schema).
+ */
+class ScholexplorerApiClientTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // isAuthenticated()
+    // -------------------------------------------------------------------------
+
+    public function testIsAuthenticatedReturnsTrueWhenConfigured(): void
+    {
+        $client = $this->makeClient($this->makeGuzzle([]), $this->makeAuthenticatedTokenProvider());
+        $this->assertTrue($client->isAuthenticated());
+    }
+
+    public function testIsAuthenticatedReturnsFalseWhenUnconfigured(): void
+    {
+        $client = $this->makeClient($this->makeGuzzle([]), null);
+        $this->assertFalse($client->isAuthenticated());
+
+        $client = $this->makeClient($this->makeGuzzle([]), $this->makeUnconfiguredTokenProvider());
+        $this->assertFalse($client->isAuthenticated());
+    }
+
+    // -------------------------------------------------------------------------
+    // requestWithRetry() (exercised through fetchLinksForDoi()) — bi-mode auth
+    // -------------------------------------------------------------------------
+
+    public function testRequestSendsBearerTokenWhenAuthenticated(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], $this->scholixPage([], 1))], $history);
+
+        $client = $this->makeClient($guzzle, $this->makeAuthenticatedTokenProvider('the-bearer-token'));
+        $client->fetchLinksForDoi('10.1234/authed', 1, 'dataset', false);
+
+        $this->assertCount(1, $history);
+        $this->assertSame('Bearer the-bearer-token', $history[0]['request']->getHeaderLine('Authorization'));
+    }
+
+    public function testRequestOmitsAuthorizationHeaderWhenUnauthenticated(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([new Response(200, [], $this->scholixPage([], 1))], $history);
+
+        $client = $this->makeClient($guzzle, null);
+        $client->fetchLinksForDoi('10.1234/anon', 1, 'dataset', false);
+
+        $this->assertCount(1, $history);
+        $this->assertFalse($history[0]['request']->hasHeader('Authorization'));
+    }
+
+    // -------------------------------------------------------------------------
+    // requestWithRetry() — HTTP 401 retry
+    // -------------------------------------------------------------------------
+
+    public function testRequestRetriesOn401AndRefreshesToken(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([
+            new Response(401, [], 'Unauthorized'),
+            new Response(200, [], $this->scholixPage([], 1)),
+        ], $history);
+
+        // Token cache pre-seeded with a stale token; clearTokenCache() + getAccessToken()
+        // must yield a (mocked) fresh one from the same cache-hit path.
+        $tokenCache = new ArrayAdapter();
+        $tokenItem  = $tokenCache->getItem('openaire_access_token');
+        $tokenItem->set('stale-token');
+        $tokenItem->expiresAfter(3600);
+        $tokenCache->save($tokenItem);
+
+        $aaiClient = new Client(['handler' => HandlerStack::create(new MockHandler([
+            new Response(200, [], json_encode(['access_token' => 'refreshed-token', 'expires_in' => 3600])),
+        ]))]);
+        $tokenProvider = new OpenAireTokenProvider($aaiClient, $tokenCache, new NullLogger(), 'id', 'secret');
+
+        $client = $this->makeClient($guzzle, $tokenProvider);
+        $client->fetchLinksForDoi('10.1234/expired-token', 1, 'dataset', false);
+
+        $this->assertCount(2, $history);
+        $this->assertSame('Bearer stale-token', $history[0]['request']->getHeaderLine('Authorization'));
+        $this->assertSame('Bearer refreshed-token', $history[1]['request']->getHeaderLine('Authorization'));
+    }
+
+    // -------------------------------------------------------------------------
+    // requestWithRetry() — HTTP 429 backoff & retry
+    // -------------------------------------------------------------------------
+
+    public function testRequestRetriesOn429WithRetryAfterHeader(): void
+    {
+        $guzzle = $this->makeGuzzle([
+            new Response(429, ['Retry-After' => '5'], 'Too Many Requests'),
+            new Response(200, [], $this->scholixPage([], 1)),
+        ]);
+
+        $client = $this->makeClient($guzzle, $this->makeAuthenticatedTokenProvider());
+        $links  = $client->fetchLinksForDoi('10.1234/ratelimited', 1, 'dataset', false);
+
+        $this->assertSame([], $links);
+        $this->assertSame(['auth:500000us', 'backoff:5s'], $client->sleepLog);
+    }
+
+    public function testRequestAbortsWithoutRetryOn429WhenNonCliContext(): void
+    {
+        $history = [];
+        // Only one response queued: a retry attempt would exhaust the mock queue and error out.
+        $guzzle = $this->makeGuzzle([new Response(429, ['Retry-After' => '5'], 'Too Many Requests')], $history);
+
+        $client = $this->makeHttpContextClient($guzzle, $this->makeAuthenticatedTokenProvider());
+        $links  = $client->fetchLinksForDoi('10.1234/ratelimited-http', 1, 'dataset', false);
+
+        $this->assertSame([], $links);
+        $this->assertCount(1, $history, 'must not retry outside CLI execution');
+    }
+
+    public function testRequestExhaustsRetriesOnRepeated429(): void
+    {
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test');
+        $logger->pushHandler($testHandler);
+
+        $guzzle = $this->makeGuzzle([
+            new Response(429, [], 'Too Many Requests'),
+            new Response(429, [], 'Too Many Requests'),
+            new Response(429, [], 'Too Many Requests'),
+        ]);
+
+        $client = $this->makeClient($guzzle, $this->makeAuthenticatedTokenProvider(), $logger);
+        $links  = $client->fetchLinksForDoi('10.1234/always-ratelimited', 1, 'dataset', false);
+
+        $this->assertSame([], $links);
+        $this->assertTrue($testHandler->hasCriticalThatContains('rate limit (429) exhausted'));
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchLinksForDoi() — pagination (0-indexed)
+    // -------------------------------------------------------------------------
+
+    public function testFetchLinksForDoiPaginatesFromPageZero(): void
+    {
+        $history = [];
+        $guzzle  = $this->makeGuzzle([
+            new Response(200, [], $this->scholixPage([$this->scholixResult('10.5061/dryad.aaa')], 2)),
+            new Response(200, [], $this->scholixPage([$this->scholixResult('10.5061/dryad.bbb')], 2)),
+        ], $history);
+
+        $client = $this->makeClient($guzzle, null);
+        $links  = $client->fetchLinksForDoi('10.1234/paginated', 1, 'dataset', false);
+
+        $this->assertCount(2, $history);
+
+        parse_str((string) $history[0]['request']->getUri()->getQuery(), $firstQuery);
+        parse_str((string) $history[1]['request']->getUri()->getQuery(), $secondQuery);
+        $this->assertSame('0', $firstQuery['page']);
+        $this->assertSame('1', $secondQuery['page']);
+
+        $this->assertCount(2, $links);
+    }
+
+    // -------------------------------------------------------------------------
+    // extractCanonicalIdentifier()
+    // -------------------------------------------------------------------------
+
+    public function testExtractCanonicalIdentifierPrefersDoiOverOthers(): void
+    {
+        $client = $this->makeClient($this->makeGuzzle([]));
+
+        $identifiers = [
+            ['ID' => '50|doi_dedup___::abcdef', 'IDScheme' => 'openaireIdentifier', 'IDURL' => null],
+            ['ID' => '20.500.12345/xyz', 'IDScheme' => 'handle', 'IDURL' => 'https://hdl.handle.net/20.500.12345/xyz'],
+            ['ID' => '10.5061/dryad.j2c4g/4', 'IDScheme' => 'doi', 'IDURL' => 'https://dx.doi.org/10.5061/dryad.j2c4g/4'],
+        ];
+
+        $result = $client->extractCanonicalIdentifier($identifiers);
+
+        $this->assertSame([
+            'id'     => '10.5061/dryad.j2c4g/4',
+            'scheme' => 'doi',
+            'url'    => 'https://dx.doi.org/10.5061/dryad.j2c4g/4',
+        ], $result);
+    }
+
+    public function testExtractCanonicalIdentifierFallsBackToHandleOrUrl(): void
+    {
+        $client = $this->makeClient($this->makeGuzzle([]));
+
+        $handleOnly = [
+            ['ID' => '20.500.12345/xyz', 'IDScheme' => 'handle', 'IDURL' => 'https://hdl.handle.net/20.500.12345/xyz'],
+            ['ID' => '50|re3data_____::abc', 'IDScheme' => 'openaireIdentifier', 'IDURL' => null],
+        ];
+        $result = $client->extractCanonicalIdentifier($handleOnly);
+        $this->assertSame('handle', $result['scheme']);
+        $this->assertSame('20.500.12345/xyz', $result['id']);
+
+        $urlOnly = [
+            ['ID' => 'https://example.org/dataset/1', 'IDScheme' => 'url', 'IDURL' => 'https://example.org/dataset/1'],
+        ];
+        $result = $client->extractCanonicalIdentifier($urlOnly);
+        $this->assertSame('url', $result['scheme']);
+
+        $noPublicIdentifier = [
+            ['ID' => '50|re3data_____::abc', 'IDScheme' => 'openaireIdentifier', 'IDURL' => null],
+        ];
+        $this->assertNull($client->extractCanonicalIdentifier($noPublicIdentifier));
+    }
+
+    // -------------------------------------------------------------------------
+    // fetchLinksForDoi() — bidirectional deduplication
+    // -------------------------------------------------------------------------
+
+    public function testBidirectionalDeduplicationIgnoresReciprocalDuplicates(): void
+    {
+        $sameDatasetIdentifiers = [
+            ['ID' => '10.5061/dryad.same', 'IDScheme' => 'doi', 'IDURL' => 'https://doi.org/10.5061/dryad.same'],
+        ];
+
+        // Article is the source, dataset is the target.
+        $sourcePidResult = [
+            'RelationshipType' => ['Name' => 'IsSupplementTo'],
+            'target'           => [
+                'Identifier' => $sameDatasetIdentifiers,
+                'Type'       => 'dataset',
+                'Title'      => 'Same dataset',
+                'Publisher'  => [['name' => 'Zenodo']],
+            ],
+        ];
+
+        // Same dataset, but declared the other way round: dataset is the source, article is the target.
+        $targetPidResult = [
+            'RelationshipType' => ['Name' => 'IsSupplementTo'],
+            'source'           => [
+                'Identifier' => $sameDatasetIdentifiers,
+                'Type'       => 'dataset',
+                'Title'      => 'Same dataset',
+                'Publisher'  => [['name' => 'Zenodo']],
+            ],
+        ];
+
+        $guzzle = $this->makeGuzzle([
+            new Response(200, [], $this->scholixPage([$sourcePidResult], 1)),
+            new Response(200, [], $this->scholixPage([$targetPidResult], 1)),
+        ]);
+
+        $client = $this->makeClient($guzzle, null);
+        $links  = $client->fetchLinksForDoi('10.1234/bidirectional', 1, 'dataset', true);
+
+        $this->assertCount(1, $links);
+        $this->assertSame('10.5061/dryad.same', $links[0]['identifier']);
+    }
+
+    // -------------------------------------------------------------------------
+    // buildFallbackCsl()
+    // -------------------------------------------------------------------------
+
+    public function testBuildFallbackCslProducesValidBiblioStructure(): void
+    {
+        $client = $this->makeClient($this->makeGuzzle([]));
+
+        $entity = [
+            'Title'           => 'Locations of Publicly Available Data for the Cohort',
+            'Type'            => 'dataset',
+            'PublicationDate' => '2021-01-01',
+            'Creator'         => [
+                [
+                    'name'       => 'Piwowar, Heather A.',
+                    'identifier' => [
+                        ['ID' => '0000-0003-1613-5981', 'IDScheme' => 'orcid', 'IDURL' => null],
+                    ],
+                ],
+            ],
+            'Publisher'  => [['name' => 'DRYAD']],
+            'Identifier' => [
+                ['ID' => '10.5061/dryad.j2c4g/4', 'IDScheme' => 'doi', 'IDURL' => 'https://dx.doi.org/10.5061/dryad.j2c4g/4'],
+            ],
+        ];
+
+        $csl = $client->buildFallbackCsl($entity, 'IsSupplementTo');
+
+        $this->assertSame('dataset', $csl['type']);
+        $this->assertSame('Locations of Publicly Available Data for the Cohort', $csl['title']);
+        $this->assertSame(
+            [['family' => 'Piwowar', 'given' => 'Heather A.', 'ORCID' => 'https://orcid.org/0000-0003-1613-5981']],
+            $csl['author']
+        );
+        $this->assertSame(['date-parts' => [[2021]]], $csl['issued']);
+        $this->assertSame('DRYAD', $csl['publisher']);
+        $this->assertSame('10.5061/dryad.j2c4g/4', $csl['DOI']);
+        $this->assertSame('https://dx.doi.org/10.5061/dryad.j2c4g/4', $csl['URL']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function scholixPage(array $results, int $totalPages): string
+    {
+        return json_encode([
+            'currentPage' => 0,
+            'totalLinks'  => count($results),
+            'totalPages'  => $totalPages,
+            'result'      => $results,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function scholixResult(string $doi): array
+    {
+        return [
+            'RelationshipType' => ['Name' => 'IsRelatedTo'],
+            'target'           => [
+                'Identifier' => [
+                    ['ID' => $doi, 'IDScheme' => 'doi', 'IDURL' => 'https://doi.org/' . $doi],
+                ],
+                'Type'  => 'dataset',
+                'Title' => 'Dataset ' . $doi,
+            ],
+        ];
+    }
+
+    private function makeGuzzle(array $responses, array &$history = []): Client
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $handlerStack->push(Middleware::history($history));
+        return new Client(['handler' => $handlerStack]);
+    }
+
+    private function makeAuthenticatedTokenProvider(string $token = 'test-access-token'): OpenAireTokenProvider
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem('openaire_access_token');
+        $item->set($token);
+        $item->expiresAfter(3600);
+        $cache->save($item);
+
+        return new OpenAireTokenProvider(
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]), // never called: cache hit
+            $cache,
+            new NullLogger(),
+            'client-id',
+            'client-secret'
+        );
+    }
+
+    private function makeUnconfiguredTokenProvider(): OpenAireTokenProvider
+    {
+        return new OpenAireTokenProvider(
+            new Client(['handler' => HandlerStack::create(new MockHandler([]))]),
+            new ArrayAdapter(),
+            new NullLogger(),
+            '',
+            ''
+        );
+    }
+
+    private function makeClient(
+        Client $guzzle,
+        ?OpenAireTokenProvider $tokenProvider = null,
+        ?Logger $logger = null
+    ): ScholexplorerApiClientNoSleep {
+        return new ScholexplorerApiClientNoSleep(
+            $guzzle,
+            new ArrayAdapter(),
+            $logger ?? new NullLogger(),
+            $tokenProvider
+        );
+    }
+
+    private function makeHttpContextClient(
+        Client $guzzle,
+        ?OpenAireTokenProvider $tokenProvider = null,
+        ?Logger $logger = null
+    ): ScholexplorerApiClientHttpContext {
+        return new ScholexplorerApiClientHttpContext(
+            $guzzle,
+            new ArrayAdapter(),
+            $logger ?? new NullLogger(),
+            $tokenProvider
+        );
+    }
+}
+
+/**
+ * Test double: records throttle/backoff calls instead of actually sleeping,
+ * so 60s-anonymous-mode and 429-backoff tests run instantly.
+ */
+class ScholexplorerApiClientNoSleep extends ScholexplorerApiClient
+{
+    /** @var array<int, string> */
+    public array $sleepLog = [];
+
+    protected function throttleAuthenticated(): void
+    {
+        $this->sleepLog[] = 'auth:500000us';
+    }
+
+    protected function throttleUnauthenticated(): void
+    {
+        $this->sleepLog[] = 'unauth:60s';
+    }
+
+    protected function backoff(int $seconds): void
+    {
+        $this->sleepLog[] = "backoff:{$seconds}s";
+    }
+}
+
+/**
+ * Test double: simulates the HTTP request path (non-CLI SAPI) by overriding only
+ * isCliContext(), while keeping the real throttle/backoff seams inert since the 429
+ * guard returns before reaching them.
+ */
+class ScholexplorerApiClientHttpContext extends ScholexplorerApiClient
+{
+    protected function isCliContext(): bool
+    {
+        return false;
+    }
+
+    protected function throttleAuthenticated(): void
+    {
+        // no-op: keep tests fast, real skip-outside-CLI logic already covered by ScholexplorerApiClientTest via isCliContext()
+    }
+
+    protected function throttleUnauthenticated(): void
+    {
+        // no-op
+    }
+}

--- a/tests/unit/scripts/ClearOpenAireCacheCommandTest.php
+++ b/tests/unit/scripts/ClearOpenAireCacheCommandTest.php
@@ -27,11 +27,14 @@ class ClearOpenAireCacheCommandTest extends TestCase
         $this->assertSame('enrichment:clear-cache', $this->command->getName());
     }
 
-    public function testCommandHasNoOptions(): void
+    public function testCommandHasScholexplorerAndAllOptions(): void
     {
         $definition = $this->command->getDefinition();
         $this->assertInstanceOf(InputDefinition::class, $definition);
-        $this->assertSame([], $definition->getOptions());
+        $this->assertTrue($definition->hasOption('scholexplorer'));
+        $this->assertTrue($definition->hasOption('all'));
+        $this->assertFalse($definition->getOption('scholexplorer')->acceptValue());
+        $this->assertFalse($definition->getOption('all')->acceptValue());
     }
 
     public function testCommandHasDescription(): void

--- a/tests/unit/scripts/GetLinkDataCommandTest.php
+++ b/tests/unit/scripts/GetLinkDataCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace unit\scripts;
+
+use GetLinkDataCommand;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../scripts/GetLinkDataCommand.php';
+
+/**
+ * Unit tests for GetLinkDataCommand.
+ *
+ * Focuses on command metadata (no bootstrap, no DB, no filesystem/network access).
+ */
+class GetLinkDataCommandTest extends TestCase
+{
+    private GetLinkDataCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = new GetLinkDataCommand();
+    }
+
+    public function testCommandName(): void
+    {
+        $this->assertSame('enrichment:links', $this->command->getName());
+    }
+
+    public function testCommandHasRequiredOptions(): void
+    {
+        $definition = $this->command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('dry-run'));
+        $this->assertFalse($definition->getOption('dry-run')->acceptValue());
+
+        $this->assertTrue($definition->hasOption('rvcode'));
+        $this->assertTrue($definition->getOption('rvcode')->isValueRequired());
+
+        $this->assertTrue($definition->hasOption('doi'));
+        $this->assertTrue($definition->getOption('doi')->isValueRequired());
+
+        $this->assertTrue($definition->hasOption('docid'));
+        $this->assertTrue($definition->getOption('docid')->isValueRequired());
+
+        $this->assertTrue($definition->hasOption('type'));
+        $this->assertTrue($definition->getOption('type')->isValueOptional());
+
+        $this->assertTrue($definition->hasOption('no-cache'));
+        $this->assertFalse($definition->getOption('no-cache')->acceptValue());
+
+        $this->assertTrue($definition->hasOption('no-bidirectional'));
+        $this->assertFalse($definition->getOption('no-bidirectional')->acceptValue());
+    }
+
+    public function testTypeOptionDefaultsToDataset(): void
+    {
+        $definition = $this->command->getDefinition();
+        $this->assertSame('dataset', $definition->getOption('type')->getDefault());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the deprecated `api.scholexplorer.openaire.eu/v1/linksFromPid` endpoint with the official `v3/Links` endpoint (Scholix 3.0 schema) via a new `Episciences\Api\ScholexplorerApiClient`, mirroring `OpenAireApiClient`'s bi-mode AAI auth / adaptive throttling / 401-refresh / 429-backoff pattern, with a dedicated `SCHOLEXPLORER` client ID/secret so batch link enrichment doesn't compete with OpenAIRE Graph enrichment for the same hourly quota (graceful fallback to `OPENAIRE_*` credentials, then anonymous mode).
- Bidirectional `sourcePid`/`targetPid` queries, 0-indexed pagination, in-memory dedup by canonical identifier (doi > handle > swhid > url priority) with relationship-name inversion on the reciprocal direction, and a CSL-JSON fallback builder used when `Episciences_DoiTools::getMetadataFromDoi()` fails or the identifier isn't a DOI.
- `GetLinkDataCommand` rewritten against the new client; adds `--doi`, `--docid`, `--type` (dataset|software|all), `--no-cache`, `--no-bidirectional`. Also fixes a latent purge bug where `fetchOne()` only removed the first of several pre-existing `paper_datasets_meta` rows per paper.
- `ClearOpenAireCacheCommand` gains `--scholexplorer`/`--all` to also purge the new `scholexplorerLinkData` / `scholexplorerAuthToken` cache pools.
- **Separate fix included**: `OpenAireTokenProvider` was posting to `https://aai.openaire.eu/token` (404) instead of the real `https://aai.openaire.eu/oidc/token` endpoint. Any properly configured OPENAIRE credentials were silently degrading to the 60 req/h anonymous quota instead of 7200 req/h — affects `OpenAireApiClient` too, not just Scholexplorer. Verified live against the real AAI endpoint.

## Test plan
- [x] 99 unit tests passing (`ScholexplorerApiClientTest`, `GetLinkDataCommandTest`, updated `ClearOpenAireCacheCommandTest`, `OpenAireTokenProviderTest`, `OpenAireApiClientTest`)
- [x] `make phpstan LEVEL=6` clean on all new/changed files
- [x] Verified live against the real Scholexplorer API v3 (authenticated mode, ~1.3s/request) with a real linked-dataset DOI: pagination, bidirectional dedup, canonical identifier extraction, and CSL-JSON fallback all produce correct output
- [x] `enrichment:links --dry-run` smoke-tested against the docker test DB (bootstrap, SQL filtering, cache hit/miss)
- [ ] Full unfiltered `enrichment:links` run against a real journal (reviewer to run — long-running against the live API)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scholix 3.0 integration for discovering and enriching dataset links, including bidirectional relationships and multiple identifier formats.
  * Added command-line options to control link types, caching, direction, DOI, and document selection.
  * Added separate cache-clearing options for OpenAIRE and Scholexplorer data.
  * Software dataset citations now render for Scholexplorer-sourced entries.

* **Bug Fixes**
  * Improved API authentication, rate-limit handling, retries, and token refresh behaviour.
  * Updated OpenAIRE authentication to use the current OIDC endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->