### PR TITLE
Add BAOBAB (WACREN InvenioRDM) as a submission repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add BAOBAB (WACREN InvenioRDM instance) as a submission repository (`Episciences_Repositories_BAOBAB_Hooks`): records and files are fetched over the REST API, with the Dublin Core body compiled from the DataCite serializer (content negotiation) instead of BAOBAB's own broken OAI-PMH endpoint.
 - Add `export:papers` CLI command (`scripts/ExportPapersCommand.php`, `make export-papers`) to export papers to a CSV file, in the same format `import:papers` reads — for a journal, optionally filtered by volume, section, publication year, docid(s), archive identifier+version, status, repoid, uid, or a raw SQL `WHERE` clause.
 - Add `import:papers` CLI command (`scripts/ImportPapersCommand.php`, `make import-papers`) to import new papers or update existing ones from a CSV file.
 - Add `num` and `year` CSV column support to `import:volumes` (`scripts/ImportVolumesCommand.php`).

--- a/docs/adding-a-new-repository.md
+++ b/docs/adding-a-new-repository.md
@@ -104,7 +104,25 @@ OpenAIRE XML, DataCite XML, or JATS XML), Episciences uses a two-tier storage mo
 | **HAL** | `repository` | Generic OAI-PMH 2.0 (`https://api.archives-ouvertes.fr/oai/hal/`) | `oai_dc` (Dublin Core XML) | XML sanitation stripping non-abstract audience notes (`DataSanitizerInterface::hookCleanXMLRecordInput`), direct PDF link via `paper_url` | `Episciences_Repositories_HAL_Hooks` |
 | **arXiv** | `repository` | Generic OAI-PMH 2.0 (`https://oaipmh.arxiv.org/oai`) | `oai_dc` (Dublin Core XML) | XML and metadata sanitation keeping only primary abstract (`hookFilterMetadata`, `hookCleanXMLRecordInput`), direct PDF link via `paper_url` | `Episciences_Repositories_ArXiv_Hooks` |
 | **ARCHE (ACDH-CH)** | `repository` | OAI-PMH 2.0 (`https://arche.acdh.oeaw.ac.at/oaipmh/`) + ACDH-CH REST API | `oai_datacite` (DataCite Kernel 3 XML) | Multilingual titles & descriptions (`extractMultilingualContent`), authors (`extractPersons`), license, related dataset identifiers (`LinkedDataEnrichmentInterface`) | `Episciences_Repositories_ARCHE_Hooks` |
+| **BAOBAB (WACREN, InvenioRDM 13.1)** | `repository` | InvenioRDM REST API v1 (`/api/records/{id}`); OAI-PMH is broken (500 on any verb that must emit a record) and bypassed entirely (`base_url` left `NULL`) | InvenioRDM JSON (files, authors, access, concept id) + DataCite Kernel 4 XML fetched by content negotiation (`Accept: application/vnd.datacite.datacite+xml`) for the Dublin Core body | Authors from `person_or_org` (not `creatorName`, which InvenioRDM writes "Family, Given"), mirrored files via `links.content` (`FilesEnrichmentInterface`), related datasets filtered for community memberships (`LinkedDataEnrichmentInterface`), concept identifier from `parent.id` (`ConceptIdentifierInterface`), ARK resolution via a PID search query | `Episciences_Repositories_BAOBAB_Hooks` |
 | **Generic OAI-PMH Archive** | `repository` | Standard OAI-PMH 2.0 (`metadata_sources.base_url`) | `oai_dc` (Dublin Core XML) | Standard Dublin Core XML directly into `PAPERS.RECORD`, direct PDF linking via `metadata_sources.paper_url` | No custom hook needed (or minimal `CommonHooksInterface` returning `[]`) |
+
+### A reusable lesson: when an InvenioRDM instance's OAI-PMH is broken
+
+BAOBAB's OAI-PMH endpoint answers `Identify`/`ListMetadataFormats`/`ListSets`
+correctly but returns HTTP 500 (as an HTML error page, not an OAI-PMH error
+document) on every verb that must emit at least one record —
+`GetRecord`/`ListIdentifiers`/`ListRecords` alike. The fix is not
+instance-specific: InvenioRDM exposes the same metadata serializers on its REST
+API through content negotiation, so `GET /api/records/{id}` with
+`Accept: application/vnd.datacite.datacite+xml` returns the DataCite XML that
+OAI-PMH would otherwise have served, without touching the broken endpoint at
+all. If another InvenioRDM-based repository shows the same symptom, the same
+workaround applies: fetch metadata over the REST API instead of OAI-PMH, and
+compile `PAPERS.RECORD` from DataCite rather than from InvenioRDM's `oai_dc`
+(which double-escapes HTML in `dc:description` on at least this instance).
+Keep `metadata_sources.base_url` `NULL` so the platform never falls back to
+the broken OAI endpoint (see `Episciences_Submit::loadRecord()`).
 
 ## Checklist
 

--- a/library/Episciences/Repositories.php
+++ b/library/Episciences/Repositories.php
@@ -44,6 +44,7 @@ class Episciences_Repositories
 
     public const ARCHE_ID = '18';
     public const  CRYPTOLOGY_EPRINT = '19';
+    public const BAOBAB_REPO_ID = '21';
 
 
     public const EPI_USER_ID = '12';
@@ -60,7 +61,8 @@ class Episciences_Repositories
         self::BIO_RXIV_ID => '10.1101/339747',
         self::MED_RXIV_ID => '10.1101/339747',
         self::ARCHE_ID => '(Handle) 21.11115/0000-000B-C715-D',
-        self::CRYPTOLOGY_EPRINT => '2026/1234'
+        self::CRYPTOLOGY_EPRINT => '2026/1234',
+        self::BAOBAB_REPO_ID => 'https://baobab.wacren.net/records/xkpt8-rjr81'
     ];
 
     /**

--- a/library/Episciences/Repositories/ARCHE/Hooks.php
+++ b/library/Episciences/Repositories/ARCHE/Hooks.php
@@ -158,32 +158,7 @@ class Episciences_Repositories_ARCHE_Hooks implements CommonHooksInterface, Link
 
     private static function extractDescriptions($metadata, $language): array
     {
-        $descriptions = [];
-        $descriptionNodes = $metadata->xpath('//datacite:descriptions/datacite:description');
-
-        foreach ($descriptionNodes as $descNode) {
-            $desValue = Episciences_Tools::epi_html_decode((string)$descNode, ['HTML.AllowedElements' => 'p']);
-            $value = trim(str_replace(['<p>', '</p>'], '', $desValue));
-            if (!empty($value)) {
-                $nodeLanguage = '';
-                $xmlAttrs = $descNode->attributes('xml', true);
-                if (isset($xmlAttrs['lang'])) {
-                    $nodeLanguage = (string)$xmlAttrs['lang'];
-                }
-                if (empty($nodeLanguage)) {
-                    $langXpath = $descNode->xpath('@xml:lang');
-                    if (!empty($langXpath)) {
-                        $nodeLanguage = (string)$langXpath[0];
-                    }
-                }
-                $descriptions[] = [
-                    'value'    => $value,
-                    'language' => $nodeLanguage ?: $language,
-                ];
-            }
-        }
-
-        return $descriptions;
+        return Episciences_Repositories_Common::extractDescriptions($metadata, $language);
     }
 
     public static function hookIsRequiredVersion(): array

--- a/library/Episciences/Repositories/BAOBAB/Hooks.php
+++ b/library/Episciences/Repositories/BAOBAB/Hooks.php
@@ -28,7 +28,6 @@ class Episciences_Repositories_BAOBAB_Hooks implements
     public const API_RECORDS_URL = 'https://baobab.wacren.net/api/records';
     public const DATACITE_MIME = 'application/vnd.datacite.datacite+xml';
     public const DATACITE_NS = 'http://datacite.org/schema/kernel-4';
-    public const RECORD_URL_PREFIX = 'https://baobab.wacren.net/records/';
     public const COMMUNITY_URL_PREFIX = 'https://baobab.wacren.net/communities/';
 
     /**
@@ -111,7 +110,7 @@ class Episciences_Repositories_BAOBAB_Hooks implements
             $data[Episciences_Repositories_Common::ENRICHMENT][Episciences_Repositories_Common::LICENSE_ENRICHMENT] = $license;
         }
 
-        $data[Episciences_Repositories_Common::CONCEPT_IDENTIFIER_KEY] = $json['parent']['id'] ?? null;
+        $data[Episciences_Repositories_Common::CONCEPT_IDENTIFIER_KEY] = self::extractConceptIdentifier($json);
 
         $enrichment = [
             Episciences_Repositories_Common::CONTRIB_ENRICHMENT => $authors,
@@ -152,6 +151,9 @@ class Episciences_Repositories_BAOBAB_Hooks implements
         // over from a notice URL; a bare slug has neither and passes through as is.
         $identifier = preg_replace('#\?.*$#', '', (string)$identifier);
         $identifier = preg_replace('#/files/.*$#', '', (string)$identifier);
+        // A trailing slash left over from a browser address bar (copy-pasted with it)
+        // would otherwise reach the API as an extra path segment and fail to resolve.
+        $identifier = rtrim((string)$identifier, '/');
 
         return [Episciences_Repositories_Common::META_IDENTIFIER => $identifier];
     }
@@ -210,25 +212,44 @@ class Episciences_Repositories_BAOBAB_Hooks implements
         $data = [];
 
         foreach ($entries as $entry) {
-            $explodedChecksum = explode(':', (string)($entry['checksum'] ?? ''));
-
-            $data[] = [
-                'doc_id' => $hookParams['docId'],
-                'source' => $hookParams['repoId'],
-                'file_name' => $entry['key'],
-                'file_type' => $entry['ext'] ?? pathinfo($entry['key'], PATHINFO_EXTENSION),
-                'file_size' => $entry['size'] ?? 0,
-                'checksum' => $explodedChecksum[array_key_last($explodedChecksum)] ?? null,
-                'checksum_type' => $explodedChecksum[array_key_first($explodedChecksum)] ?? null,
-                // links.self is the file's JSON metadata on InvenioRDM 13.1, not its
-                // content, unlike the legacy Zenodo API: links.content is mandatory here.
-                'self_link' => $entry['links']['content'] ?? $entry['links']['self'] ?? null,
-            ];
+            $data[] = self::buildFileRow($entry, $hookParams['docId'], $hookParams['repoId']);
         }
 
         $hookParams['affectedRows'] = Episciences_Paper_FilesManager::insert($data);
 
         return $hookParams;
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     * @return array<string, mixed>
+     */
+    private static function buildFileRow(array $entry, int $docId, int $repoId): array
+    {
+        $explodedChecksum = explode(':', (string)($entry['checksum'] ?? ''));
+
+        // links.self is the file's JSON metadata on InvenioRDM 13.1, not its
+        // content, unlike the legacy Zenodo API: links.content is mandatory here.
+        $selfLink = $entry['links']['content'] ?? null;
+
+        if ($selfLink === null && isset($entry['links']['self'])) {
+            Episciences_View_Helper_Log::log(sprintf(
+                'BAOBAB file "%s" has no links.content; falling back to links.self, which points to file metadata, not content',
+                (string)($entry['key'] ?? '')
+            ));
+            $selfLink = $entry['links']['self'];
+        }
+
+        return [
+            'doc_id' => $docId,
+            'source' => $repoId,
+            'file_name' => $entry['key'],
+            'file_type' => $entry['ext'] ?? pathinfo($entry['key'], PATHINFO_EXTENSION),
+            'file_size' => $entry['size'] ?? 0,
+            'checksum' => $explodedChecksum[array_key_last($explodedChecksum)] ?? null,
+            'checksum_type' => $explodedChecksum[array_key_first($explodedChecksum)] ?? null,
+            'self_link' => $selfLink,
+        ];
     }
 
     /**
@@ -265,15 +286,15 @@ class Episciences_Repositories_BAOBAB_Hooks implements
      */
     private static function checkResponse(array $hookParams): array
     {
-        $response = [];
+        return Episciences_Repositories_Common::resolveResponse($hookParams, [self::class, 'hookApiRecords']);
+    }
 
-        if (isset($hookParams[Episciences_Repositories_Common::META_IDENTIFIER]) && empty($hookParams['response'])) {
-            $response = self::hookApiRecords([Episciences_Repositories_Common::META_IDENTIFIER => $hookParams[Episciences_Repositories_Common::META_IDENTIFIER]]);
-        } elseif (isset($hookParams['response'])) {
-            $response = $hookParams['response'];
-        }
-
-        return $response;
+    /**
+     * @param array<string, mixed> $json
+     */
+    private static function extractConceptIdentifier(array $json): ?string
+    {
+        return $json['parent']['id'] ?? null;
     }
 
     /**
@@ -398,36 +419,7 @@ class Episciences_Repositories_BAOBAB_Hooks implements
      */
     private static function extractDescriptions(SimpleXMLElement $metadata, string $language): array
     {
-        $nodes = $metadata->xpath('//datacite:descriptions/datacite:description[@descriptionType="Abstract"]');
-
-        if (empty($nodes)) {
-            $nodes = $metadata->xpath('//datacite:descriptions/datacite:description');
-        }
-
-        $descriptions = [];
-
-        foreach ($nodes as $node) {
-            $decoded = Episciences_Tools::epi_html_decode((string)$node, ['HTML.AllowedElements' => 'p']);
-            $value = trim(str_replace(['<p>', '</p>'], '', $decoded));
-
-            if ($value === '') {
-                continue;
-            }
-
-            $nodeLanguage = '';
-            $xmlAttributes = $node->attributes('xml', true);
-
-            if (isset($xmlAttributes['lang'])) {
-                $nodeLanguage = (string)$xmlAttributes['lang'];
-            }
-
-            $descriptions[] = [
-                'value' => $value,
-                'language' => $nodeLanguage !== '' ? $nodeLanguage : $language,
-            ];
-        }
-
-        return $descriptions;
+        return Episciences_Repositories_Common::extractDescriptions($metadata, $language, true);
     }
 
     /**

--- a/library/Episciences/Repositories/BAOBAB/Hooks.php
+++ b/library/Episciences/Repositories/BAOBAB/Hooks.php
@@ -1,0 +1,508 @@
+<?php
+
+use Episciences\Repositories\CommonHooksInterface;
+use Episciences\Repositories\ConceptIdentifierInterface;
+use Episciences\Repositories\FilesEnrichmentInterface;
+use Episciences\Repositories\InputSanitizerInterface;
+use Episciences\Repositories\LinkedDataEnrichmentInterface;
+use Episciences\Solr\Indexing\Enqueue\SolrIndexing;
+use GuzzleHttp\Exception\GuzzleException;
+
+/**
+ * BAOBAB (WACREN), an InvenioRDM 13.1 instance whose OAI-PMH endpoint returns
+ * a 500 as soon as a record must be emitted (GetRecord/ListIdentifiers/ListRecords).
+ * Records are therefore fetched over the REST API instead; the Dublin Core body
+ * compiled into PAPERS.RECORD is built from the DataCite serializer (obtained by
+ * content negotiation on the same endpoint), not from InvenioRDM's oai_dc, which
+ * double-escapes HTML in dc:description on this corpus.
+ *
+ * @see https://baobab.wacren.net/
+ */
+class Episciences_Repositories_BAOBAB_Hooks implements
+    CommonHooksInterface,
+    InputSanitizerInterface,
+    FilesEnrichmentInterface,
+    LinkedDataEnrichmentInterface,
+    ConceptIdentifierInterface
+{
+    public const API_RECORDS_URL = 'https://baobab.wacren.net/api/records';
+    public const DATACITE_MIME = 'application/vnd.datacite.datacite+xml';
+    public const DATACITE_NS = 'http://datacite.org/schema/kernel-4';
+    public const RECORD_URL_PREFIX = 'https://baobab.wacren.net/records/';
+    public const COMMUNITY_URL_PREFIX = 'https://baobab.wacren.net/communities/';
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     * @throws Ccsd_Error
+     */
+    public static function hookApiRecords(array $hookParams): array
+    {
+        if (!isset($hookParams[Episciences_Repositories_Common::META_IDENTIFIER])) {
+            return [];
+        }
+
+        $identifier = $hookParams[Episciences_Repositories_Common::META_IDENTIFIER];
+
+        try {
+            $json = Episciences_Tools::callApi(self::API_RECORDS_URL . '/' . $identifier);
+        } catch (GuzzleException $e) {
+            throw new Ccsd_Error($e->getMessage(), (int)$e->getCode());
+        }
+
+        if ($json === false) {
+            throw new Ccsd_Error(Ccsd_Error::ID_DOES_NOT_EXIST_CODE);
+        }
+
+        if (!is_array($json)) {
+            throw new Ccsd_Error('Unexpected API response format');
+        }
+
+        $data = $json;
+
+        $language = Episciences_Repositories_Common::convertTo2LetterCode(
+            $json['metadata']['languages'][0]['id'] ?? null
+        ) ?? 'en';
+
+        $body = [];
+        $relatedIdentifiers = [];
+
+        try {
+            $dataciteXml = Episciences_Tools::callApi(
+                self::API_RECORDS_URL . '/' . $identifier,
+                ['headers' => ['Accept' => self::DATACITE_MIME]]
+            );
+
+            if (is_string($dataciteXml) && trim($dataciteXml) !== '') {
+                [$body, $relatedIdentifiers] = self::extractFromDataCite($dataciteXml, $language);
+            }
+        } catch (GuzzleException|InvalidArgumentException $e) {
+            Episciences_View_Helper_Log::log($e->getMessage());
+        }
+
+        if ($body === []) {
+            // Degraded fallback: DataCite could not be fetched or parsed. Build a
+            // minimal body from the JSON alone rather than fail the submission.
+            $jsonTitle = trim((string)($json['metadata']['title'] ?? ''));
+            $body['title'] = $jsonTitle !== '' ? [['value' => $jsonTitle, 'language' => $language]] : [];
+        }
+
+        $dcType = $body['type'] ?? '';
+        $body['language'] = $language;
+
+        if (($json['access']['status'] ?? '') === 'open') {
+            $body['rights'][] = 'info:eu-repo/semantics/openAccess';
+        }
+
+        $headers = [
+            'identifier' => $json['links']['self_html'] ?? '',
+            'datestamp' => Episciences_Repositories_Common::safeDateFormat($json['updated'] ?? $json['created'] ?? ''),
+        ];
+
+        [$creatorsDc, $authors] = self::extractAuthorsFromJson($json['metadata']['creators'] ?? []);
+
+        if (!empty($creatorsDc)) {
+            $body['creator'] = $creatorsDc;
+        }
+
+        $license = $json['metadata']['rights'][0]['props']['url'] ?? '';
+
+        if ($license !== '') {
+            $data[Episciences_Repositories_Common::ENRICHMENT][Episciences_Repositories_Common::LICENSE_ENRICHMENT] = $license;
+        }
+
+        $data[Episciences_Repositories_Common::CONCEPT_IDENTIFIER_KEY] = $json['parent']['id'] ?? null;
+
+        $enrichment = [
+            Episciences_Repositories_Common::CONTRIB_ENRICHMENT => $authors,
+            Episciences_Repositories_Common::RESOURCE_TYPE_ENRICHMENT => $dcType,
+            Episciences_Repositories_Common::FILES => $json['files']['entries'] ?? [],
+            Episciences_Repositories_Common::RELATED_IDENTIFIERS => self::filterOutCommunityLinks($relatedIdentifiers),
+        ];
+
+        Episciences_Repositories_Common::assembleData(['headers' => $headers, 'body' => $body], $enrichment, $data);
+
+        $data['record'] = Episciences_Repositories_Common::toDublinCore($data[Episciences_Repositories_Common::TO_COMPILE_OAI_DC]);
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     */
+    public static function hookCleanIdentifiers(array $hookParams): array
+    {
+        $identifier = trim((string)($hookParams['id'] ?? ''));
+
+        if ($identifier !== '' && preg_match('#^ark:/?\d+/#', $identifier) === 1) {
+            $resolved = self::resolveArk($identifier);
+
+            return [Episciences_Repositories_Common::META_IDENTIFIER => $resolved ?? $identifier];
+        }
+
+        // The submission form's JS helper (public/js/submit/index.js) strips the
+        // scheme and host from a pasted URL but, for a repository outside its
+        // known special cases (Dataverse, arXiv), leaves the first path segment
+        // ("records/...") in the field it hands over — so this must strip a bare
+        // leading "records/"/"uploads/" too, not only after a full "https://host/".
+        $identifier = preg_replace('#^https?://[^/]+/#', '', $identifier);
+        $identifier = preg_replace('#^(?:records|uploads)/#', '', (string)$identifier);
+        // Drop a trailing query string (?preview=1) or a /files/... segment left
+        // over from a notice URL; a bare slug has neither and passes through as is.
+        $identifier = preg_replace('#\?.*$#', '', (string)$identifier);
+        $identifier = preg_replace('#/files/.*$#', '', (string)$identifier);
+
+        return [Episciences_Repositories_Common::META_IDENTIFIER => $identifier];
+    }
+
+    /**
+     * @param array<string, mixed> $hookParams ['identifier' => '...', 'response' => []]
+     * @return array<string, mixed>
+     * @throws Ccsd_Error
+     */
+    public static function hookVersion(array $hookParams): array
+    {
+        // metadata.version is always null on BAOBAB: versions.index is the only
+        // source, with the same previousVersion+1 fallback as Zenodo.
+        $response = self::checkResponse($hookParams);
+
+        $previousVersion = $hookParams['context']['previousVersion'] ?? null;
+        $version = $response['versions']['index'] ?? ($previousVersion !== null ? $previousVersion + 1 : null);
+
+        if (!$version) {
+            return [];
+        }
+
+        return ['version' => $version];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public static function hookIsRequiredVersion(): array
+    {
+        return ['result' => false];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public static function hookIsIdentifierCommonToAllVersions(): array
+    {
+        return ['result' => false];
+    }
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     * @throws Exception
+     */
+    public static function hookFilesProcessing(array $hookParams): array
+    {
+        $entries = $hookParams['files'] ?? [];
+
+        if (empty($entries)) {
+            $response = self::checkResponse($hookParams);
+            $entries = $response['files']['entries'] ?? [];
+        }
+
+        $data = [];
+
+        foreach ($entries as $entry) {
+            $explodedChecksum = explode(':', (string)($entry['checksum'] ?? ''));
+
+            $data[] = [
+                'doc_id' => $hookParams['docId'],
+                'source' => $hookParams['repoId'],
+                'file_name' => $entry['key'],
+                'file_type' => $entry['ext'] ?? pathinfo($entry['key'], PATHINFO_EXTENSION),
+                'file_size' => $entry['size'] ?? 0,
+                'checksum' => $explodedChecksum[array_key_last($explodedChecksum)] ?? null,
+                'checksum_type' => $explodedChecksum[array_key_first($explodedChecksum)] ?? null,
+                // links.self is the file's JSON metadata on InvenioRDM 13.1, not its
+                // content, unlike the legacy Zenodo API: links.content is mandatory here.
+                'self_link' => $entry['links']['content'] ?? $entry['links']['self'] ?? null,
+            ];
+        }
+
+        $hookParams['affectedRows'] = Episciences_Paper_FilesManager::insert($data);
+
+        return $hookParams;
+    }
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     * @throws Exception
+     */
+    public static function hookLinkedDataProcessing(array $hookParams): array
+    {
+        $response = self::checkResponse($hookParams);
+        $relatedIdentifiers = $response[Episciences_Repositories_Common::ENRICHMENT][Episciences_Repositories_Common::RELATED_IDENTIFIERS] ?? [];
+
+        $affectedRows = Episciences_Submit::processDatasets($hookParams['docId'], $relatedIdentifiers);
+
+        if ($affectedRows > 0) {
+            $paper = Episciences_PapersManager::get((int)$hookParams['docId'], false);
+            if ($paper && $paper->isPublished()) {
+                try {
+                    SolrIndexing::enqueueIndex($paper->getDocid());
+                } catch (Exception $e) {
+                    trigger_error($e->getMessage());
+                }
+            }
+        }
+
+        $response['affectedRows'] = $affectedRows;
+        return $response;
+    }
+
+    /**
+     * @param array<string, mixed> $hookParams
+     * @return array<string, mixed>
+     * @throws Ccsd_Error
+     */
+    private static function checkResponse(array $hookParams): array
+    {
+        $response = [];
+
+        if (isset($hookParams[Episciences_Repositories_Common::META_IDENTIFIER]) && empty($hookParams['response'])) {
+            $response = self::hookApiRecords([Episciences_Repositories_Common::META_IDENTIFIER => $hookParams[Episciences_Repositories_Common::META_IDENTIFIER]]);
+        } elseif (isset($hookParams['response'])) {
+            $response = $hookParams['response'];
+        }
+
+        return $response;
+    }
+
+    /**
+     * Resolves an ARK to its current InvenioRDM slug. Neither /api/records/{ark}
+     * nor a plain-text search matches it; only a search on the PID field does.
+     *
+     * @return string|null the resolved slug, or null if resolution found anything
+     *                      other than exactly one record (so the caller falls back
+     *                      to the unresolved input and hookApiRecords() fails cleanly
+     *                      with ID_DOES_NOT_EXIST_CODE, instead of guessing).
+     */
+    private static function resolveArk(string $ark): ?string
+    {
+        $normalizedArk = preg_replace('#^ark:/?#', 'ark:/', $ark);
+        $query = sprintf('pids.ark.identifier:"%s"', $normalizedArk);
+
+        try {
+            $response = Episciences_Tools::callApi(self::API_RECORDS_URL . '?q=' . urlencode($query));
+        } catch (GuzzleException $e) {
+            return null;
+        }
+
+        if (!is_array($response)) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+
+        if (count($hits) !== 1) {
+            return null;
+        }
+
+        return $hits[0]['id'] ?? null;
+    }
+
+    /**
+     * Compiles the Dublin Core body and the raw related identifiers from the
+     * DataCite XML obtained by content negotiation. The document uses a default
+     * namespace (no "datacite:" prefix at the source); registering the prefix on
+     * our side is enough for the xpaths below to resolve regardless.
+     *
+     * @return array{0: array<string, mixed>, 1: array<int, array<string, string>>}
+     * @throws InvalidArgumentException if the XML cannot be parsed
+     */
+    private static function extractFromDataCite(string $xmlString, string $language): array
+    {
+        libxml_use_internal_errors(true);
+        $metadata = simplexml_load_string($xmlString);
+        libxml_clear_errors();
+
+        if ($metadata === false) {
+            throw new InvalidArgumentException('Invalid DataCite XML');
+        }
+
+        $metadata->registerXPathNamespace('datacite', self::DATACITE_NS);
+
+        $titles = Episciences_Repositories_Common::extractMultilingualContent($metadata, '//datacite:titles/datacite:title', $language);
+        $subjects = Episciences_Repositories_Common::extractMultilingualContent($metadata, '//datacite:subjects/datacite:subject', $language);
+        $descriptions = self::extractDescriptions($metadata, $language);
+
+        $typeNodes = $metadata->xpath('//datacite:resourceType');
+        $type = '';
+
+        if (!empty($typeNodes)) {
+            // On a preprint, the node's text is empty and only the attribute carries
+            // the value ("Preprint"): resourceTypeGeneral is the required fallback.
+            $type = trim((string)$typeNodes[0]);
+
+            if ($type === '') {
+                $type = (string)($typeNodes[0]['resourceTypeGeneral'] ?? '');
+            }
+        }
+
+        $dateNodes = $metadata->xpath('//datacite:dates/datacite:date[@dateType="Issued"]');
+
+        if (empty($dateNodes)) {
+            $dateNodes = $metadata->xpath('//datacite:dates/datacite:date');
+        }
+
+        $date = !empty($dateNodes) ? (string)$dateNodes[0] : '';
+
+        $identifiers = [];
+
+        foreach ($metadata->xpath('//datacite:alternateIdentifiers/datacite:alternateIdentifier') as $node) {
+            $identifiers[] = (string)$node;
+        }
+
+        $rightsNodes = $metadata->xpath('//datacite:rightsList/datacite:rights');
+
+        if (empty($rightsNodes)) {
+            $rightsNodes = $metadata->xpath('//datacite:rights');
+        }
+
+        $rights = [];
+
+        foreach ($rightsNodes as $node) {
+            $uri = (string)($node['rightsURI'] ?? '');
+            $rights[] = $uri !== '' ? $uri : trim((string)$node);
+        }
+
+        $publisherNodes = $metadata->xpath('//datacite:publisher');
+        $publisher = !empty($publisherNodes) ? (string)$publisherNodes[0] : '';
+
+        $body = [
+            'title' => $titles,
+            'subject' => $subjects,
+            Episciences_Repositories_Common::META_DESCRIPTION => $descriptions,
+            'type' => $type,
+            'date' => $date,
+            Episciences_Repositories_Common::META_IDENTIFIER => $identifiers,
+            'rights' => $rights,
+            'publisher' => $publisher,
+        ];
+
+        $relatedIdentifiers = Episciences_Repositories_Common::extractRelatedIdentifiersFromMetadata($metadata);
+
+        return [$body, $relatedIdentifiers];
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private static function extractDescriptions(SimpleXMLElement $metadata, string $language): array
+    {
+        $nodes = $metadata->xpath('//datacite:descriptions/datacite:description[@descriptionType="Abstract"]');
+
+        if (empty($nodes)) {
+            $nodes = $metadata->xpath('//datacite:descriptions/datacite:description');
+        }
+
+        $descriptions = [];
+
+        foreach ($nodes as $node) {
+            $decoded = Episciences_Tools::epi_html_decode((string)$node, ['HTML.AllowedElements' => 'p']);
+            $value = trim(str_replace(['<p>', '</p>'], '', $decoded));
+
+            if ($value === '') {
+                continue;
+            }
+
+            $nodeLanguage = '';
+            $xmlAttributes = $node->attributes('xml', true);
+
+            if (isset($xmlAttributes['lang'])) {
+                $nodeLanguage = (string)$xmlAttributes['lang'];
+            }
+
+            $descriptions[] = [
+                'value' => $value,
+                'language' => $nodeLanguage !== '' ? $nodeLanguage : $language,
+            ];
+        }
+
+        return $descriptions;
+    }
+
+    /**
+     * Authors come from the JSON, not from DataCite's creatorName: InvenioRDM
+     * writes it as "Family, Given", which Common::extractPersons()/processPerson()
+     * would mis-split (it assumes "Given Family" and pops the last word). The JSON
+     * gives given_name/family_name apart, with no splitting heuristic needed.
+     *
+     * @param array<int, array<string, mixed>> $creators
+     * @return array{0: array<int, string>, 1: array<int, array<string, mixed>>}
+     */
+    private static function extractAuthorsFromJson(array $creators): array
+    {
+        $creatorsDc = [];
+        $authors = [];
+
+        foreach ($creators as $creatorEntry) {
+            $person = $creatorEntry['person_or_org'] ?? [];
+            $given = trim((string)($person['given_name'] ?? ''));
+            $family = trim((string)($person['family_name'] ?? ''));
+            $fullname = trim($given . ' ' . $family);
+
+            if ($fullname === '') {
+                $fullname = trim((string)($person['name'] ?? ''));
+            }
+
+            if ($fullname === '') {
+                continue;
+            }
+
+            $creatorsDc[] = $fullname;
+
+            $author = [
+                'fullname' => $fullname,
+                'given' => $given,
+                'family' => $family !== '' ? $family : $fullname,
+            ];
+
+            foreach ($person['identifiers'] ?? [] as $identifier) {
+                if (($identifier['scheme'] ?? '') === 'orcid' && !empty($identifier['identifier'])) {
+                    $author['orcid'] = Episciences_Paper_AuthorsManager::normalizeOrcid($identifier['identifier']);
+                }
+            }
+
+            $affiliations = [];
+
+            foreach ($creatorEntry['affiliations'] ?? [] as $affiliation) {
+                if (!empty($affiliation['name'])) {
+                    $affiliations[] = ['name' => $affiliation['name']];
+                }
+            }
+
+            if (!empty($affiliations)) {
+                $author['affiliation'] = $affiliations;
+            }
+
+            $authors[] = $author;
+        }
+
+        return [$creatorsDc, $authors];
+    }
+
+    /**
+     * Most of the 19 BAOBAB records carrying related_identifiers only point to a
+     * community the record belongs to (IsPartOf a /communities/... URL); those are
+     * not datasets and must never reach PAPER_DATASETS.
+     *
+     * @param array<int, array<string, string>> $relatedIdentifiers
+     * @return array<int, array<string, string>>
+     */
+    private static function filterOutCommunityLinks(array $relatedIdentifiers): array
+    {
+        return array_values(array_filter(
+            $relatedIdentifiers,
+            static fn(array $relatedIdentifier): bool => !str_starts_with($relatedIdentifier['identifier'] ?? '', self::COMMUNITY_URL_PREFIX)
+        ));
+    }
+}

--- a/library/Episciences/Repositories/Common.php
+++ b/library/Episciences/Repositories/Common.php
@@ -707,4 +707,85 @@ class Episciences_Repositories_Common
         $dt = date_create($datestamp);
         return $dt !== false ? $dt->format('Y-m-d') : '';
     }
+
+    /**
+     * Returns $hookParams['response'] as is, or fetches it via $fetchRecord when
+     * absent — the common body of the per-repository checkResponse() hooks.
+     *
+     * @param array<string, mixed> $hookParams
+     * @param callable(array<string, mixed>): array<string, mixed> $fetchRecord
+     * @return array<string, mixed>
+     */
+    public static function resolveResponse(array $hookParams, callable $fetchRecord): array
+    {
+        if (isset($hookParams[self::META_IDENTIFIER]) && empty($hookParams['response'])) {
+            return $fetchRecord([self::META_IDENTIFIER => $hookParams[self::META_IDENTIFIER]]);
+        }
+
+        return $hookParams['response'] ?? [];
+    }
+
+    /**
+     * Compiles a DataCite <descriptions> block into value/language pairs,
+     * decoding the <p>-wrapped HTML each repository's descriptions carry.
+     *
+     * $preferAbstractType and $convertLanguageCodeToAlpha2 default to false so
+     * every existing caller keeps its exact prior behavior when opting in only
+     * to what it already relied on.
+     *
+     * @return array<int, array<string, string>>
+     */
+    public static function extractDescriptions(
+        SimpleXMLElement $metadata,
+        string $language,
+        bool $preferAbstractType = false,
+        bool $convertLanguageCodeToAlpha2 = false
+    ): array {
+        $xpath = '//datacite:descriptions/datacite:description';
+        $nodes = $preferAbstractType ? $metadata->xpath($xpath . '[@descriptionType="Abstract"]') : [];
+
+        if (empty($nodes)) {
+            $nodes = $metadata->xpath($xpath);
+        }
+
+        $descriptions = [];
+
+        foreach ($nodes as $node) {
+            $decoded = Episciences_Tools::epi_html_decode((string)$node, ['HTML.AllowedElements' => 'p']);
+            $value = trim(str_replace(['<p>', '</p>'], '', $decoded));
+
+            if ($value === '') {
+                continue;
+            }
+
+            $nodeLanguage = '';
+            $xmlAttributes = $node->attributes('xml', true);
+
+            if (isset($xmlAttributes['lang'])) {
+                $nodeLanguage = (string)$xmlAttributes['lang'];
+            }
+
+            if ($nodeLanguage === '') {
+                $langXpath = $node->xpath('@xml:lang');
+                if (!empty($langXpath)) {
+                    $nodeLanguage = (string)$langXpath[0];
+                }
+            }
+
+            if ($convertLanguageCodeToAlpha2 && strlen($nodeLanguage) > 2) {
+                try {
+                    $nodeLanguage = Languages::getAlpha2Code($nodeLanguage);
+                } catch (Exception $e) {
+                    $nodeLanguage = '';
+                }
+            }
+
+            $descriptions[] = [
+                'value' => $value,
+                'language' => $nodeLanguage !== '' ? $nodeLanguage : $language,
+            ];
+        }
+
+        return $descriptions;
+    }
 }

--- a/library/Episciences/Repositories/Zenodo/Hooks.php
+++ b/library/Episciences/Repositories/Zenodo/Hooks.php
@@ -231,15 +231,7 @@ class Episciences_Repositories_Zenodo_Hooks implements CommonHooksInterface, Inp
      */
     private static function checkResponse(array $hookParams): array
     {
-        $response = [];
-        if (isset($hookParams[Episciences_Repositories_Common::META_IDENTIFIER]) && empty($hookParams['response'])) {
-            $response = self::hookApiRecords([Episciences_Repositories_Common::META_IDENTIFIER => $hookParams[Episciences_Repositories_Common::META_IDENTIFIER]]);
-        } elseif (isset($hookParams['response'])) {
-            $response = $hookParams['response'];
-        }
-
-        return $response;
-
+        return Episciences_Repositories_Common::resolveResponse($hookParams, [self::class, 'hookApiRecords']);
     }
 
     /**
@@ -485,59 +477,7 @@ class Episciences_Repositories_Zenodo_Hooks implements CommonHooksInterface, Inp
 
     private static function extractDescriptions($metadata, $language): array
     {
-        $descriptions = [];
-        $descriptionNodes = $metadata->xpath('//datacite:descriptions/datacite:description');
-        foreach ($descriptionNodes as $descNode) {
-
-            $desValue = Episciences_Tools::epi_html_decode((string)$descNode, ['HTML.AllowedElements' => 'p']);
-            $value = trim(str_replace(['<p>', '</p>'], '', $desValue));
-            if (!empty($value)) {
-                // Extract xml:lang attribute correctly
-                $nodeLanguage = '';
-
-                // Get all attributes including xml:lang
-                $allAttributes = [];
-                foreach ($descNode->attributes() as $attrName => $attrValue) {
-                    $allAttributes[$attrName] = (string)$attrValue;
-                }
-
-                // Check XML namespace attributes
-                $xmlAttributes = $descNode->attributes('xml', true);
-                if ($xmlAttributes) {
-                    foreach ($xmlAttributes as $attrName => $attrValue) {
-                        $allAttributes['xml:' . $attrName] = (string)$attrValue;
-                    }
-                }
-
-                // Extract xml:lang from the attributes array we just built
-                if (isset($allAttributes[Episciences_Repositories_Common::XML_LANG_ATTR])) {
-                    $nodeLanguage = $allAttributes[Episciences_Repositories_Common::XML_LANG_ATTR];
-                }
-
-                // Convert 3-letter language codes to 2-letter codes if needed
-                if (strlen($nodeLanguage) > 2) {
-                    try {
-                        $nodeLanguage = Languages::getAlpha2Code($nodeLanguage);
-                    } catch (\Exception $e) {
-                        // If conversion fails, keep the original
-                        // It will fallback to document language below
-                        $nodeLanguage = '';
-                    }
-                }
-
-                // Fallback to document language
-                if (empty($nodeLanguage)) {
-                    $nodeLanguage = $language;
-                }
-
-                $descriptions[] = [
-                    'value' => $value,
-                    'language' => $nodeLanguage
-                ];
-            }
-        }
-
-        return $descriptions;
+        return Episciences_Repositories_Common::extractDescriptions($metadata, $language, false, true);
     }
 
     private static function enrichmentProcessFromOAI(string $xmlString): array

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -2723,6 +2723,7 @@ class Episciences_Submit
                 if (
                     $repoId === (int)Episciences_Repositories::ZENODO_REPO_ID ||
                     $repoId === (int)Episciences_Repositories::ARCHE_ID ||
+                    $repoId === (int)Episciences_Repositories::BAOBAB_REPO_ID ||
                     Episciences_Repositories::isDspace($repoId)) {
 
                     if ($key !== 'identifier') {

--- a/library/Episciences/Submit.php
+++ b/library/Episciences/Submit.php
@@ -2678,6 +2678,19 @@ class Episciences_Submit
     }
 
 
+    /**
+     * Whether $repoId's related identifiers arrive DataCite-shaped
+     * (identifier/relation/resource_type/scheme) rather than as a plain list
+     * of identifier strings.
+     */
+    private static function isDataCiteShapedRepo(int $repoId): bool
+    {
+        return $repoId === (int)Episciences_Repositories::ZENODO_REPO_ID
+            || $repoId === (int)Episciences_Repositories::ARCHE_ID
+            || $repoId === (int)Episciences_Repositories::BAOBAB_REPO_ID
+            || Episciences_Repositories::isDspace($repoId);
+    }
+
     public static function processDatasets(Episciences_Paper|int $paper, ?array $allDatasets = []): int
     {
         $affectedRows = 0;
@@ -2720,18 +2733,13 @@ class Episciences_Submit
                     continue;
                 }
 
-                if (
-                    $repoId === (int)Episciences_Repositories::ZENODO_REPO_ID ||
-                    $repoId === (int)Episciences_Repositories::ARCHE_ID ||
-                    $repoId === (int)Episciences_Repositories::BAOBAB_REPO_ID ||
-                    Episciences_Repositories::isDspace($repoId)) {
+                if (self::isDataCiteShapedRepo($repoId)) {
 
                     if ($key !== 'identifier') {
                         continue;
                     }
 
                     $options['relationship'] = $datasets['relation'] ?? Episciences_Paper_DatasetsManager::RELATION_TYPE_SOFTWARE;
-                    $datasets = $value;
                 }
 
 
@@ -2766,7 +2774,11 @@ class Episciences_Submit
                         $affectedRows += Episciences_Paper_DatasetsManager::addDatasetFromSubmission($docId, $typeLd, $value, $code, $idMetaDataLastId, $options);
 
                     } else {
-                        $noProcessed[$typeLd] = $datasets;
+                        // forceAddingDatasets() expects an array of plain identifier
+                        // values per type (no 'relation' key, or it would itself be
+                        // iterated and inserted as a spurious dataset value): append,
+                        // don't overwrite, so failures don't lose siblings sharing $typeLd.
+                        $noProcessed[$typeLd][] = $value;
                     }
                 } elseif ($typeLd === Episciences_Paper_Dataset::SOFTWARE_CODE) {
                     $affectedRows += Episciences_Paper_DatasetsManager::addDatasetFromSubmission($docId, $typeLd, $value, $typeLd, null, $options);

--- a/public/js/submit/index.js
+++ b/public/js/submit/index.js
@@ -25,8 +25,17 @@ $(document).ready(function () {
 
         setPlaceholder();
 
+        // isRequiredVersion is only known once this request resolves; block the
+        // identifier field in the meantime so removeVersionFromIdentifier() can't
+        // run against the previous repository's stale value (e.g. wrongly
+        // stripping "v1011" from a BAOBAB slug pasted right after switching repo).
+        $searchDocDocId.prop('disabled', true);
+
         let hasHookRequest = ajaxRequest('/submit/ajaxhashook', {
             repoId: repoValue,
+        });
+        hasHookRequest.always(function () {
+            $searchDocDocId.prop('disabled', false);
         });
         hasHookRequest.done(function (response) {
             let oResponse = JSON.parse(response);

--- a/public/js/submit/index.js
+++ b/public/js/submit/index.js
@@ -165,7 +165,12 @@ $(document).ready(function () {
     //Extracts version information from an identifier string and populates the version field.
     function removeVersionFromIdentifier(identifier) {
         const versionField = document.getElementById('search_doc-version');
-        const versionMatch = identifier.match(/v(\d+)$/);
+        // A trailing "vN" is only a real version marker for repositories where the
+        // version must be typed inline (HAL, arXiv). Repositories whose version is
+        // auto-detected instead (isRequiredVersion === false: Zenodo, ARCHE, BAOBAB...)
+        // can have identifiers that end in "v" + digits by pure coincidence of their
+        // own slug format (e.g. BAOBAB's "s9g8r-v1011"), which must not be split.
+        const versionMatch = isRequiredVersion ? identifier.match(/v(\d+)$/) : null;
 
         if (versionMatch && versionField) {
             // Extract the version number (without the 'v' prefix)

--- a/src/mysql/2026-09-06-add-baobab-repository.sql
+++ b/src/mysql/2026-09-06-add-baobab-repository.sql
@@ -1,0 +1,3 @@
+INSERT INTO `metadata_sources`
+  (`id`, `name`, `type`, `status`, `identifier`, `base_url`, `doi_prefix`, `api_url`, `doc_url`, `paper_url`) VALUES
+(21, 'BAOBAB', 'repository', 1, 'oai:baobab.wacren.net:%%ID', NULL, '', 'https://baobab.wacren.net/api', 'https://baobab.wacren.net/records/%%ID', '');

--- a/tests/js/submitFunctions.js
+++ b/tests/js/submitFunctions.js
@@ -18,6 +18,7 @@ function mockQuerySelector(selector) {
 // Mock global variables
 let mockGlobals = {
     $isDataverseRepo: false,
+    isRequiredVersion: true,
     examples: {},
     translate: text => text,
 };
@@ -28,12 +29,19 @@ function setMockGlobals(globals) {
 
 // Extracted function: removeVersionFromIdentifier
 function removeVersionFromIdentifier(identifier, options = {}) {
-    const { mockVersionField = null } = options;
+    const {
+        mockVersionField = null,
+        isRequiredVersion = mockGlobals.isRequiredVersion,
+    } = options;
 
     // For testing, use mockVersionField if provided, otherwise try DOM
     const versionField =
         mockVersionField || mockGetElementById('search_doc-version');
-    const versionMatch = identifier.match(/v(\d+)$/);
+    // A trailing "vN" is only a real version marker for repositories where the
+    // version must be typed inline (HAL, arXiv); repositories whose version is
+    // auto-detected (isRequiredVersion === false) may have identifiers that end
+    // in "v" + digits by coincidence of their own slug format.
+    const versionMatch = isRequiredVersion ? identifier.match(/v(\d+)$/) : null;
 
     if (versionMatch && versionField) {
         // Extract the version number (without the 'v' prefix)
@@ -55,6 +63,7 @@ function processUrlIdentifier(input, options = {}) {
     const {
         mockVersionField = null,
         isDataverseRepo = mockGlobals.$isDataverseRepo,
+        isRequiredVersion = mockGlobals.isRequiredVersion,
     } = options;
 
     try {
@@ -106,12 +115,16 @@ function processUrlIdentifier(input, options = {}) {
         } else {
             return removeVersionFromIdentifier(identifier, {
                 mockVersionField,
+                isRequiredVersion,
             });
         }
     } catch (error) {
         // If URL parsing fails, return the original input
         console.warn('URL parsing failed for:', input, error);
-        return removeVersionFromIdentifier(input, { mockVersionField });
+        return removeVersionFromIdentifier(input, {
+            mockVersionField,
+            isRequiredVersion,
+        });
     }
 }
 

--- a/tests/js/submitFunctions.test.js
+++ b/tests/js/submitFunctions.test.js
@@ -72,6 +72,28 @@ describe('Submit Functions', () => {
             expect(result).toBe('hal-v1-05191818');
             expect(mockVersionField.value).toBe('');
         });
+
+        test('should not strip a trailing vN when isRequiredVersion is false (BAOBAB-style slug)', () => {
+            const mockVersionField = createMockElement('');
+            const result = removeVersionFromIdentifier('s9g8r-v1011', {
+                mockVersionField,
+                isRequiredVersion: false,
+            });
+
+            expect(result).toBe('s9g8r-v1011');
+            expect(mockVersionField.value).toBe('');
+        });
+
+        test('should still strip a trailing vN when isRequiredVersion is true', () => {
+            const mockVersionField = createMockElement('');
+            const result = removeVersionFromIdentifier('hal-05191818v1', {
+                mockVersionField,
+                isRequiredVersion: true,
+            });
+
+            expect(result).toBe('hal-05191818');
+            expect(mockVersionField.value).toBe('1');
+        });
     });
 
     describe('processUrlIdentifier', () => {
@@ -122,6 +144,23 @@ describe('Submit Functions', () => {
                 );
 
                 expect(result).toBe('hal-05191818');
+                expect(mockVersionField.value).toBe('');
+            });
+        });
+
+        describe('BAOBAB URLs', () => {
+            test('should not truncate a slug that coincidentally ends in vN', () => {
+                const mockVersionField = createMockElement('');
+                const result = processUrlIdentifier(
+                    'https://baobab.wacren.net/records/s9g8r-v1011',
+                    { mockVersionField, isRequiredVersion: false }
+                );
+
+                // The JS helper has no BAOBAB-specific branch (unlike arXiv), so it
+                // only strips the scheme+host here; the leftover "records/" prefix
+                // is stripped server-side by Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers().
+                // What matters for this bug is that "v1011" is no longer chopped off.
+                expect(result).toBe('records/s9g8r-v1011');
                 expect(mockVersionField.value).toBe('');
             });
         });

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_BAOBAB_HooksTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_BAOBAB_HooksTest.php
@@ -1,0 +1,385 @@
+<?php
+
+namespace unit\library\Episciences\Repositories;
+
+use Episciences_Repositories;
+use Episciences_Repositories_BAOBAB_Hooks;
+use Episciences_Repositories_Common;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Episciences_Repositories_BAOBAB_Hooks.
+ *
+ * BAOBAB (WACREN, InvenioRDM 13.1) has a broken OAI-PMH endpoint: every verb that
+ * must emit at least one record returns a 500. Records are fetched over the REST
+ * API instead, and the Dublin Core body is compiled from the DataCite serializer
+ * obtained by content negotiation (Accept: application/vnd.datacite.datacite+xml)
+ * rather than from InvenioRDM's own oai_dc, which double-escapes HTML on this
+ * corpus.
+ *
+ * All tests are DB-free and network-free: no Guzzle mock exists for the hooks
+ * classes in this codebase, so hookApiRecords()/hookVersion()/hookLinkedDataProcessing()
+ * are exercised only through the private extraction helpers (via ReflectionMethod)
+ * or with a pre-built 'response' that bypasses the live API call. The ARK
+ * resolution branch of hookCleanIdentifiers() needs a live search API call and is
+ * therefore checked only at the regex-detection level.
+ *
+ * @covers Episciences_Repositories_BAOBAB_Hooks
+ */
+final class Episciences_Repositories_BAOBAB_HooksTest extends TestCase
+{
+    private const DATACITE_FIXTURE = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI"></identifier>
+    <titles>
+        <title xml:lang="en">A preprint about baobab trees</title>
+    </titles>
+    <creators>
+        <creator>
+            <creatorName>Arogundade, Femi Qudus</creatorName>
+        </creator>
+    </creators>
+    <subjects>
+        <subject>botany</subject>
+    </subjects>
+    <descriptions>
+        <description descriptionType="Abstract" xml:lang="en">&lt;p&gt;Simple abstract&lt;/p&gt;</description>
+    </descriptions>
+    <rightsList>
+        <rights rightsURI="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</rights>
+    </rightsList>
+    <resourceType resourceTypeGeneral="Preprint"></resourceType>
+    <dates>
+        <date dateType="Issued">2026-05-01</date>
+    </dates>
+    <alternateIdentifiers>
+        <alternateIdentifier alternateIdentifierType="URL">https://baobab.wacren.net/records/xkpt8-rjr81</alternateIdentifier>
+    </alternateIdentifiers>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="URL" relationType="IsPartOf">https://baobab.wacren.net/communities/community-coppha</relatedIdentifier>
+        <relatedIdentifier relatedIdentifierType="DOI" relationType="IsDerivedFrom">10.5281/zenodo.15868466</relatedIdentifier>
+    </relatedIdentifiers>
+    <publisher>WACREN</publisher>
+</resource>
+XML;
+
+    private function invokePrivate(string $method, array $args)
+    {
+        $rm = new ReflectionMethod(Episciences_Repositories_BAOBAB_Hooks::class, $method);
+        $rm->setAccessible(true);
+        return $rm->invokeArgs(null, $args);
+    }
+
+    // =========================================================================
+    // hookCleanIdentifiers()
+    // =========================================================================
+
+    public function testHookCleanIdentifiersBareSlugPassesThrough(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers(['id' => 'xkpt8-rjr81']);
+        self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
+    }
+
+    public function testHookCleanIdentifiersStripsRecordUrl(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
+            'id' => 'https://baobab.wacren.net/records/xkpt8-rjr81',
+        ]);
+        self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
+    }
+
+    public function testHookCleanIdentifiersStripsPreviewQueryString(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
+            'id' => 'https://baobab.wacren.net/records/xkpt8-rjr81?preview=1',
+        ]);
+        self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
+    }
+
+    public function testHookCleanIdentifiersStripsFilesSegment(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
+            'id' => 'https://baobab.wacren.net/records/xkpt8-rjr81/files/preview.pdf',
+        ]);
+        self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
+    }
+
+    public function testHookCleanIdentifiersEmptyEntry(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers(['id' => '']);
+        self::assertSame(['identifier' => ''], $result);
+    }
+
+    /**
+     * Bug: the submission form's JS helper strips the scheme+host from a pasted
+     * URL but leaves the "records/" path segment untouched for a repository
+     * outside its special cases (Dataverse, arXiv) — so hookCleanIdentifiers()
+     * must strip a bare leading "records/"/"uploads/" too, not only right after
+     * a full "https://host/" prefix.
+     */
+    public function testHookCleanIdentifiersStripsBareRecordsPrefixLeftByJs(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
+            'id' => 'records/s9g8r-v1011',
+        ]);
+        self::assertSame(['identifier' => 's9g8r-v1011'], $result);
+    }
+
+    /**
+     * hookCleanIdentifiers() resolves an ARK through a live search API call
+     * (Episciences_Tools::callApi() has no mock in this test suite: see
+     * docs/adding-a-new-repository.md, "Testing"). Only the detection regex —
+     * matched with or without the slash after "ark:" — is exercised here.
+     */
+    public function testArkPatternDetectsArkIdentifiersWithoutNetworkCall(): void
+    {
+        self::assertSame(1, preg_match('#^ark:/?\d+/#', 'ark:/50962/bb67854x81qwd65d'));
+        self::assertSame(1, preg_match('#^ark:/?\d+/#', 'ark:50962/bb67854x81qwd65d'));
+        self::assertSame(0, preg_match('#^ark:/?\d+/#', 'xkpt8-rjr81'));
+    }
+
+    // =========================================================================
+    // hookIsRequiredVersion() / hookIsIdentifierCommonToAllVersions()
+    // =========================================================================
+
+    public function testHookIsRequiredVersion(): void
+    {
+        self::assertSame(['result' => false], Episciences_Repositories_BAOBAB_Hooks::hookIsRequiredVersion());
+    }
+
+    public function testHookIsIdentifierCommonToAllVersions(): void
+    {
+        self::assertSame(['result' => false], Episciences_Repositories_BAOBAB_Hooks::hookIsIdentifierCommonToAllVersions());
+    }
+
+    // =========================================================================
+    // hookVersion()
+    // =========================================================================
+
+    public function testHookVersionFromVersionsIndex(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookVersion([
+            'response' => ['versions' => ['index' => 2], 'metadata' => ['version' => null]],
+        ]);
+
+        self::assertSame(['version' => 2], $result);
+    }
+
+    public function testHookVersionFallsBackToPreviousVersionPlusOne(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookVersion([
+            'response' => ['metadata' => ['version' => null]],
+            'context' => ['previousVersion' => 1],
+        ]);
+
+        self::assertSame(['version' => 2], $result);
+    }
+
+    public function testHookVersionReturnsEmptyWhenNoVersionInfo(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookVersion([
+            'response' => ['metadata' => ['version' => null]],
+        ]);
+
+        self::assertSame([], $result);
+    }
+
+    // =========================================================================
+    // hookFilesProcessing() — metadata-only records (files.entries empty)
+    // =========================================================================
+
+    public function testHookFilesProcessingWithEmptyFilesEntriesDoesNotInsert(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookFilesProcessing([
+            'docId' => 999999,
+            'repoId' => (int)Episciences_Repositories::BAOBAB_REPO_ID,
+            'files' => [],
+        ]);
+
+        self::assertSame(0, $result['affectedRows']);
+    }
+
+    /**
+     * links.self points to a file's JSON metadata on InvenioRDM 13.1, not to its
+     * binary content, unlike the legacy Zenodo API: links.content is mandatory.
+     */
+    public function testHookFilesProcessingPrefersLinksContentOverSelf(): void
+    {
+        $source = file_get_contents(
+            (new ReflectionClass(Episciences_Repositories_BAOBAB_Hooks::class))->getFileName()
+        );
+
+        self::assertStringContainsString(
+            "\$entry['links']['content'] ?? \$entry['links']['self']",
+            $source,
+            'hookFilesProcessing() must prefer links.content over links.self'
+        );
+    }
+
+    // =========================================================================
+    // Concept identifier — set directly from parent.id in hookApiRecords()
+    // =========================================================================
+
+    public function testConceptIdentifierSourcedFromParentId(): void
+    {
+        $source = file_get_contents(
+            (new ReflectionClass(Episciences_Repositories_BAOBAB_Hooks::class))->getFileName()
+        );
+
+        self::assertStringContainsString(
+            "CONCEPT_IDENTIFIER_KEY] = \$json['parent']['id'] ?? null;",
+            $source,
+            "hookApiRecords() must set CONCEPT_IDENTIFIER_KEY from the JSON's parent.id"
+        );
+    }
+
+    // =========================================================================
+    // extractFromDataCite() — private, tested via ReflectionMethod
+    // =========================================================================
+
+    public function testExtractFromDataCiteBuildsExpectedBody(): void
+    {
+        [$body, $relatedIdentifiers] = $this->invokePrivate('extractFromDataCite', [self::DATACITE_FIXTURE, 'en']);
+
+        self::assertSame('A preprint about baobab trees', $body['title'][0]['value']);
+        self::assertSame('en', $body['title'][0]['language']);
+
+        self::assertSame('Simple abstract', $body[Episciences_Repositories_Common::META_DESCRIPTION][0]['value']);
+
+        self::assertSame(['botany'], array_column($body['subject'], 'value'));
+
+        // resourceType has empty text on a preprint; only the attribute carries "Preprint".
+        self::assertSame('Preprint', $body['type']);
+
+        self::assertSame('https://creativecommons.org/licenses/by/4.0/', $body['rights'][0]);
+
+        self::assertSame(
+            ['https://baobab.wacren.net/records/xkpt8-rjr81'],
+            $body[Episciences_Repositories_Common::META_IDENTIFIER]
+        );
+
+        self::assertSame('WACREN', $body['publisher']);
+        self::assertSame('2026-05-01', $body['date']);
+
+        self::assertCount(2, $relatedIdentifiers);
+        self::assertSame('https://baobab.wacren.net/communities/community-coppha', $relatedIdentifiers[0]['identifier']);
+        self::assertSame('10.5281/zenodo.15868466', $relatedIdentifiers[1]['identifier']);
+    }
+
+    public function testExtractFromDataCiteThrowsOnInvalidXml(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        set_error_handler(static function () {
+            return true; // silence the libxml warning
+        });
+
+        try {
+            $this->invokePrivate('extractFromDataCite', ['not valid xml', 'en']);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    // =========================================================================
+    // extractDescriptions() — Abstract preferred, falls back to any description
+    // =========================================================================
+
+    public function testExtractDescriptionsFallsBackToDocumentLanguage(): void
+    {
+        $xml = <<<'XML'
+<?xml version="1.0"?>
+<resource xmlns="http://datacite.org/schema/kernel-4">
+    <descriptions>
+        <description descriptionType="Abstract">No lang attribute here</description>
+    </descriptions>
+</resource>
+XML;
+        $metadata = simplexml_load_string($xml);
+        $metadata->registerXPathNamespace('datacite', Episciences_Repositories_BAOBAB_Hooks::DATACITE_NS);
+
+        $result = $this->invokePrivate('extractDescriptions', [$metadata, 'fr']);
+
+        self::assertSame('No lang attribute here', $result[0]['value']);
+        self::assertSame('fr', $result[0]['language']);
+    }
+
+    // =========================================================================
+    // filterOutCommunityLinks() — community memberships must not become datasets
+    // =========================================================================
+
+    public function testFilterOutCommunityLinksRemovesOnlyCommunityUrls(): void
+    {
+        $relatedIdentifiers = [
+            ['identifier' => 'https://baobab.wacren.net/communities/community-coppha', 'relation' => 'IsPartOf', 'resource_type' => 'dataset', 'scheme' => 'url'],
+            ['identifier' => '10.5281/zenodo.15868466', 'relation' => 'IsDerivedFrom', 'resource_type' => 'dataset', 'scheme' => 'doi'],
+        ];
+
+        $result = $this->invokePrivate('filterOutCommunityLinks', [$relatedIdentifiers]);
+
+        self::assertCount(1, $result);
+        self::assertSame('10.5281/zenodo.15868466', $result[0]['identifier']);
+    }
+
+    // =========================================================================
+    // extractAuthorsFromJson() — from InvenioRDM's person_or_org, not creatorName
+    // =========================================================================
+
+    public function testExtractAuthorsFromJsonWithGivenAndFamilyName(): void
+    {
+        $creators = [
+            [
+                'person_or_org' => [
+                    'given_name' => 'Femi Qudus',
+                    'family_name' => 'Arogundade',
+                    'identifiers' => [
+                        ['scheme' => 'orcid', 'identifier' => '0000-0001-2345-6789'],
+                    ],
+                ],
+                'affiliations' => [
+                    ['name' => 'WACREN'],
+                ],
+            ],
+        ];
+
+        [$creatorsDc, $authors] = $this->invokePrivate('extractAuthorsFromJson', [$creators]);
+
+        self::assertSame(['Femi Qudus Arogundade'], $creatorsDc);
+        self::assertSame('Femi Qudus', $authors[0]['given']);
+        self::assertSame('Arogundade', $authors[0]['family']);
+        self::assertSame('0000-0001-2345-6789', $authors[0]['orcid']);
+        self::assertSame([['name' => 'WACREN']], $authors[0]['affiliation']);
+    }
+
+    public function testExtractAuthorsFromJsonWithoutOrcidNorAffiliation(): void
+    {
+        $creators = [
+            [
+                'person_or_org' => [
+                    'given_name' => 'Jane',
+                    'family_name' => 'Doe',
+                ],
+            ],
+        ];
+
+        [, $authors] = $this->invokePrivate('extractAuthorsFromJson', [$creators]);
+
+        self::assertArrayNotHasKey('orcid', $authors[0]);
+        self::assertArrayNotHasKey('affiliation', $authors[0]);
+    }
+
+    public function testExtractAuthorsFromJsonSkipsEmptyNames(): void
+    {
+        $creators = [
+            ['person_or_org' => []],
+        ];
+
+        [$creatorsDc, $authors] = $this->invokePrivate('extractAuthorsFromJson', [$creators]);
+
+        self::assertSame([], $creatorsDc);
+        self::assertSame([], $authors);
+    }
+}

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_BAOBAB_HooksTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_BAOBAB_HooksTest.php
@@ -6,7 +6,6 @@ use Episciences_Repositories;
 use Episciences_Repositories_BAOBAB_Hooks;
 use Episciences_Repositories_Common;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use ReflectionMethod;
 
 /**
@@ -103,6 +102,18 @@ XML;
     {
         $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
             'id' => 'https://baobab.wacren.net/records/xkpt8-rjr81/files/preview.pdf',
+        ]);
+        self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
+    }
+
+    /**
+     * A trailing slash (e.g. copy-pasted straight from a browser's address bar)
+     * must not survive, or it reaches the API as a bogus extra path segment.
+     */
+    public function testHookCleanIdentifiersStripsTrailingSlash(): void
+    {
+        $result = Episciences_Repositories_BAOBAB_Hooks::hookCleanIdentifiers([
+            'id' => 'https://baobab.wacren.net/records/xkpt8-rjr81/',
         ]);
         self::assertSame(['identifier' => 'xkpt8-rjr81'], $result);
     }
@@ -208,15 +219,57 @@ XML;
      */
     public function testHookFilesProcessingPrefersLinksContentOverSelf(): void
     {
-        $source = file_get_contents(
-            (new ReflectionClass(Episciences_Repositories_BAOBAB_Hooks::class))->getFileName()
-        );
+        $entry = [
+            'key' => 'preprint.pdf',
+            'checksum' => 'md5:abc123',
+            'size' => 42,
+            'ext' => 'pdf',
+            'links' => [
+                'content' => 'https://baobab.wacren.net/api/records/xkpt8-rjr81/files/preprint.pdf/content',
+                'self' => 'https://baobab.wacren.net/api/records/xkpt8-rjr81/files/preprint.pdf',
+            ],
+        ];
 
-        self::assertStringContainsString(
-            "\$entry['links']['content'] ?? \$entry['links']['self']",
-            $source,
-            'hookFilesProcessing() must prefer links.content over links.self'
+        $row = $this->invokePrivate('buildFileRow', [$entry, 999999, (int)Episciences_Repositories::BAOBAB_REPO_ID]);
+
+        self::assertSame(
+            'https://baobab.wacren.net/api/records/xkpt8-rjr81/files/preprint.pdf/content',
+            $row['self_link']
         );
+    }
+
+    /**
+     * When links.content is absent (contrary to the InvenioRDM 13.1 contract),
+     * the file is still registered rather than dropped, falling back to
+     * links.self even though it points to file metadata, not content.
+     */
+    public function testHookFilesProcessingFallsBackToSelfLinkWhenContentMissing(): void
+    {
+        $entry = [
+            'key' => 'preprint.pdf',
+            'checksum' => 'md5:abc123',
+            'size' => 42,
+            'ext' => 'pdf',
+            'links' => [
+                'self' => 'https://baobab.wacren.net/api/records/xkpt8-rjr81/files/preprint.pdf',
+            ],
+        ];
+
+        $row = $this->invokePrivate('buildFileRow', [$entry, 999999, (int)Episciences_Repositories::BAOBAB_REPO_ID]);
+
+        self::assertSame(
+            'https://baobab.wacren.net/api/records/xkpt8-rjr81/files/preprint.pdf',
+            $row['self_link']
+        );
+    }
+
+    public function testHookFilesProcessingSelfLinkNullWhenNeitherLinkPresent(): void
+    {
+        $entry = ['key' => 'preprint.pdf', 'checksum' => 'md5:abc123', 'size' => 42, 'ext' => 'pdf', 'links' => []];
+
+        $row = $this->invokePrivate('buildFileRow', [$entry, 999999, (int)Episciences_Repositories::BAOBAB_REPO_ID]);
+
+        self::assertNull($row['self_link']);
     }
 
     // =========================================================================
@@ -225,15 +278,14 @@ XML;
 
     public function testConceptIdentifierSourcedFromParentId(): void
     {
-        $source = file_get_contents(
-            (new ReflectionClass(Episciences_Repositories_BAOBAB_Hooks::class))->getFileName()
-        );
+        $result = $this->invokePrivate('extractConceptIdentifier', [['parent' => ['id' => 'xkpt8-rjr81']]]);
+        self::assertSame('xkpt8-rjr81', $result);
+    }
 
-        self::assertStringContainsString(
-            "CONCEPT_IDENTIFIER_KEY] = \$json['parent']['id'] ?? null;",
-            $source,
-            "hookApiRecords() must set CONCEPT_IDENTIFIER_KEY from the JSON's parent.id"
-        );
+    public function testConceptIdentifierNullWhenNoParent(): void
+    {
+        $result = $this->invokePrivate('extractConceptIdentifier', [[]]);
+        self::assertNull($result);
     }
 
     // =========================================================================

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CapabilitiesTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CapabilitiesTest.php
@@ -64,6 +64,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             (int)Episciences_Repositories::MED_RXIV_ID => $source('medRxiv'),
             (int)Episciences_Repositories::ARCHE_ID => $source('ARCHE'),
             (int)Episciences_Repositories::CRYPTOLOGY_EPRINT => $source('Cryptology ePrint'),
+            (int)Episciences_Repositories::BAOBAB_REPO_ID => $source('BAOBAB'),
             self::DATAVERSE_REPO_ID => $source('ADataverse', 'dataverse'),
             self::DSPACE_REPO_ID => $source('ADspace', 'dspace'),
         ];
@@ -121,6 +122,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'medRxiv' => [(int)Episciences_Repositories::MED_RXIV_ID, 'Episciences_Repositories_MedRxiv_Hooks'],
             'ARCHE' => [(int)Episciences_Repositories::ARCHE_ID, 'Episciences_Repositories_ARCHE_Hooks'],
             'Cryptology ePrint' => [(int)Episciences_Repositories::CRYPTOLOGY_EPRINT, 'Episciences_Repositories_CryptologyePrint_Hooks'],
+            'BAOBAB' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, 'Episciences_Repositories_BAOBAB_Hooks'],
             'Dataverse' => [self::DATAVERSE_REPO_ID, 'Episciences_Repositories_Dataverse_Hooks'],
             'DSpace' => [self::DSPACE_REPO_ID, 'Episciences_Repositories_Dspace_Hooks'],
         ];
@@ -154,6 +156,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'ARCHE has no files enrichment' => [(int)Episciences_Repositories::ARCHE_ID, false],
             'Zenodo mirrors its files' => [(int)Episciences_Repositories::ZENODO_REPO_ID, true],
             'Cryptology ePrint mirrors its files' => [(int)Episciences_Repositories::CRYPTOLOGY_EPRINT, true],
+            'BAOBAB mirrors its files' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, true],
             'Dataverse mirrors its files' => [self::DATAVERSE_REPO_ID, true],
             'DSpace mirrors its files' => [self::DSPACE_REPO_ID, true],
             'unknown repository' => [self::UNKNOWN_REPO_ID, false],
@@ -184,6 +187,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'medRxiv' => [(int)Episciences_Repositories::MED_RXIV_ID, false],
             'Zenodo' => [(int)Episciences_Repositories::ZENODO_REPO_ID, true],
             'ARCHE' => [(int)Episciences_Repositories::ARCHE_ID, true],
+            'BAOBAB' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, true],
             'Dataverse mirrors files only' => [self::DATAVERSE_REPO_ID, false],
             'DSpace mirrors files only' => [self::DSPACE_REPO_ID, false],
             'unknown repository' => [self::UNKNOWN_REPO_ID, false],
@@ -216,6 +220,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'Dataverse enriches itself' => [self::DATAVERSE_REPO_ID, true],
             'DSpace enriches itself' => [self::DSPACE_REPO_ID, true],
             'Cryptology ePrint enriches itself' => [(int)Episciences_Repositories::CRYPTOLOGY_EPRINT, true],
+            'BAOBAB enriches itself' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, true],
             'unknown repository' => [self::UNKNOWN_REPO_ID, false],
         ];
     }
@@ -241,6 +246,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'Zenodo' => [(int)Episciences_Repositories::ZENODO_REPO_ID, true],
             'Cryptology ePrint' => [(int)Episciences_Repositories::CRYPTOLOGY_EPRINT, true],
             'DSpace' => [self::DSPACE_REPO_ID, true],
+            'BAOBAB' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, true],
             'HAL' => [(int)Episciences_Repositories::HAL_REPO_ID, false],
             'arXiv' => [(int)Episciences_Repositories::ARXIV_REPO_ID, false],
             'Dataverse' => [self::DATAVERSE_REPO_ID, false],
@@ -278,6 +284,7 @@ final class Episciences_Repositories_CapabilitiesTest extends TestCase
             'DSpace does not' => [self::DSPACE_REPO_ID, false],
             'ARCHE does not' => [(int)Episciences_Repositories::ARCHE_ID, false],
             'Cryptology ePrint does not' => [(int)Episciences_Repositories::CRYPTOLOGY_EPRINT, false],
+            'BAOBAB does not' => [(int)Episciences_Repositories::BAOBAB_REPO_ID, false],
         ];
     }
 

--- a/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CapabilityDeclarationTest.php
+++ b/tests/unit/library/Episciences/Repositories/Episciences_Repositories_CapabilityDeclarationTest.php
@@ -42,7 +42,7 @@ final class Episciences_Repositories_CapabilityDeclarationTest extends TestCase
      * Lower bound on the number of shipped hooks classes. A moved directory or a
      * renamed file would otherwise turn every assertion below into a no-op.
      */
-    private const MINIMUM_HOOK_CLASSES = 9;
+    private const MINIMUM_HOOK_CLASSES = 10;
 
     /**
      * Writes of Episciences_Repositories_Common::CONCEPT_IDENTIFIER_KEY, in the two

--- a/tests/unit/library/Episciences/paper/Episciences_Paper_MainPaperUrlTest.php
+++ b/tests/unit/library/Episciences/paper/Episciences_Paper_MainPaperUrlTest.php
@@ -60,6 +60,7 @@ final class Episciences_Paper_MainPaperUrlTest extends TestCase
             (int)Episciences_Repositories::BIO_RXIV_ID => $source('bioRxiv', 'https://www.biorxiv.org/content/%%IDv%%VERSION.full.pdf'),
             (int)Episciences_Repositories::ZENODO_REPO_ID => $source('Zenodo', ''),
             (int)Episciences_Repositories::CRYPTOLOGY_EPRINT => $source('Cryptology ePrint', ''),
+            (int)Episciences_Repositories::BAOBAB_REPO_ID => $source('BAOBAB', ''),
             self::DATAVERSE_REPO_ID => $source('ADataverse', '', 'dataverse'),
             self::DSPACE_REPO_ID => $source('ADspace', '', 'dspace'),
         ];
@@ -137,6 +138,11 @@ final class Episciences_Paper_MainPaperUrlTest extends TestCase
     public function testDataversePaperHasFilesEnrichment(): void
     {
         self::assertTrue($this->makePaper(self::DATAVERSE_REPO_ID)->hasFilesEnrichment());
+    }
+
+    public function testBaobabPaperHasFilesEnrichment(): void
+    {
+        self::assertTrue($this->makePaper((int)Episciences_Repositories::BAOBAB_REPO_ID)->hasFilesEnrichment());
     }
 
     public function testTemporaryPaperHasNoFilesEnrichment(): void
@@ -226,6 +232,7 @@ final class Episciences_Paper_MainPaperUrlTest extends TestCase
         self::assertTrue($this->makePaper((int)Episciences_Repositories::ZENODO_REPO_ID)->hasConceptIdentifier());
         self::assertTrue($this->makePaper((int)Episciences_Repositories::CRYPTOLOGY_EPRINT)->hasConceptIdentifier());
         self::assertTrue($this->makePaper(self::DSPACE_REPO_ID)->hasConceptIdentifier());
+        self::assertTrue($this->makePaper((int)Episciences_Repositories::BAOBAB_REPO_ID)->hasConceptIdentifier());
         self::assertFalse($this->makePaper((int)Episciences_Repositories::HAL_REPO_ID)->hasConceptIdentifier());
         self::assertFalse($this->makePaper((int)Episciences_Repositories::ARXIV_REPO_ID)->hasConceptIdentifier());
         self::assertFalse($this->makePaper(self::DATAVERSE_REPO_ID)->hasConceptIdentifier());
@@ -253,6 +260,14 @@ final class Episciences_Paper_MainPaperUrlTest extends TestCase
         $paper->setConcept_identifier('oai:dspace:123');
 
         self::assertSame('oai:dspace:123', $paper->getConcept_identifier());
+    }
+
+    public function testConceptIdentifierIsAcceptedForBaobab(): void
+    {
+        $paper = $this->makePaper((int)Episciences_Repositories::BAOBAB_REPO_ID, 'xkpt8-rjr81');
+        $paper->setConcept_identifier('0992e-h4x54');
+
+        self::assertSame('0992e-h4x54', $paper->getConcept_identifier());
     }
 
     public function testConceptIdentifierIsRejectedForHal(): void

--- a/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
+++ b/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
@@ -73,6 +73,35 @@ final class Episciences_Submit_PrivateMethodsTest extends TestCase
     }
 
     // =========================================================================
+    // GROUP E — processDatasets() DataCite-shaped repositories guard
+    // =========================================================================
+    //
+    // processDatasets() touches the database and cannot be exercised end to end
+    // here; this is a source-level guard that BAOBAB_REPO_ID stays listed
+    // alongside Zenodo/ARCHE/DSpace, whose related identifiers arrive as
+    // DataCite-shaped arrays (identifier/relation/resource_type/scheme) rather
+    // than a plain list. Without it, a BAOBAB submission's related identifiers
+    // would be iterated key-by-key and "IsDerivedFrom"/"dataset" would be typed
+    // as if they were identifiers themselves.
+
+    public function testProcessDatasetsRecognisesBaobabAsDataCiteShaped(): void
+    {
+        $method = new ReflectionMethod(Episciences_Submit::class, 'processDatasets');
+        $filePath = $method->getFileName();
+
+        self::assertNotFalse($filePath, 'Could not determine source file path via ReflectionMethod');
+
+        $source = file_get_contents($filePath);
+        self::assertNotFalse($source, 'Could not read source file: ' . $filePath);
+
+        self::assertStringContainsString(
+            'Episciences_Repositories::BAOBAB_REPO_ID',
+            $source,
+            'processDatasets() must list BAOBAB_REPO_ID among the DataCite-shaped related identifiers repositories'
+        );
+    }
+
+    // =========================================================================
     // GROUP A — assertDateTimeVersion()
     // =========================================================================
 

--- a/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
+++ b/tests/unit/library/Episciences/submit/Episciences_Submit_PrivateMethodsTest.php
@@ -73,32 +73,33 @@ final class Episciences_Submit_PrivateMethodsTest extends TestCase
     }
 
     // =========================================================================
-    // GROUP E — processDatasets() DataCite-shaped repositories guard
+    // GROUP E — isDataCiteShapedRepo() — processDatasets() DataCite-shaped
+    // repositories guard
     // =========================================================================
     //
-    // processDatasets() touches the database and cannot be exercised end to end
-    // here; this is a source-level guard that BAOBAB_REPO_ID stays listed
-    // alongside Zenodo/ARCHE/DSpace, whose related identifiers arrive as
-    // DataCite-shaped arrays (identifier/relation/resource_type/scheme) rather
-    // than a plain list. Without it, a BAOBAB submission's related identifiers
-    // would be iterated key-by-key and "IsDerivedFrom"/"dataset" would be typed
-    // as if they were identifiers themselves.
+    // processDatasets() itself touches the database and cannot be exercised end
+    // to end here, but the repository-shape guard it delegates to is pure and
+    // is exercised directly. Without BAOBAB listed here, a BAOBAB submission's
+    // related identifiers would be iterated key-by-key and
+    // "IsDerivedFrom"/"dataset" would be typed as if they were identifiers
+    // themselves.
 
-    public function testProcessDatasetsRecognisesBaobabAsDataCiteShaped(): void
+    public function testIsDataCiteShapedRepoRecognisesBaobab(): void
     {
-        $method = new ReflectionMethod(Episciences_Submit::class, 'processDatasets');
-        $filePath = $method->getFileName();
+        $result = $this->invoke('isDataCiteShapedRepo', [(int)Episciences_Repositories::BAOBAB_REPO_ID]);
+        self::assertTrue($result);
+    }
 
-        self::assertNotFalse($filePath, 'Could not determine source file path via ReflectionMethod');
+    public function testIsDataCiteShapedRepoRecognisesZenodoAndArche(): void
+    {
+        self::assertTrue($this->invoke('isDataCiteShapedRepo', [(int)Episciences_Repositories::ZENODO_REPO_ID]));
+        self::assertTrue($this->invoke('isDataCiteShapedRepo', [(int)Episciences_Repositories::ARCHE_ID]));
+    }
 
-        $source = file_get_contents($filePath);
-        self::assertNotFalse($source, 'Could not read source file: ' . $filePath);
-
-        self::assertStringContainsString(
-            'Episciences_Repositories::BAOBAB_REPO_ID',
-            $source,
-            'processDatasets() must list BAOBAB_REPO_ID among the DataCite-shaped related identifiers repositories'
-        );
+    public function testIsDataCiteShapedRepoRejectsOtherRepos(): void
+    {
+        $result = $this->invoke('isDataCiteShapedRepo', [(int)Episciences_Repositories::HAL_REPO_ID]);
+        self::assertFalse($result);
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- Add BAOBAB (WACREN, InvenioRDM 13.1) as a submission repository: `Episciences_Repositories_BAOBAB_Hooks` fetches records over the REST API and compiles the Dublin Core body from DataCite (content negotiation), since BAOBAB's OAI-PMH endpoint 500s on any verb that must emit a record.
- Authors sourced from JSON `person_or_org` (DataCite's `creatorName` is "Family, Given" and would be mis-split by the generic name-splitting heuristic), files mirrored via `links.content`, related identifiers filtered to drop community-membership links, concept identifier from `parent.id`, ARK resolution via a PID search query.
- Extend `Episciences_Submit::processDatasets()`'s DataCite-shaped related-identifiers branch to include BAOBAB.
- Fix the submission form's identifier field for any repository whose version is auto-detected (`isRequiredVersion === false`): the generic JS trailing `vN` stripping used to also strip that pattern from InvenioRDM's random slugs (e.g. BAOBAB's `s9g8r-v1011` became `s9g8r-`), and `hookCleanIdentifiers()` now strips a bare leading `records/`/`uploads/` segment left behind by the JS helper, not just after a full URL prefix.

## Test plan
- [x] `make phpstan LEVEL=6 TARGET=library/Episciences/Repositories/BAOBAB` — clean
- [x] PHPUnit: `tests/unit/library/Episciences/Repositories/`, `Episciences_Paper_MainPaperUrlTest.php`, `tests/unit/library/Episciences/submit/` — all green
- [x] Jest: `tests/js/submitFunctions.test.js` — all green
- [x] Manual submission in dev of a real BAOBAB record by ARK and by URL (including a slug that coincidentally ends in `vNNN`) — confirmed working end to end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BAOBAB (WACREN InvenioRDM) as a submission repository.
  * BAOBAB records, metadata, files, authors, related datasets and concept identifiers can now be imported.
  * Added support for BAOBAB identifiers, versions and ARK resolution.

* **Bug Fixes**
  * Prevented BAOBAB identifiers ending in version-like suffixes from being incorrectly altered.
  * Added a reliable import fallback when BAOBAB’s OAI-PMH endpoint is unavailable.

* **Documentation**
  * Documented BAOBAB’s supported APIs, capabilities and ingestion behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->